### PR TITLE
[cleanup][broker] Remove configuration entries that no longer exist in the code

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1244,10 +1244,6 @@ bookkeeperClientIsolationGroups=
 # have enough bookie available.
 bookkeeperClientSecondaryIsolationGroups=
 
-# Minimum bookies that should be available as part of bookkeeperClientIsolationGroups
-# else broker will include bookkeeperClientSecondaryIsolationGroups bookies in isolated list.
-bookkeeperClientMinAvailableBookiesInIsolationGroups=
-
 # Enable/disable having read operations for a ledger to be sticky to a single bookie.
 # If this flag is enabled, the client will use one single bookie (by preference) to read
 # all entries for a ledger.
@@ -2263,6 +2259,3 @@ brokerInterceptorsDirectory=./interceptors
 
 # List of broker interceptor to load, which is a list of broker interceptor names
 brokerInterceptors=
-
-# Enable or disable the broker interceptor, which is only used for testing for now
-disableBrokerInterceptors=true

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -798,10 +798,6 @@ bookkeeperClientIsolationGroups=
 # have enough bookie available.
 bookkeeperClientSecondaryIsolationGroups=
 
-# Minimum bookies that should be available as part of bookkeeperClientIsolationGroups
-# else broker will include bookkeeperClientSecondaryIsolationGroups bookies in isolated list.
-bookkeeperClientMinAvailableBookiesInIsolationGroups=
-
 # Set the client security provider factory class name.
 # Default: org.apache.bookkeeper.tls.TLSContextFactory
 bookkeeperTLSProviderFactoryClass=org.apache.bookkeeper.tls.TLSContextFactory
@@ -1554,9 +1550,6 @@ brokerInterceptorsDirectory=./interceptors
 
 # List of broker interceptor to load, which is a list of broker interceptor names
 brokerInterceptors=
-
-# Enable or disable the broker interceptor, which is only used for testing for now
-disableBrokerInterceptors=true
 
 # Whether retain null-key message during topic compaction
 topicCompactionRetainNullKey=false

--- a/deployment/terraform-ansible/templates/broker.conf
+++ b/deployment/terraform-ansible/templates/broker.conf
@@ -693,10 +693,6 @@ bookkeeperClientIsolationGroups=
 # have enough bookie available.
 bookkeeperClientSecondaryIsolationGroups=
 
-# Minimum bookies that should be available as part of bookkeeperClientIsolationGroups
-# else broker will include bookkeeperClientSecondaryIsolationGroups bookies in isolated list.
-bookkeeperClientMinAvailableBookiesInIsolationGroups=
-
 # Enable/disable having read operations for a ledger to be sticky to a single bookie.
 # If this flag is enabled, the client will use one single bookie (by preference) to read
 # all entries for a ledger.

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/plugins/TestBrokerInterceptors.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/plugins/TestBrokerInterceptors.java
@@ -41,7 +41,6 @@ public class TestBrokerInterceptors extends TopicMessagingBase {
 
     @Override
     public void setupCluster() throws Exception {
-        brokerEnvs.put(PREFIX + "disableBrokerInterceptors", "false");
         brokerEnvs.put(PREFIX + "brokerInterceptorsDirectory", "/pulsar/examples");
         brokerEnvs.put(PREFIX + "brokerInterceptors", "loggingInterceptor");
         super.setupCluster();


### PR DESCRIPTION
### Motivation

Two settings are still documented and shipped in the sample configuration files, but nothing in the
codebase reads them. Operators who set them get silence rather than an error, and one of them is
actively misleading.

**`disableBrokerInterceptors`** was deleted from `ServiceConfiguration` by PIP-293 (`pip/pip-293.md`:
*"This `disableBrokerInterceptors` config is very confusing, so we decide to delete it."*), but the
entry survived in `conf/broker.conf` and `conf/standalone.conf`, where it reads:

```
# Enable or disable the broker interceptor, which is only used for testing for now
disableBrokerInterceptors=true
```

Shipped as `true`, that reasonably suggests broker interceptors are disabled by default and have to be
switched on here — which has not been the case since PIP-293.
`tests/integration/src/test/java/org/apache/pulsar/tests/integration/plugins/TestBrokerInterceptors.java`
also still sets `PULSAR_PREFIX_disableBrokerInterceptors=false`, which is a no-op.

**`bookkeeperClientMinAvailableBookiesInIsolationGroups`** has no field in `ServiceConfiguration` and
no reader anywhere in the tree. It is not picked up by the BookKeeper passthrough either, which only
forwards `bookkeeper_`-prefixed keys (`BookKeeperClientFactoryImpl.java:165`). The behaviour its
comment describes — falling back to the secondary isolation group when the primary has too few
bookies — is implemented in `IsolatedBookieEnsemblePlacementPolicy`, but keyed on the requested
ensemble size rather than on a configurable minimum, so the setting has nothing to control.

`ServiceConfigurationTest#testConfigFileDefaults` already compares `conf/broker.conf` against
`ServiceConfiguration`, but only in one direction: it iterates the Java bean properties and checks the
file agrees. A key present in the file but absent from Java is invisible to it, which is how both of
these survived.

### Modifications

Removed both entries, together with their comment blocks, from:

- `conf/broker.conf`
- `conf/standalone.conf`
- `deployment/terraform-ansible/templates/broker.conf` (the isolation-groups key only; it never
  carried the interceptor one)

and dropped the no-op environment variable from `TestBrokerInterceptors`.

No code behaviour changes: neither key was read before this change.

The remaining references to `disableBrokerInterceptors` are in `pip/pip-293.md`, which is the
historical proposal record and is intentionally left untouched.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

`ServiceConfigurationTest` passes; it is the existing guard that loads `conf/broker.conf` and checks it
against `ServiceConfiguration`.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [x] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

Both removed entries were already inert, so no effective default changes — the box is checked only
because the sample configuration files are edited.

Assisted-by: Claude Code
