### PR TITLE
[improve][broker] Avoid blocking joins in ClusterResources sync APIs

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/ClusterResources.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/ClusterResources.java
@@ -23,6 +23,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -71,8 +73,21 @@ public class ClusterResources extends BaseResources<ClusterData> {
         return getAsync(joinPath(BASE_CLUSTERS_PATH, clusterName));
     }
 
+    public CompletableFuture<List<String>> getNamespacesForClusterAsync(String tenant, String clusterName) {
+        return getChildrenAsync(joinPath(BASE_POLICIES_PATH, tenant, clusterName));
+    }
+
     public List<String> getNamespacesForCluster(String tenant, String clusterName) throws MetadataStoreException {
-        return getChildren(joinPath(BASE_POLICIES_PATH, tenant, clusterName));
+        try {
+            return getNamespacesForClusterAsync(tenant, clusterName)
+                    .get(getOperationTimeoutSec(), TimeUnit.SECONDS);
+        } catch (ExecutionException e) {
+            throw (e.getCause() instanceof MetadataStoreException) ? (MetadataStoreException) e.getCause()
+                    : new MetadataStoreException(e.getCause());
+        } catch (Exception e) {
+            throw new MetadataStoreException(
+                    "Failed to get namespaces for tenant " + tenant + " in cluster " + clusterName, e);
+        }
     }
 
     public void createCluster(String clusterName, ClusterData clusterData) throws MetadataStoreException {
@@ -109,22 +124,28 @@ public class ClusterResources extends BaseResources<ClusterData> {
                             .collect(Collectors.toList());
                     return FutureUtil.waitForAll(futures)
                             .thenApply(__ -> {
-                                // We found a tenant that has at least a namespace in this cluster
-                                return futures.stream().map(CompletableFuture::join)
+                                // Futures are already complete after waitForAll; use getNow to avoid
+                                // accidental blocking if this is ever refactored.
+                                return futures.stream()
+                                        .map(f -> f.getNow(List.of()))
                                         .anyMatch(CollectionUtils::isNotEmpty);
                             });
                 });
     }
 
+    /**
+     * Synchronous wrapper around {@link #isClusterUsedAsync(String)}.
+     * Prefer the async method so callers do not block metadata store threads.
+     */
     public boolean isClusterUsed(String clusterName) throws MetadataStoreException {
-        for (String tenant : getCache().getChildren(BASE_POLICIES_PATH).join()) {
-            if (!getCache().getChildren(joinPath(BASE_POLICIES_PATH, tenant, clusterName)).join().isEmpty()) {
-                // We found a tenant that has at least a namespace in this cluster
-                return true;
-            }
+        try {
+            return isClusterUsedAsync(clusterName).get(getOperationTimeoutSec(), TimeUnit.SECONDS);
+        } catch (ExecutionException e) {
+            throw (e.getCause() instanceof MetadataStoreException) ? (MetadataStoreException) e.getCause()
+                    : new MetadataStoreException(e.getCause());
+        } catch (Exception e) {
+            throw new MetadataStoreException("Failed to check if cluster is used: " + clusterName, e);
         }
-
-        return false;
     }
 
     public boolean clusterExists(String clusterName) throws MetadataStoreException {


### PR DESCRIPTION
Main Issue: #22544

### Motivation

Issue #22544 asks to clean up synchronous metadata access in the broker **resources** layer so callers cannot easily block metadata store threads.

`ClusterResources.isClusterUsed` was one of the clearer offenders: it called `MetadataCache.getChildren(...).join()` in a loop with **no operation timeout**, and did sequential metadata RPCs instead of using the existing parallel async path.

Related background: #22542 (closed) discussed not chaining heavy sync metadata work after metadata completions; admin already uses `isClusterUsedAsync` in `ClustersBase`.

### Modifications

In `ClusterResources`:

1. **`isClusterUsed`** now wraps **`isClusterUsedAsync`** with the standard `operationTimeoutSec` (same pattern as other `BaseResources` sync helpers).
2. **`getNamespacesForClusterAsync`** added; sync **`getNamespacesForCluster`** routes through it with timeout.
3. In **`isClusterUsedAsync`**, after `FutureUtil.waitForAll`, use **`getNow`** instead of **`join`** so a future refactor cannot reintroduce blocking.

This is intentionally scoped (one resources class / one class of bugs). Broader removal of all sync resource APIs remains future work under #22544.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a focused rework of existing APIs without new behavior beyond timeout + non-blocking composition. Existing admin paths already use `isClusterUsedAsync`.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

<!-- threading model: reduces risk of blocking; no intentional public API break -->