### PR TITLE
[fix][misc] Remove unnecessary " {}" suffix from log lines when there are no context attributes

### DIFF
--- a/buildtools/src/main/resources/log4j2.xml
+++ b/buildtools/src/main/resources/log4j2.xml
@@ -31,14 +31,14 @@
   <Appenders>
     <!-- setting follow="true" is required for using ConsoleCaptor to validate log messages -->
     <Console name="CONSOLE" target="SYSTEM_OUT" follow="true">
-      <PatternLayout pattern="%d{ISO8601_OFFSET_DATE_TIME_HHMM} %-5level [%t{12}] %c{1.} - %msg %X%n"/>
+      <PatternLayout pattern="%d{ISO8601_OFFSET_DATE_TIME_HHMM} %-5level [%t{12}] %c{1.} - %msg%equals{ %X}{ {}}{}%n"/>
     </Console>
     <RollingFile name="FILE"
                  fileName="${sys:pulsar.test.logging.file}"
                  filePattern="${sys:pulsar.test.logging.file}-%i.log"
                  immediateFlush="${sys:pulsar.test.logging.file.immediateFlush}"
                  createOnDemand="true">
-      <PatternLayout pattern="%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg %X%n"/>
+      <PatternLayout pattern="%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%equals{ %X}{ {}}{}%n"/>
       <Policies>
         <SizeBasedTriggeringPolicy size="10MB"/>
       </Policies>

--- a/conf/functions_log4j2.xml
+++ b/conf/functions_log4j2.xml
@@ -40,7 +40,7 @@
             <name>Console</name>
             <target>SYSTEM_OUT</target>
             <PatternLayout>
-                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg %X%n</Pattern>
+                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%equals{ %X}{ {}}{}%n</Pattern>
             </PatternLayout>
         </Console>
         <RollingFile>
@@ -49,7 +49,7 @@
             <filePattern>${sys:pulsar.function.log.dir}/${sys:pulsar.function.log.file}-%d{MM-dd-yyyy}-%i.log.gz</filePattern>
             <immediateFlush>true</immediateFlush>
             <PatternLayout>
-                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg %X%n</Pattern>
+                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%equals{ %X}{ {}}{}%n</Pattern>
             </PatternLayout>
             <Policies>
                 <TimeBasedTriggeringPolicy>
@@ -82,7 +82,7 @@
             <filePattern>${sys:pulsar.function.log.dir}/${sys:pulsar.function.log.file}.bk-%d{MM-dd-yyyy}-%i.log.gz</filePattern>
             <immediateFlush>true</immediateFlush>
             <PatternLayout>
-                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg %X%n</Pattern>
+                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%equals{ %X}{ {}}{}%n</Pattern>
             </PatternLayout>
             <Policies>
                 <TimeBasedTriggeringPolicy>

--- a/conf/log4j2.yaml
+++ b/conf/log4j2.yaml
@@ -67,7 +67,7 @@ Configuration:
         - propertyName: pulsar.log.format
           propertyValue: text
           PatternLayout:
-            Pattern: "%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg %X%n"
+            Pattern: "%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%equals{ %X}{ {}}{}%n"
 
     # Rolling file appender configuration
     RollingFile:
@@ -83,7 +83,7 @@ Configuration:
         - propertyName: pulsar.log.format
           propertyValue: text
           PatternLayout:
-            Pattern: "%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg %X%n"
+            Pattern: "%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%equals{ %X}{ {}}{}%n"
       Policies:
         TimeBasedTriggeringPolicy:
           interval: 1
@@ -128,7 +128,7 @@ Configuration:
                         - propertyName: pulsar.log.format
                           propertyValue: text
                           PatternLayout:
-                            Pattern: "%d{ABSOLUTE} %level{length=5} [%thread] [instance: %X{instance}] %logger{1} - %msg%n"
+                            Pattern: "%d{ABSOLUTE} %level{length=5} [%thread] [instance: %X{instance}] %logger{1} - %msg%equals{ %X}{ {}}{}%n"
                       Policies:
                         TimeBasedTriggeringPolicy:
                           interval: 1

--- a/microbench/src/main/resources/log4j2.xml
+++ b/microbench/src/main/resources/log4j2.xml
@@ -22,7 +22,7 @@
 <Configuration status="WARN">
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg %X%n"/>
+            <PatternLayout pattern="%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%equals{ %X}{ {}}{}%n"/>
         </Console>
     </Appenders>
     <Loggers>

--- a/pulsar-broker/src/test/resources/log4j2.xml
+++ b/pulsar-broker/src/test/resources/log4j2.xml
@@ -30,14 +30,14 @@
   <Appenders>
     <!-- setting follow="true" is required for using ConsoleCaptor to validate log messages -->
     <Console name="CONSOLE" target="SYSTEM_OUT" follow="true">
-      <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%c{1}] - %m %X%n"/>
+      <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%c{1}] - %m%equals{ %X}{ {}}{}%n"/>
     </Console>
     <RollingFile name="FILE"
                  fileName="${sys:pulsar.test.logging.file}"
                  filePattern="${sys:pulsar.test.logging.file}-%i.log"
                  immediateFlush="${sys:pulsar.test.logging.file.immediateFlush}"
                  createOnDemand="true">
-      <PatternLayout pattern="%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg %X%n"/>
+      <PatternLayout pattern="%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%equals{ %X}{ {}}{}%n"/>
       <Policies>
         <SizeBasedTriggeringPolicy size="10MB"/>
       </Policies>

--- a/pulsar-client-admin/src/test/resources/log4j2.xml
+++ b/pulsar-client-admin/src/test/resources/log4j2.xml
@@ -25,7 +25,7 @@
   <Appenders>
     <!-- setting follow="true" is required for using ConsoleCaptor to validate log messages -->
     <Console name="CONSOLE" target="SYSTEM_OUT" follow="true">
-      <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%c{1}] - %m %X%n"/>
+      <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%c{1}] - %m%equals{ %X}{ {}}{}%n"/>
     </Console>
   </Appenders>
   <Loggers>

--- a/pulsar-functions/localrun/src/main/resources/log4j2.xml
+++ b/pulsar-functions/localrun/src/main/resources/log4j2.xml
@@ -22,7 +22,7 @@
 <Configuration status="WARN">
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg %X%n"/>
+            <PatternLayout pattern="%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%equals{ %X}{ {}}{}%n"/>
         </Console>
     </Appenders>
     <Loggers>

--- a/pulsar-functions/runtime-all/src/main/resources/java_instance_log4j2.xml
+++ b/pulsar-functions/runtime-all/src/main/resources/java_instance_log4j2.xml
@@ -40,7 +40,7 @@
             <name>Console</name>
             <target>SYSTEM_OUT</target>
             <PatternLayout>
-                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg %X%n</Pattern>
+                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%equals{ %X}{ {}}{}%n</Pattern>
             </PatternLayout>
         </Console>
         <RollingFile>
@@ -49,7 +49,7 @@
             <filePattern>${sys:pulsar.function.log.dir}/${sys:pulsar.function.log.file}-%d{MM-dd-yyyy}-%i.log.gz</filePattern>
             <immediateFlush>true</immediateFlush>
             <PatternLayout>
-                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg %X%n</Pattern>
+                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%equals{ %X}{ {}}{}%n</Pattern>
             </PatternLayout>
             <Policies>
                 <TimeBasedTriggeringPolicy>
@@ -82,7 +82,7 @@
             <filePattern>${sys:pulsar.function.log.dir}/${sys:pulsar.function.log.file}.bk-%d{MM-dd-yyyy}-%i.log.gz</filePattern>
             <immediateFlush>true</immediateFlush>
             <PatternLayout>
-                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg %X%n</Pattern>
+                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%equals{ %X}{ {}}{}%n</Pattern>
             </PatternLayout>
             <Policies>
                 <TimeBasedTriggeringPolicy>

--- a/pulsar-functions/runtime-all/src/main/resources/kubernetes_instance_log4j2.xml
+++ b/pulsar-functions/runtime-all/src/main/resources/kubernetes_instance_log4j2.xml
@@ -36,7 +36,7 @@
             <name>Console</name>
             <target>SYSTEM_OUT</target>
             <PatternLayout>
-                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg %X%n</Pattern>
+                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%equals{ %X}{ {}}{}%n</Pattern>
             </PatternLayout>
         </Console>
     </Appenders>

--- a/pulsar-proxy/src/test/resources/log4j2.xml
+++ b/pulsar-proxy/src/test/resources/log4j2.xml
@@ -25,7 +25,7 @@
   <Appenders>
     <!-- setting follow="true" is required for using ConsoleCaptor to validate log messages -->
     <Console name="CONSOLE" target="SYSTEM_OUT" follow="true">
-      <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%c{1}] - %m %X%n"/>
+      <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%c{1}] - %m%equals{ %X}{ {}}{}%n"/>
     </Console>
   </Appenders>
   <Loggers>

--- a/tiered-storage/jcloud/src/test/resources/log4j2-test.yml
+++ b/tiered-storage/jcloud/src/test/resources/log4j2-test.yml
@@ -33,12 +33,12 @@ Configuration:
       name: STDOUT
       target: SYSTEM_OUT
       PatternLayout:
-        Pattern: "%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg %X%n"
+        Pattern: "%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%equals{ %X}{ {}}{}%n"
     File:
       name: File
       fileName: ${filename}
       PatternLayout:
-        Pattern: "%d %p %c{1.} [%t] %m %X%n"
+        Pattern: "%d %p %c{1.} [%t] %m%equals{ %X}{ {}}{}%n"
       Filters:
         ThresholdFilter:
           level: error


### PR DESCRIPTION
### Motivation

Pulsar's Log4j2 patterns render the thread context map with `%X` so that context attributes
added by [slog](https://github.com/merlimat/slog) end up in the log output (see PIP-89).

On `branch-4.2` and `branch-4.0` this was added by
[97463c445a4550feb53462a16198475f2a63fc8d](https://github.com/apache/pulsar/commit/97463c445a4550feb53462a16198475f2a63fc8d)
and [ffabaaec](https://github.com/apache/pulsar/commit/ffabaaecdb9799a5fd9083db75f688947c7c91be),
because upgrading the Oxia client to 0.9.4 pulled in slog
([oxia-db/oxia-client-java#273](https://github.com/oxia-db/oxia-client-java/pull/273)). Without
that change, no attributes added by slog would have been logged for Oxia client logs.

The problem is that Log4j2's `%X` converter renders an empty thread context map as the literal
string `{}`. Every log line that carries no context attributes therefore gets a useless ` {}`
suffix:

```
2026-08-07T14:44:30,406 [main] INFO  org.example.MyClass - hello world {}
```

On `branch-4.2` and `branch-4.0` this affects nearly *every* log line, since Oxia client logging is
the only slog user there and all other logging goes through slf4j without context attributes. On
`master` slog is used broadly, but the same ` {}` suffix still shows up on every log line that has
no context attributes, which is why the fix is needed on `master`, `branch-4.2` and `branch-4.0`.

### Modifications

Replace the plain ` %X` in the Log4j2 pattern layouts with
`%equals{ %X}{ {}}{}`, using Log4j2's
[`EqualsReplacementConverter`](https://logging.apache.org/log4j/2.x/manual/pattern-layout.html):
it renders ` %X` and, when the result equals the literal ` {}` (i.e. the context map is empty),
replaces it with an empty string. When context attributes are present the output is unchanged.

Updated in all 11 Log4j2 configurations that render `%X`:

- `buildtools/src/main/resources/log4j2.xml`
- `conf/functions_log4j2.xml`
- `conf/log4j2.yaml`
- `microbench/src/main/resources/log4j2.xml`
- `pulsar-broker/src/test/resources/log4j2.xml`
- `pulsar-client-admin/src/test/resources/log4j2.xml`
- `pulsar-functions/localrun/src/main/resources/log4j2.xml`
- `pulsar-functions/runtime-all/src/main/resources/java_instance_log4j2.xml`
- `pulsar-functions/runtime-all/src/main/resources/kubernetes_instance_log4j2.xml`
- `pulsar-proxy/src/test/resources/log4j2.xml`
- `tiered-storage/jcloud/src/test/resources/log4j2-test.yml`

Note that the per-instance function appender in `conf/log4j2.yaml` also gains the context-attribute
suffix (it previously ended in `%msg%n`), which brings it in line with the other function log
patterns and with `branch-4.2`/`branch-4.0`. Its existing `[instance: %X{instance}]` single-key
lookup is intentionally left alone — a single-key `%X{key}` renders an empty string, not `{}`, when
the key is absent, so it needs no `%equals` wrapping.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

The pattern behavior was verified directly against `log4j-core` 2.26.0 (the version in the version
catalog) by rendering `LogEvent`s through `PatternLayout`:

| context data | output |
|---|---|
| *(empty)* | `2026-08-07T14:44:30,406 [main] INFO  org.example.MyClass - hello world` |
| `a=b` | `2026-08-07T14:44:30,409 [main] INFO  org.example.MyClass - hello world {a=b}` |
| `instance=0` (with `[instance: %X{instance}]`) | `INFO [instance: 0] MyClass - hello world {instance=0}` |

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

This changes the default text log output format: log lines without context attributes no longer end
in ` {}`. JSON log output (`JsonTemplateLayout`) is unaffected.
