### PR TITLE
fix: allocate rebatch buffer with uncompressed size (#26290)

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawBatchConverter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawBatchConverter.java
@@ -142,12 +142,12 @@ public class RawBatchConverter {
         } else {
             Commands.skipMessageMetadata(payload);
         }
-        ByteBuf batchBuffer = PulsarByteBufAllocator.DEFAULT.buffer(payload.capacity());
+        int uncompressedSize = metadata.getUncompressedSize();
+        ByteBuf batchBuffer = PulsarByteBufAllocator.DEFAULT.buffer(uncompressedSize);
 
         CompressionType compressionType = metadata.getCompression();
         CompressionCodec codec = CompressionCodecProvider.getCompressionCodec(compressionType);
 
-        int uncompressedSize = metadata.getUncompressedSize();
         ByteBuf uncompressedPayload = codec.decode(payload, uncompressedSize);
         try {
             int batchSize = metadata.getNumMessagesInBatch();


### PR DESCRIPTION
### Motivation

`RawBatchConverter.rebatchMessage` allocates the output batch buffer using the **compressed** payload capacity, but then re-serializes the **uncompressed** single messages into it. When the compressed payload is much smaller than the uncompressed rebatched size, the buffer is undersized and `SingleMessageMetadata.writeTo()`'s zero-copy `getBytes` path (from `_parsedBuffer`) throws `IndexOutOfBoundsException` because Netty's `getBytes` does not auto-expand the destination.

### Fix

Move `metadata.getUncompressedSize()` before the buffer allocation and use it as the initial capacity instead of `payload.capacity()`.

### Affected versions

- **4.0.x (LTS) and 4.1.x**: the bug manifests as a deterministic compaction failure for compressed batches.
- **4.2.0+ / master**: the LightProto 0.6.x upgrade (#25332) masks the bug by making the generated `SingleMessageMetadata.writeTo()` call `ensureWritable()` before the zero-copy `getBytes` path. This fix is still a defensive improvement for these versions.

### Verification

The reproducer from the issue (a topic with batched ZSTD-compressed messages and automatic compaction) can be used to verify the fix.

Fixes #26290