### PR TITLE
[fix][broker] Fix bucket snapshot trim and segment loading

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTracker.java
@@ -800,6 +800,18 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
                     return null;
                 })
                 .thenCompose(__ -> {
+                    CompletableFuture<Void> load;
+                    synchronized (BucketDelayedDeliveryTracker.this) {
+                        load = pendingLoad;
+                    }
+                    return (load == null ? CompletableFuture.completedFuture(null) : load)
+                            .exceptionally(t -> {
+                                log.warn().exception(t)
+                                        .log("Failed to load bucket snapshot segment during clear, ignore");
+                                return null;
+                            });
+                })
+                .thenCompose(__ -> {
                     synchronized (BucketDelayedDeliveryTracker.this) {
                         CompletableFuture<Void> future = cleanImmutableBuckets();
                         sharedBucketPriorityQueue.clear();
@@ -898,17 +910,6 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
     }
 
     private CompletableFuture<Void> deleteBucketSnapshot(String ledgerName,
-                                                          Range<Long> range, ImmutableBucket bucket) {
-        // The bucket id is only known once the snapshot creation completes, so wait for an in-flight
-        // creation before deleting. When the creation failed the bucket has already been removed and
-        // downgraded to memory mode, so there is no snapshot left to delete.
-        return bucket.getSnapshotCreateFuture().orElse(NULL_LONG_PROMISE)
-                .thenCompose(bucketId -> bucketId == null
-                        ? CompletableFuture.<Void>completedFuture(null)
-                        : doDeleteBucketSnapshot(ledgerName, range, bucket));
-    }
-
-    private CompletableFuture<Void> doDeleteBucketSnapshot(String ledgerName,
                                                            Range<Long> range, ImmutableBucket bucket) {
         synchronized (this) {
             if (!isCurrentBucket(range, bucket)) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTracker.java
@@ -84,8 +84,6 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
 
     static final int AsyncOperationTimeoutSeconds = 60;
 
-    private static final Long INVALID_BUCKET_ID = -1L;
-
     private static final int MAX_MERGE_NUM = 4;
 
     private final long minIndexCountPerBucket;
@@ -354,7 +352,7 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
                     immutableBucket);
 
             immutableBucket.getSnapshotCreateFuture().ifPresent(createFuture -> {
-                CompletableFuture<Long> future = createFuture.handle((bucketId, ex) -> {
+                CompletableFuture<Long> future = createFuture.whenComplete((bucketId, ex) -> {
                     if (ex == null) {
                         immutableBucket.setSnapshotSegments(null);
                         immutableBucket.asyncUpdateSnapshotLength()
@@ -369,8 +367,7 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
 
                         stats.recordSuccessEvent(BucketDelayedMessageIndexStats.Type.create,
                                 System.currentTimeMillis() - startTime);
-
-                        return bucketId;
+                        return;
                     }
 
                     log.error()
@@ -397,7 +394,6 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
                         snapshotSegmentLastIndexMap.remove(
                                 new SnapshotKey(lastDelayedIndex.getLedgerId(), lastDelayedIndex.getEntryId()));
                     }
-                    return INVALID_BUCKET_ID;
                 });
                 immutableBucket.setSnapshotCreateFuture(future);
             });
@@ -559,16 +555,12 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
                 buckets.stream().map(bucket -> bucket.getSnapshotCreateFuture().orElse(NULL_LONG_PROMISE))
                         .toList();
 
-        return FutureUtil.waitForAll(createFutures).thenCompose(bucketId -> {
-            if (createFutures.stream().anyMatch(future -> INVALID_BUCKET_ID.equals(future.join()))) {
-                return FutureUtil.failedFuture(new RuntimeException("Can't merge buckets due to bucket create failed"));
-            }
-
+        return FutureUtil.waitForAll(createFutures).thenCompose(__ -> {
             List<CompletableFuture<List<SnapshotSegment>>> getAllSnapshotFutures =
                     buckets.stream().map(ImmutableBucket::getAllSnapshotSegments).toList();
 
             return FutureUtil.waitForAll(getAllSnapshotFutures)
-                    .thenApply(__ -> {
+                    .thenApply(ignore -> {
                         return CombinedSegmentDelayedIndexQueue.wrap(
                                 getAllSnapshotFutures.stream().map(CompletableFuture::join).toList());
                     })
@@ -675,21 +667,20 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
 
         while (n > 0 && !sharedBucketPriorityQueue.isEmpty()) {
             long timestamp = sharedBucketPriorityQueue.peekN1();
-            long ledgerId = sharedBucketPriorityQueue.peekN2();
-            long entryId = sharedBucketPriorityQueue.peekN3();
-            if (firstLiveLedgerId != null && ledgerId < firstLiveLedgerId) {
-                sharedBucketPriorityQueue.pop();
-                removeIndexBit(ledgerId, entryId);
-                continue;
-            }
             if (timestamp > cutoffTime) {
                 break;
             }
 
-            SnapshotKey snapshotKey = new SnapshotKey(ledgerId, entryId);
+            long ledgerId = sharedBucketPriorityQueue.peekN2();
+            long entryId = sharedBucketPriorityQueue.peekN3();
 
+            boolean orphaned = firstLiveLedgerId != null && ledgerId < firstLiveLedgerId;
+            SnapshotKey snapshotKey = new SnapshotKey(ledgerId, entryId);
             ImmutableBucket bucket = snapshotSegmentLastIndexMap.get(snapshotKey);
-            if (bucket != null && immutableBuckets.asMapOfRanges().containsValue(bucket)) {
+            boolean shouldLoadNextSegment = bucket != null
+                    && immutableBuckets.asMapOfRanges().containsValue(bucket)
+                    && (!orphaned || bucket.getEndLedgerId() >= firstLiveLedgerId);
+            if (shouldLoadNextSegment) {
                 // All message of current snapshot segment are scheduled, try load next snapshot segment
                 if (bucket.merging) {
                     log.info()
@@ -765,6 +756,12 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
             }
 
             sharedBucketPriorityQueue.pop();
+
+            if (orphaned) {
+                removeIndexBit(ledgerId, entryId);
+                continue;
+            }
+
             // Dedup: queue may carry the same position twice (initial seal + merge); only the
             // first delivery of each position decrements the counter via removeIndexBit.
             if (removeIndexBit(ledgerId, entryId)) {
@@ -906,13 +903,18 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
         // creation before deleting. When the creation failed the bucket has already been removed and
         // downgraded to memory mode, so there is no snapshot left to delete.
         return bucket.getSnapshotCreateFuture().orElse(NULL_LONG_PROMISE)
-                .thenCompose(bucketId -> INVALID_BUCKET_ID.equals(bucketId)
+                .thenCompose(bucketId -> bucketId == null
                         ? CompletableFuture.<Void>completedFuture(null)
                         : doDeleteBucketSnapshot(ledgerName, range, bucket));
     }
 
     private CompletableFuture<Void> doDeleteBucketSnapshot(String ledgerName,
                                                            Range<Long> range, ImmutableBucket bucket) {
+        synchronized (this) {
+            if (!isCurrentBucket(range, bucket)) {
+                return CompletableFuture.completedFuture(null);
+            }
+        }
         return bucket.asyncDeleteBucketSnapshot(stats)
                 .handle((__, t) -> {
                     if (t != null) {
@@ -922,6 +924,9 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
                         throw new CompletionException(t);
                     }
                     synchronized (this) {
+                        if (!isCurrentBucket(range, bucket)) {
+                            return null;
+                        }
                         snapshotSegmentLastIndexMap.entrySet().removeIf(entry -> entry.getValue() == bucket);
                         removeBucket(range);
                         bucket.getDelayedIndexBitMap().forEach((ledgerId, bitmap) ->
@@ -929,6 +934,11 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
                     }
                     return null;
                 });
+    }
+
+    private boolean isCurrentBucket(Range<Long> range, ImmutableBucket expectedBucket) {
+        ImmutableBucket currentBucket = immutableBuckets.asMapOfRanges().get(range);
+        return currentBucket == expectedBucket;
     }
 
     private Long firstActiveLedgerId() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/ImmutableBucket.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/ImmutableBucket.java
@@ -319,32 +319,55 @@ class ImmutableBucket {
         long deleteStartTime = System.currentTimeMillis();
         stats.recordTriggerEvent(BucketDelayedMessageIndexStats.Type.delete);
         String bucketKey = bucketKey();
-        long bucketId = getAndUpdateBucketId();
+        CompletableFuture<Optional<Long>> bucketIdFuture = resolveBucketIdForDelete();
 
-        return executeWithRetry(() -> ctx.bucketSnapshotStorage().deleteBucketSnapshot(bucketId),
-                BucketSnapshotPersistenceException.class, MaxRetryTimes)
-                .whenComplete((__, ex) -> {
-                    if (ex != null) {
-                        log.error()
-                                .attr("dispatcher", ctx.dispatcherName())
-                                .attr("bucketId", bucketId)
-                                .attr("bucketKey", bucketKey)
-                                .exception(ex)
-                                .log("Failed to delete bucket snapshot");
+        return bucketIdFuture.thenCompose(optionalBucketId -> {
+            if (optionalBucketId.isEmpty()) {
+                return CompletableFuture.completedFuture(null);
+            }
+            long bucketId = optionalBucketId.get();
+            return executeWithRetry(() -> ctx.bucketSnapshotStorage().deleteBucketSnapshot(bucketId),
+                    BucketSnapshotPersistenceException.class, MaxRetryTimes)
+                    .whenComplete((__, ex) -> {
+                        if (ex != null) {
+                            log.error()
+                                    .attr("dispatcher", ctx.dispatcherName())
+                                    .attr("bucketId", bucketId)
+                                    .attr("bucketKey", bucketKey)
+                                    .exception(ex)
+                                    .log("Failed to delete bucket snapshot");
 
-                        stats.recordFailEvent(BucketDelayedMessageIndexStats.Type.delete);
-                    } else {
-                        log.info()
-                                .attr("dispatcher", ctx.dispatcherName())
-                                .attr("bucketId", bucketId)
-                                .attr("bucketKey", bucketKey)
-                                .log("Delete bucket snapshot finish");
+                            stats.recordFailEvent(BucketDelayedMessageIndexStats.Type.delete);
+                        } else {
+                            log.info()
+                                    .attr("dispatcher", ctx.dispatcherName())
+                                    .attr("bucketId", bucketId)
+                                    .attr("bucketKey", bucketKey)
+                                    .log("Delete bucket snapshot finish");
 
-                        stats.recordSuccessEvent(BucketDelayedMessageIndexStats.Type.delete,
-                                System.currentTimeMillis() - deleteStartTime);
-                    }
-                })
-                .thenCompose(__ -> removeBucketCursorProperty(bucketKey));
+                            stats.recordSuccessEvent(BucketDelayedMessageIndexStats.Type.delete,
+                                    System.currentTimeMillis() - deleteStartTime);
+                        }
+                    });
+        }).thenCompose(__ -> removeBucketCursorProperty(bucketKey));
+    }
+
+    private CompletableFuture<Optional<Long>> resolveBucketIdForDelete() {
+        Optional<CompletableFuture<Long>> snapshotCreateFuture = getSnapshotCreateFuture();
+        if (snapshotCreateFuture.isPresent()) {
+            return snapshotCreateFuture.get().handle((bucketId, ex) -> {
+                if (ex != null) {
+                    return Optional.empty();
+                }
+                setBucketId(bucketId);
+                return Optional.of(bucketId);
+            });
+        }
+        try {
+            return CompletableFuture.completedFuture(Optional.of(getAndUpdateBucketId()));
+        } catch (Exception e) {
+            return FutureUtil.failedFuture(e);
+        }
     }
 
     CompletableFuture<Void> clear(BucketDelayedMessageIndexStats stats) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -1002,67 +1002,89 @@ public class PersistentSubscription extends AbstractSubscription {
             log.info()
                     .log("Successfully disconnected consumers from subscription, proceeding with cursor reset");
 
-            CompletableFuture<Boolean> forceReset = new CompletableFuture<>();
-            if (topic.getTopicCompactionService() == null) {
-                forceReset.complete(false);
-            } else {
-                topic.getTopicCompactionService().getLastCompactedPosition().thenAccept(lastCompactedPosition -> {
-                    Position resetTo = finalPosition;
-                    if (lastCompactedPosition != null && resetTo.compareTo(lastCompactedPosition.getLedgerId(),
-                            lastCompactedPosition.getEntryId()) <= 0) {
-                        forceReset.complete(true);
-                    } else {
-                        forceReset.complete(false);
-                    }
-                }).exceptionally(ex -> {
-                    forceReset.completeExceptionally(ex);
-                    return null;
-                });
+            CompletableFuture<Void> clearDelayedMessagesFuture;
+            try {
+                clearDelayedMessagesFuture = dispatcher != null
+                        ? dispatcher.clearDelayedMessages()
+                        : CompletableFuture.completedFuture(null);
+            } catch (Throwable t) {
+                clearDelayedMessagesFuture = FutureUtil.failedFuture(t);
             }
 
-            forceReset.thenAccept(forceResetValue -> {
-                cursor.asyncResetCursor(finalPosition, forceResetValue, new AsyncCallbacks.ResetCursorCallback() {
-                    @Override
-                    public void resetComplete(Object ctx) {
-                        log.debug()
-                                .attr("finalPosition", finalPosition)
-                                .log("Successfully reset subscription to position");
-                        if (dispatcher != null) {
-                            dispatcher.cursorIsReset();
-                            dispatcher.afterAckMessages(null, finalPosition);
-                        }
-                        IS_FENCED_UPDATER.set(PersistentSubscription.this, FALSE);
-                        inProgressResetCursorFuture = null;
-                        future.complete(null);
-                    }
+            clearDelayedMessagesFuture.whenComplete((__, clearEx) -> {
+                if (clearEx != null) {
+                    log.error()
+                            .exception(clearEx)
+                            .log("Error while clearing delayed messages during cursor reset");
+                    IS_FENCED_UPDATER.set(PersistentSubscription.this, FALSE);
+                    inProgressResetCursorFuture = null;
+                    future.completeExceptionally(new BrokerServiceException(clearEx));
+                    return;
+                }
 
-                    @Override
-                    public void resetFailed(ManagedLedgerException exception, Object ctx) {
-                        log.error()
-                                .attr("finalPosition", finalPosition)
-                                .exception(exception)
-                                .log("Failed to reset subscription to position");
-                        IS_FENCED_UPDATER.set(PersistentSubscription.this, FALSE);
-                        inProgressResetCursorFuture = null;
-                        // todo - retry on InvalidCursorPositionException
-                        // or should we just ask user to retry one more time?
-                        if (exception instanceof InvalidCursorPositionException) {
-                            future.completeExceptionally(new SubscriptionInvalidCursorPosition(exception.getMessage()));
-                        } else if (exception instanceof ConcurrentFindCursorPositionException) {
-                            future.completeExceptionally(new SubscriptionBusyException(exception.getMessage()));
+                CompletableFuture<Boolean> forceReset = new CompletableFuture<>();
+                if (topic.getTopicCompactionService() == null) {
+                    forceReset.complete(false);
+                } else {
+                    topic.getTopicCompactionService().getLastCompactedPosition().thenAccept(lastCompactedPosition -> {
+                        Position resetTo = finalPosition;
+                        if (lastCompactedPosition != null && resetTo.compareTo(lastCompactedPosition.getLedgerId(),
+                                lastCompactedPosition.getEntryId()) <= 0) {
+                            forceReset.complete(true);
                         } else {
-                            future.completeExceptionally(new BrokerServiceException(exception));
+                            forceReset.complete(false);
                         }
-                    }
+                    }).exceptionally(ex -> {
+                        forceReset.completeExceptionally(ex);
+                        return null;
+                    });
+                }
+
+                forceReset.thenAccept(forceResetValue -> {
+                    cursor.asyncResetCursor(finalPosition, forceResetValue, new AsyncCallbacks.ResetCursorCallback() {
+                        @Override
+                        public void resetComplete(Object ctx) {
+                            log.debug()
+                                    .attr("finalPosition", finalPosition)
+                                    .log("Successfully reset subscription to position");
+                            if (dispatcher != null) {
+                                dispatcher.cursorIsReset();
+                                dispatcher.afterAckMessages(null, finalPosition);
+                            }
+                            IS_FENCED_UPDATER.set(PersistentSubscription.this, FALSE);
+                            inProgressResetCursorFuture = null;
+                            future.complete(null);
+                        }
+
+                        @Override
+                        public void resetFailed(ManagedLedgerException exception, Object ctx) {
+                            log.error()
+                                    .attr("finalPosition", finalPosition)
+                                    .exception(exception)
+                                    .log("Failed to reset subscription to position");
+                            IS_FENCED_UPDATER.set(PersistentSubscription.this, FALSE);
+                            inProgressResetCursorFuture = null;
+                            // todo - retry on InvalidCursorPositionException
+                            // or should we just ask user to retry one more time?
+                            if (exception instanceof InvalidCursorPositionException) {
+                                future.completeExceptionally(
+                                        new SubscriptionInvalidCursorPosition(exception.getMessage()));
+                            } else if (exception instanceof ConcurrentFindCursorPositionException) {
+                                future.completeExceptionally(new SubscriptionBusyException(exception.getMessage()));
+                            } else {
+                                future.completeExceptionally(new BrokerServiceException(exception));
+                            }
+                        }
+                    });
+                }).exceptionally((e) -> {
+                    log.error()
+                            .exception(e)
+                            .log("Error while resetting cursor");
+                    IS_FENCED_UPDATER.set(PersistentSubscription.this, FALSE);
+                    inProgressResetCursorFuture = null;
+                    future.completeExceptionally(new BrokerServiceException(e));
+                    return null;
                 });
-            }).exceptionally((e) -> {
-                log.error()
-                        .exception(e)
-                        .log("Error while resetting cursor");
-                IS_FENCED_UPDATER.set(PersistentSubscription.this, FALSE);
-                inProgressResetCursorFuture = null;
-                future.completeExceptionally(new BrokerServiceException(e));
-                return null;
             });
         });
         return future;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTrackerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTrackerTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.delayed.bucket;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.atLeastOnce;
@@ -39,6 +40,7 @@ import io.netty.util.TimerTask;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.time.Clock;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -977,7 +979,8 @@ public class BucketDelayedDeliveryTrackerTest extends AbstractDeliveryTrackerTes
 
             // Release the load; clear() then completes and no stale segment state may survive.
             storage.segmentLoadGate.complete(null);
-            clearFuture.get(1, TimeUnit.MINUTES);
+
+            assertThat(clearFuture).succeedsWithin(Duration.ofSeconds(3));
 
             assertEquals(tracker.getNumberOfDelayedMessages(), 0);
             assertEquals(tracker.getImmutableBuckets().asMapOfRanges().size(), 0);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTrackerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTrackerTest.java
@@ -20,9 +20,13 @@ package org.apache.pulsar.broker.delayed.bucket;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotSame;
@@ -48,6 +52,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import lombok.Cleanup;
 import org.apache.bookkeeper.mledger.ManagedCursor;
@@ -167,7 +172,9 @@ public class BucketDelayedDeliveryTrackerTest extends AbstractDeliveryTrackerTes
                             true, bucketSnapshotStorage, 1000, TimeUnit.MILLISECONDS.toMillis(100), -1, 50)
             }};
             case "testExpiredTrackedMessageReturnsFalse", "testRecoverThenExpireAddMessage",
-                     "testExpiredTrackedMessageDecrementsCount" -> new Object[][]{{
+                 "testExpiredTrackedMessageDecrementsCount",
+                 "testLoadsNextSnapshotSegmentAfterCutoff",
+                 "testDoesNotLoadNextSnapshotSegmentBeforeCutoff" -> new Object[][]{{
                     new BucketDelayedDeliveryTracker(dispatcher, timer, 1, clock,
                             true, bucketSnapshotStorage, 5, TimeUnit.MILLISECONDS.toMillis(10), -1, 50)
             }};
@@ -245,6 +252,69 @@ public class BucketDelayedDeliveryTrackerTest extends AbstractDeliveryTrackerTes
                 tracker2.addMessage(1, 1, 1000));
 
         tracker2.close();
+    }
+
+    @Test(dataProvider = "delayedTracker")
+    public void testDoesNotLoadNextSnapshotSegmentBeforeCutoff(BucketDelayedDeliveryTracker tracker)
+            throws Exception {
+        for (int i = 1; i <= 6; i++) {
+            tracker.addMessage(i, i, i * 10);
+        }
+
+        Awaitility.await().untilAsserted(() ->
+                assertTrue(tracker.getImmutableBuckets().asMapOfRanges().values().stream()
+                        .noneMatch(x -> x.merging || !x.getSnapshotCreateFuture().get().isDone())));
+
+        tracker.close();
+
+        MockManagedCursor recoveredCursor = spy((MockManagedCursor) dispatcher.getCursor());
+        doReturn(PositionFactory.create(3, 0)).when(recoveredCursor).getMarkDeletedPosition();
+        doReturn(recoveredCursor).when(dispatcher).getCursor();
+
+        clockTime.set(1);
+        MockBucketSnapshotStorage localStorage = spy((MockBucketSnapshotStorage) bucketSnapshotStorage);
+        @Cleanup
+        BucketDelayedDeliveryTracker tracker2 = new BucketDelayedDeliveryTracker(
+                dispatcher, timer, 1000, clock, true, localStorage, 4, TimeUnit.MILLISECONDS.toMillis(10), 2, 50);
+
+        // Recovery loads segment 1; reset so the assertion observes only getScheduledMessages-driven loads.
+        clearInvocations(localStorage);
+        assertTrue(tracker2.getScheduledMessages(10).isEmpty());
+
+        Awaitility.await().during(3, TimeUnit.SECONDS).untilAsserted(() ->
+                verify(localStorage, never()).getBucketSnapshotSegment(anyLong(), anyLong(), anyLong()));
+    }
+
+    @Test(dataProvider = "delayedTracker")
+    public void testLoadsNextSnapshotSegmentAfterCutoff(BucketDelayedDeliveryTracker tracker)
+            throws Exception {
+        for (int i = 1; i <= 6; i++) {
+            tracker.addMessage(i, i, i * 100);
+        }
+
+        Awaitility.await().untilAsserted(() ->
+                assertTrue(tracker.getImmutableBuckets().asMapOfRanges().values().stream()
+                        .noneMatch(x -> x.merging || !x.getSnapshotCreateFuture().get().isDone())));
+
+        tracker.close();
+
+        MockManagedCursor recoveredCursor = spy((MockManagedCursor) dispatcher.getCursor());
+        doReturn(PositionFactory.create(3, 0)).when(recoveredCursor).getMarkDeletedPosition();
+        doReturn(recoveredCursor).when(dispatcher).getCursor();
+
+        clockTime.set(0);
+        MockBucketSnapshotStorage localStorage = spy((MockBucketSnapshotStorage) bucketSnapshotStorage);
+        @Cleanup
+        BucketDelayedDeliveryTracker tracker2 = new BucketDelayedDeliveryTracker(
+                dispatcher, timer, 1000, clock, true, localStorage, 4, TimeUnit.MILLISECONDS.toMillis(10), 2, 50);
+
+        // Trigger the segment loading
+        clockTime.set(600);
+        tracker2.getScheduledMessages(10);
+        Awaitility.await().untilAsserted(() -> {
+            assertTrue(tracker2.getScheduledMessages(10).contains(PositionFactory.create(4, 4)));
+            verify(localStorage, atLeastOnce()).getBucketSnapshotSegment(anyLong(), anyLong(), anyLong());
+        });
     }
 
     @Test(dataProvider = "delayedTracker")

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTrackerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTrackerTest.java
@@ -49,6 +49,8 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -692,6 +694,58 @@ public class BucketDelayedDeliveryTrackerTest extends AbstractDeliveryTrackerTes
         }
     }
 
+    /**
+     * Gates snapshot segment loads after recovery, so a segment load can be held in flight while
+     * clear() runs and then released to observe the stale-load vs reset interaction.
+     */
+    private static class GatedSegmentLoadStorage extends MockBucketSnapshotStorage {
+        volatile CompletableFuture<Void> segmentLoadGate;
+
+        @Override
+        public CompletableFuture<List<SnapshotSegment>> getBucketSnapshotSegment(long bucketId,
+                                                                                long firstSegmentEntryId,
+                                                                                long lastSegmentEntryId) {
+            CompletableFuture<List<SnapshotSegment>> future =
+                    super.getBucketSnapshotSegment(bucketId, firstSegmentEntryId, lastSegmentEntryId);
+            CompletableFuture<Void> gate = segmentLoadGate;
+            if (gate == null) {
+                return future;
+            }
+            return gate.thenCompose(__ -> future);
+        }
+    }
+
+    /**
+     * Blocks every attempt (initial + retries) of the first bucket snapshot creation until
+     * {@link #gate} completes. Used to keep that bucket's snapshot creation pending while the trim
+     * selects it, and then fail it to exercise the failed-create trim path.
+     */
+    private static class BlockingFirstCreateStorage extends MockBucketSnapshotStorage {
+        final CompletableFuture<Void> gate = new CompletableFuture<>();
+        final Set<String> blockedBucketKeys = ConcurrentHashMap.newKeySet();
+        private final AtomicLong createCalls = new AtomicLong();
+
+        @Override
+        public CompletableFuture<Long> createBucketSnapshot(SnapshotMetadata snapshotMetadata,
+                                                            List<SnapshotSegment> bucketSnapshotSegments,
+                                                            String bucketKey, String topicName, String cursorName) {
+            if (createCalls.incrementAndGet() == 1) {
+                blockedBucketKeys.add(bucketKey);
+            }
+            if (blockedBucketKeys.contains(bucketKey)) {
+                return gate.handle((__, ex) -> {
+                    if (ex != null) {
+                        throw new CompletionException(ex);
+                    }
+                    throw new CompletionException(
+                            new BucketSnapshotPersistenceException("Unexpected create success"));
+                });
+            }
+            return super.createBucketSnapshot(snapshotMetadata, bucketSnapshotSegments,
+                    bucketKey, topicName, cursorName);
+        }
+    }
+
     private ImmutableBucket createMergeableBucket(TrackerWithStorage trackerWithStorage, long startLedgerId,
                                                   long endLedgerId, List<Long> firstScheduleTimestamps) {
         ImmutableBucket bucket = new ImmutableBucket(trackerWithStorage.tracker.getCtx(), startLedgerId, endLedgerId);
@@ -845,6 +899,93 @@ public class BucketDelayedDeliveryTrackerTest extends AbstractDeliveryTrackerTes
             });
         } finally {
             ts.close();
+        }
+    }
+
+    @Test
+    public void testTrimSkipsFailedSnapshotCreation() throws Exception {
+        long firstLedgerId = 31L;
+        BlockingFirstCreateStorage storage = new BlockingFirstCreateStorage();
+        TrackerWithStorage ts = createTrackerWithMockLedger(firstLedgerId, 5, storage);
+        try {
+            // Sealing the sixth bucket exceeds maxNumBuckets and triggers the trim while the first
+            // bucket's snapshot creation is still in flight (blocked by the gate).
+            for (int i = 1; i <= 31; i++) {
+                ts.tracker.addMessage(i, i, i * 10);
+            }
+
+            synchronized (ts.tracker) {
+                assertEquals(storage.blockedBucketKeys.size(), 1,
+                        "The first bucket snapshot creation should have been blocked");
+                assertTrue(ts.tracker.getImmutableBuckets().asMapOfRanges().keySet().stream()
+                                .anyMatch(range -> range.lowerEndpoint() == 1L && range.upperEndpoint() == 5L),
+                        "The first bucket should still be present while its snapshot creation is pending");
+            }
+
+            // Fail the first bucket's snapshot creation while the trim chain is waiting on it.
+            storage.gate.completeExceptionally(new BucketSnapshotPersistenceException("Create failed"));
+
+            // The trim chain must not stop on the failed create: every orphaned bucket is cleaned up.
+            Awaitility.await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
+                synchronized (ts.tracker) {
+                    assertTrue(ts.tracker.getImmutableBuckets().asMapOfRanges().isEmpty(),
+                            "All orphaned buckets should be removed despite the failed snapshot creation");
+                }
+            });
+        } finally {
+            ts.close();
+        }
+    }
+
+    @Test
+    public void testClearWaitsForInFlightSegmentLoad() throws Exception {
+        AbstractPersistentDispatcherMultipleConsumers testDispatcher =
+                mock(AbstractPersistentDispatcherMultipleConsumers.class);
+        Clock testClock = mock(Clock.class);
+        AtomicLong testClockTime = new AtomicLong();
+        when(testClock.millis()).then(x -> testClockTime.get());
+
+        GatedSegmentLoadStorage storage = new GatedSegmentLoadStorage();
+        storage.start();
+
+        ManagedCursor cursor = new MockManagedCursor("test_clear_load_cursor");
+        doReturn(cursor).when(testDispatcher).getCursor();
+        doReturn("persistent://public/default/testClearLoad / " + cursor.getName())
+                .when(testDispatcher).getName();
+
+        BucketDelayedDeliveryTracker tracker = new BucketDelayedDeliveryTracker(
+                testDispatcher, timer, 1000, testClock, true, storage,
+                4, TimeUnit.MILLISECONDS.toMillis(10), 2, 50);
+        try {
+
+            // 6 messages with 2 indexes per segment produce 3 snapshot segments; segment 1 is loaded
+            // during recovery, so reaching the first segment boundary triggers a load of segment 2.
+            for (int i = 1; i <= 6; i++) {
+                tracker.addMessage(i, i, i * 100);
+            }
+            Awaitility.await().untilAsserted(() ->
+                    assertTrue(tracker.getImmutableBuckets().asMapOfRanges().values().stream()
+                            .noneMatch(x -> x.merging || !x.getSnapshotCreateFuture().get().isDone())));
+
+            // Block the segment 2 load so it stays in flight while clear() runs.
+            storage.segmentLoadGate = new CompletableFuture<>();
+            testClockTime.set(600);
+            tracker.getScheduledMessages(10);
+
+            CompletableFuture<Void> clearFuture = tracker.clear();
+            assertFalse("clear() should wait for the in-flight segment load", clearFuture.isDone());
+
+            // Release the load; clear() then completes and no stale segment state may survive.
+            storage.segmentLoadGate.complete(null);
+            clearFuture.get(1, TimeUnit.MINUTES);
+
+            assertEquals(tracker.getNumberOfDelayedMessages(), 0);
+            assertEquals(tracker.getImmutableBuckets().asMapOfRanges().size(), 0);
+            assertEquals(tracker.getLastMutableBucket().size(), 0);
+            assertEquals(tracker.getSharedBucketPriorityQueue().size(), 0);
+        } finally {
+            tracker.close();
+            storage.clean();
         }
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTrackerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTrackerTest.java
@@ -52,7 +52,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import lombok.Cleanup;
 import org.apache.bookkeeper.mledger.ManagedCursor;


### PR DESCRIPTION
### Motivation

Fix delayed-delivery bucket recovery and trim races that could stall progress or break cleanup:

- Segment-boundary advancement could be skipped when the current tail entry is orphaned (ledger below first live ledger), leaving the next snapshot segment unloaded.
- Trim/delete could race with snapshot creation and bucket-id resolution, including failed-create and missing/malformed cursor-property paths.
- Cursor reset needed to wait for delayed-delivery cleanup so in-flight trim/delete does not overlap with reset/replay.

### Modifications

- In `getScheduledMessages()`, process snapshot-segment boundary transition before dropping an orphaned tail entry, while still suppressing delivery of that orphaned entry.
- Kept cutoff gating behavior: next segment is not loaded before cutoff and is loaded once cutoff is reached.
- Hardened bucket-id resolution in `ImmutableBucket.asyncDeleteBucketSnapshot()`:
  - resolve delete bucket id via `Optional`
  - skip storage delete when create future failed
  - propagate missing/malformed recovered bucket id as failed `CompletableFuture` (no synchronous throw)
- `deleteBucketSnapshot()` now delegates the snapshot lifecycle to `ImmutableBucket.asyncDeleteBucketSnapshot()`: a failed snapshot creation resolves to "nothing to delete", so the sequential trim chain keeps going instead of failing on a failed create.
- `clear()` now waits for any in-flight snapshot segment load before clearing the in-memory state, so a stale load callback cannot republish pre-reset state after a cursor reset.
- Kept trim lifecycle checks in tracker delete flow with ownership revalidation before delete start and again before in-memory state removal.
- Made `resetCursor()` clear delayed delivery state and wait for any in-flight trim to finish before completing the reset.
- Added deterministic regressions in `BucketDelayedDeliveryTrackerTest`:
  - `testDoesNotLoadNextSnapshotSegmentBeforeCutoff`
  - `testLoadsNextSnapshotSegmentAfterCutoff`
  - `testTrimSkipsFailedSnapshotCreation`
  - `testClearWaitsForInFlightSegmentLoad`
