### PR TITLE
[fix][client] Make V5 async producer flush() await the caller's send futures

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/v5/V5AsyncApisTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/v5/V5AsyncApisTest.java
@@ -78,10 +78,17 @@ public class V5AsyncApisTest extends V5ClientBaseTest {
         }
 
         // flush() must complete only after all in-flight sends have been acknowledged.
-        async.flush().get(AWAIT.toMillis(), TimeUnit.MILLISECONDS);
+        // Sample the send futures from *inside* a flush() dependent rather than after
+        // flush().get() returns: the dependent runs on the thread that completes flush(),
+        // before that thread moves on to any other dependent of the last send. A send
+        // future flush() didn't genuinely await therefore shows up as not-done here every
+        // time, instead of only when the woken test thread happens to win the race.
+        List<Boolean> doneWhenFlushCompleted = async.flush()
+                .thenApply(__ -> sendFutures.stream().map(CompletableFuture::isDone).toList())
+                .get(AWAIT.toMillis(), TimeUnit.MILLISECONDS);
         for (int i = 0; i < n; i++) {
-            assertTrue(sendFutures.get(i).isDone(),
-                    "send future " + i + " must be done after flush()");
+            assertTrue(doneWhenFlushCompleted.get(i),
+                    "send future " + i + " must be done when flush() completes");
             assertNotNull(sendFutures.get(i).getNow(null),
                     "send future " + i + " must carry a non-null MessageId");
         }

--- a/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/AsyncMessageBuilderV5.java
+++ b/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/AsyncMessageBuilderV5.java
@@ -51,10 +51,13 @@ final class AsyncMessageBuilderV5<T> implements AsyncMessageBuilder<T> {
 
     @Override
     public CompletableFuture<MessageId> send() {
+        // Return the producer's future as-is. Wrapping it in a derived stage would leave
+        // flush() awaiting the upstream future while the caller holds the downstream one,
+        // and dependents of a completing future fire in unspecified order — so flush()
+        // could return before the caller's future is done.
         return producer.sendInternalAsync(
                 key, value, properties, eventTime, sequenceId,
-                deliverAfter, deliverAt, replicationClusters, txn)
-                .thenApply(id -> id);
+                deliverAfter, deliverAt, replicationClusters, txn);
     }
 
     @Override

--- a/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/ScalableTopicProducer.java
+++ b/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/ScalableTopicProducer.java
@@ -28,6 +28,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
 import org.apache.pulsar.client.api.ProducerAccessMode;
 import org.apache.pulsar.client.api.v5.MessageBuilder;
+import org.apache.pulsar.client.api.v5.MessageId;
 import org.apache.pulsar.client.api.v5.Producer;
 import org.apache.pulsar.client.api.v5.PulsarClientException;
 import org.apache.pulsar.client.api.v5.async.AsyncProducer;
@@ -94,8 +95,15 @@ final class ScalableTopicProducer<T> implements Producer<T>, DagWatchClient.Layo
      * Currently in-flight async sends. {@link #flushAsync()} snapshots and
      * awaits these (each user-visible send future completes on broker ack —
      * exactly the flush guarantee).
+     *
+     * <p>These are the very futures handed back to the caller by
+     * {@code AsyncMessageBuilder.send()}, not upstream stages of them. Tracking an
+     * upstream stage instead would break the flush contract: {@code allOf} and the
+     * caller-facing stage would both be dependents of that upstream future, and the JDK
+     * fires dependents of a completing future in unspecified order — so flush() could
+     * complete while a send future the caller holds is still not {@code isDone()}.
      */
-    private final Set<CompletableFuture<MessageIdV5>> inFlightSends =
+    private final Set<CompletableFuture<MessageId>> inFlightSends =
             ConcurrentHashMap.newKeySet();
 
     // Current active segments (volatile for visibility across threads)
@@ -261,15 +269,19 @@ final class ScalableTopicProducer<T> implements Producer<T>, DagWatchClient.Layo
     /**
      * Send a message asynchronously with routing. Called by AsyncMessageBuilderV5.
      * Returns a future of MessageIdV5 that includes the segment ID.
+     *
+     * <p>The returned future is handed to the caller as-is — no identity {@code thenApply}
+     * stage in between — so that {@link #flushAsync()} awaits exactly the futures the caller
+     * observes. See {@link #inFlightSends}.
      */
-    CompletableFuture<MessageIdV5> sendInternalAsync(
+    CompletableFuture<MessageId> sendInternalAsync(
             String key, T value, java.util.Map<String, String> properties,
             java.time.Instant eventTime, Long sequenceId,
             java.time.Duration deliverAfter, java.time.Instant deliverAt,
             java.util.List<String> replicationClusters,
             org.apache.pulsar.client.api.v5.Transaction txn) {
 
-        CompletableFuture<MessageIdV5> userFuture = new CompletableFuture<>();
+        CompletableFuture<MessageId> userFuture = new CompletableFuture<>();
         inFlightSends.add(userFuture);
         userFuture.whenComplete((__, ___) -> inFlightSends.remove(userFuture));
         dispatchSendAttempt(userFuture, key, value, properties, eventTime, sequenceId,
@@ -278,7 +290,7 @@ final class ScalableTopicProducer<T> implements Producer<T>, DagWatchClient.Layo
     }
 
     private void dispatchSendAttempt(
-            CompletableFuture<MessageIdV5> userFuture,
+            CompletableFuture<MessageId> userFuture,
             String key, T value, java.util.Map<String, String> properties,
             java.time.Instant eventTime, Long sequenceId,
             java.time.Duration deliverAfter, java.time.Instant deliverAt,
@@ -334,7 +346,7 @@ final class ScalableTopicProducer<T> implements Producer<T>, DagWatchClient.Layo
      * run {@code retry}; otherwise fail the user-visible future. Covers both the v4 send
      * failure and the per-segment producer-creation failure.
      */
-    private void handleAsyncSegmentFailure(CompletableFuture<MessageIdV5> userFuture, long segmentId,
+    private void handleAsyncSegmentFailure(CompletableFuture<MessageId> userFuture, long segmentId,
                                            int attempt, Throwable ex, Runnable retry) {
         Throwable cause = ex instanceof java.util.concurrent.CompletionException ? ex.getCause() : ex;
         if (isSegmentGoneError(cause) && attempt < SEND_RETRY_MAX_ATTEMPTS) {


### PR DESCRIPTION
Fixes #26283

### Motivation

`V5AsyncApisTest.testAsyncProducerSendAndFlush` fails intermittently in CI:

```
java.lang.AssertionError: send future 19 must be done after flush() expected [true] but found [false]
	at org.apache.pulsar.client.api.v5.V5AsyncApisTest.testAsyncProducerSendAndFlush(V5AsyncApisTest.java:83)
```

This is not test flakiness — it is a real contract violation in the V5 client.

`AsyncMessageBuilderV5.send()` returned

```java
producer.sendInternalAsync(...).thenApply(id -> id);
```

an identity stage whose only purpose was to widen `CompletableFuture<MessageIdV5>` to
`CompletableFuture<MessageId>` (Java generics are invariant). Meanwhile
`ScalableTopicProducer` registered the **upstream** future in `inFlightSends`, and
`flushAsync()` returns `CompletableFuture.allOf(...)` over a snapshot of that set.

So `allOf` and the caller-facing `thenApply` stage were **sibling dependents of the same
upstream future**. When the last send is acked on the Netty IO thread,
`CompletableFuture.postComplete()` drains the dependent stack in LIFO order: the `allOf` node
fires first, completing `flush()` and unparking the caller blocked in `get()`, *before* the
`thenApply` link that completes the future the caller actually holds. The caller can then
observe `isDone() == false` on a send that `flush()` claimed to have awaited.

The reported index is always the last one because `allOf` completes precisely on the last
send's completion, so that send's caller-facing stage is the one still pending. On an
unloaded machine the Netty thread wins that race by microseconds, which is why this only
showed up under CI load.

### Modifications

- `ScalableTopicProducer.sendInternalAsync` now creates and returns a
  `CompletableFuture<MessageId>` directly, and `AsyncMessageBuilderV5.send()` hands it back
  as-is. `inFlightSends` therefore holds the very futures returned to callers, so when
  `flush()`'s `allOf` completes, every one of them is guaranteed `isDone()` — `allOf` only
  completes after each component's result is set. This also drops one allocation and one
  dependent stage per async send.
- `dispatchSendAttempt` / `handleAsyncSegmentFailure` / `inFlightSends` follow the same type
  change. `MessageIdV5` still implements `org.apache.pulsar.client.api.v5.MessageId`, so the
  segment-carrying message id is unchanged on the wire and in the completed value; only the
  static type of the internal plumbing narrows. `sendInternalAsync` had exactly one caller.
- Comments on `inFlightSends` and `send()` record *why* no wrapper stage may be introduced
  between the tracked future and the returned one, so the bug is not reintroduced.
- `V5AsyncApisTest.testAsyncProducerSendAndFlush` now samples `isDone()` from **inside** a
  `flush()` dependent instead of after `flush().get()` returns. That dependent runs on the
  thread completing `flush()`, before it moves on to any other dependent of the last send, so
  a send that `flush()` did not genuinely await shows up as not-done every time instead of
  only when the woken test thread happens to win the race. The original assertions are kept
  and none are weakened.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as
`V5AsyncApisTest.testAsyncProducerSendAndFlush`, which was strengthened here so that it
pins the regression deterministically.

Verified locally:

- With the `.thenApply(id -> id)` wrapper temporarily reintroduced, the updated test fails
  **deterministically** with exactly the CI assertion
  (`send future 19 must be done when flush() completes expected [true] but found [false]`)
  — i.e. the test now catches the bug on every run rather than occasionally.
- With the fix in place, the whole `V5AsyncApisTest` class is green, with
  `testAsyncProducerSendAndFlush` at `invocationCount = 10`: 15/15 tests passed, 0 failures.
  (`invocationCount` was removed again before opening this PR.)
- The ordering hazard was also confirmed in isolation with a standalone JDK harness modelling
  both shapes over 20 futures × 2000 runs: the old shape (identity `thenApply` + `allOf` on the
  upstream future) had at least one caller-visible future not done at flush completion in
  2000/2000 runs; the new shape, 0/2000.
- `./gradlew spotlessCheck checkstyleMain checkstyleTest` passes.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

The V5 public API is unchanged: `AsyncMessageBuilder.send()` keeps its
`CompletableFuture<MessageId>` signature, and the completed value is still a `MessageIdV5`.
Only which `CompletableFuture` instance is returned changes, which is what fixes the
`flush()` guarantee.
