### PR TITLE
[fix][ml] Skip contiguous deleted ranges during reads

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -2424,9 +2424,8 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             // without issuing a ledger read.
             if (firstValidEntry == -1L) {
                 final Position lastScannedPosition = PositionFactory.create(ledger.getId(), lastEntry);
-                // If the last scanned position belongs to an individually deleted range, hop past its
-                // upper bound. Otherwise, getNextAvailablePosition() advances by one position. A hop can
-                // cross maxPosition safely because every position crossed by the hop is individually deleted.
+                // The whole scan window was skipped. If the last scanned position is individually deleted,
+                // hop over its deleted range instead of advancing one window at a time.
                 final Position nextReadPosition = opReadEntry.cursor.getNextAvailablePosition(lastScannedPosition);
                 opReadEntry.updateReadPosition(nextReadPosition);
                 opReadEntry.checkReadCompletion();

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -2420,17 +2420,14 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                 }
             }
 
-            // If all messages in [firstEntry...lastEntry] are filter out,
-            // then manual call internalReadEntriesComplete to advance read position.
+            // If all positions in [firstEntry...lastEntry] are filtered out, advance the read position
+            // without issuing a ledger read.
             if (firstValidEntry == -1L) {
                 final Position lastScannedPosition = PositionFactory.create(ledger.getId(), lastEntry);
-                // The whole scan window was skipped. When that is because the entries are already
-                // acknowledged, hop over the entire deleted range instead of advancing one window at a
-                // time. getNextAvailablePosition() falls back to the next position when the window was
-                // skipped for any other reason, for example a delayed-delivery skip condition.
-                final Position nextReadPosition = opReadEntry.cursor != null
-                        ? opReadEntry.cursor.getNextAvailablePosition(lastScannedPosition)
-                        : lastScannedPosition.getNext();
+                // If the last scanned position belongs to an individually deleted range, hop past its
+                // upper bound. Otherwise, getNextAvailablePosition() advances by one position. A hop can
+                // cross maxPosition safely because every position crossed by the hop is individually deleted.
+                final Position nextReadPosition = opReadEntry.cursor.getNextAvailablePosition(lastScannedPosition);
                 opReadEntry.updateReadPosition(nextReadPosition);
                 opReadEntry.checkReadCompletion();
                 return;

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -2423,7 +2423,14 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             // If all messages in [firstEntry...lastEntry] are filter out,
             // then manual call internalReadEntriesComplete to advance read position.
             if (firstValidEntry == -1L) {
-                final var nextReadPosition = PositionFactory.create(ledger.getId(), lastEntry).getNext();
+                final Position lastScannedPosition = PositionFactory.create(ledger.getId(), lastEntry);
+                // The whole scan window was skipped. When that is because the entries are already
+                // acknowledged, hop over the entire deleted range instead of advancing one window at a
+                // time. getNextAvailablePosition() falls back to the next position when the window was
+                // skipped for any other reason, for example a delayed-delivery skip condition.
+                final Position nextReadPosition = opReadEntry.cursor != null
+                        ? opReadEntry.cursor.getNextAvailablePosition(lastScannedPosition)
+                        : lastScannedPosition.getNext();
                 opReadEntry.updateReadPosition(nextReadPosition);
                 opReadEntry.checkReadCompletion();
                 return;

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorSkipDeletedEntriesTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorSkipDeletedEntriesTest.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.mledger.impl;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
+import lombok.Cleanup;
+import org.apache.bookkeeper.mledger.AsyncCallbacks.ReadEntriesCallback;
+import org.apache.bookkeeper.mledger.Entry;
+import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
+import org.apache.bookkeeper.mledger.ManagedLedgerException;
+import org.apache.bookkeeper.mledger.Position;
+import org.apache.bookkeeper.mledger.PositionFactory;
+import org.apache.bookkeeper.test.MockedBookKeeperTestCase;
+import org.testng.annotations.Test;
+
+/**
+ * Regression test for reading over a cursor that has a very large contiguous range of individually
+ * deleted (acknowledged) entries while its mark-delete position is pinned by an older unacknowledged entry.
+ *
+ * <p>This is the shape a Key_Shared subscription ends up in when a single unacknowledged message blocks the
+ * mark-delete position while consumers keep acknowledging everything after it. Reads then have to get
+ * past tens of millions of already-acknowledged entries before they can fill a batch.
+ *
+ * <p>The skip pre-filter in {@link ManagedLedgerImpl#internalReadFromLedger} used to advance the read
+ * position by the size of the scan window when every entry in that window was already acknowledged, instead of
+ * hopping over the whole deleted range via
+ * {@link ManagedCursorImpl#getNextAvailablePosition(Position)}. That turned a single range hop into
+ * O(entries / batchSize) read-loop iterations. Each iteration re-ran
+ * {@code isLedgerFullyAcked} -> {@code ManagedCursorImpl#getNumberOfEntries} ->
+ * {@code RangeSetWrapper#cardinality}, which clones the cursor's per-ledger Roaring bitmap.
+ */
+public class ManagedCursorSkipDeletedEntriesTest extends MockedBookKeeperTestCase {
+
+    private static final int TOTAL_ENTRIES = 20_000;
+    private static final int READ_BATCH_SIZE = 100;
+    /** Entries {@code [1, LAST_DELETED_INDEX]} are individually deleted, forming one contiguous range. */
+    private static final int LAST_DELETED_INDEX = TOTAL_ENTRIES - 4;
+
+    /**
+     * A read that has to get past one large contiguous deleted range must hop over it rather than walk
+     * it one batch at a time.
+     */
+    @Test(timeOut = 300_000)
+    public void testReadHopsOverLargeDeletedRangeInsteadOfWalkingIt() throws Exception {
+        ManagedLedgerConfig config = new ManagedLedgerConfig()
+                // Keep every entry below in a single ledger, then force a rollover so that the reads
+                // under test target a closed ledger. That makes every read-loop iteration go through
+                // the isLedgerFullyAcked check, as it does in production.
+                .setMaxEntriesPerLedger(TOTAL_ENTRIES)
+                .setRetentionTime(1, TimeUnit.HOURS)
+                .setRetentionSizeInMB(-1);
+
+        @Cleanup
+        ManagedLedgerImpl ledger = (ManagedLedgerImpl) factory.open("skip-deleted-entries", config);
+        ManagedCursorImpl cursor = (ManagedCursorImpl) ledger.openCursor("sub");
+
+        List<Position> positions = new ArrayList<>(TOTAL_ENTRIES);
+        for (int i = 0; i < TOTAL_ENTRIES; i++) {
+            positions.add(ledger.addEntry(new byte[]{1}));
+        }
+        // Roll the ledger holding the entries above, so it is closed by the time it is read.
+        Position afterRollover = ledger.addEntry(new byte[]{1});
+        assertTrue(ledger.getLedgersInfoAsList().size() >= 2,
+                "expected the entries under test to live in a closed ledger, ledgers="
+                        + ledger.getLedgersInfoAsList().size());
+
+        // Individually acknowledge [1, LAST_DELETED_INDEX]. Entry 0 stays unacknowledged and pins the
+        // mark-delete position, so none of these acknowledgments can be collapsed into it.
+        cursor.delete(positions.subList(1, LAST_DELETED_INDEX + 1));
+
+        assertEquals(cursor.getMarkDeletedPosition(), PositionFactory.create(positions.get(0).getLedgerId(), -1),
+                "mark-delete position must stay pinned behind the unacknowledged entry 0");
+        assertEquals(cursor.getTotalNonContiguousDeletedMessagesRange(), 1,
+                "the acknowledgments must collapse into a single contiguous range");
+
+        // The deliverable entries are entry 0, the tail holes, and the entry that caused the rollover.
+        List<Position> expected = new ArrayList<>();
+        expected.add(positions.get(0));
+        for (int i = LAST_DELETED_INDEX + 1; i < TOTAL_ENTRIES; i++) {
+            expected.add(positions.get(i));
+        }
+        expected.add(afterRollover);
+
+        // Count every position the skip pre-filter examines. Predicate#or evaluates this one first, so
+        // it sees exactly the positions ManagedLedgerImpl walks before deciding what to read.
+        AtomicInteger examinedPositions = new AtomicInteger();
+        Predicate<Position> countingCondition = position -> {
+            examinedPositions.incrementAndGet();
+            return false;
+        };
+
+        CompletableFuture<List<Entry>> readFuture = new CompletableFuture<>();
+        cursor.asyncReadEntriesWithSkip(READ_BATCH_SIZE, -1L, new ReadEntriesCallback() {
+            @Override
+            public void readEntriesComplete(List<Entry> entries, Object ctx) {
+                readFuture.complete(entries);
+            }
+
+            @Override
+            public void readEntriesFailed(ManagedLedgerException exception, Object ctx) {
+                readFuture.completeExceptionally(exception);
+            }
+        }, null, PositionFactory.LATEST, countingCondition);
+
+        List<Entry> read = readFuture.get(120, TimeUnit.SECONDS);
+        List<Position> readPositions = new ArrayList<>();
+        for (Entry entry : read) {
+            readPositions.add(entry.getPosition());
+            entry.release();
+        }
+        assertEquals(readPositions, expected, "the read must return exactly the unacknowledged entries");
+
+        // Hopping the range examines one scan window before jumping it and a small number of windows for
+        // the entries actually returned. Walking it examines every position in the deleted block.
+        assertTrue(examinedPositions.get() <= 4 * READ_BATCH_SIZE,
+                "read examined " + examinedPositions.get() + " positions to return " + read.size()
+                        + " entries over a deleted range of " + LAST_DELETED_INDEX + " entries");
+    }
+}


### PR DESCRIPTION
### Motivation

When an older unacknowledged entry pins a cursor's mark-delete position, acknowledgments for later entries can form a very large contiguous individually deleted range. This is common for Key_Shared subscriptions when consumers continue acknowledging messages after the blocking entry.

`ManagedLedgerImpl.internalReadFromLedger` pre-filters a scan window before reading it. When every position in the window is skipped, it currently advances only to the position after that window. Reading past a large individually deleted range therefore takes O(entries / batchSize) read-loop iterations instead of one range lookup.

For closed ledgers, each iteration also repeats the fully-acknowledged ledger check. That check calls `getNumberOfEntries` and `RangeSetWrapper.cardinality`, which clones the cursor's per-ledger Roaring bitmap. Repeating it while walking a large acknowledged range can stall delivery and consume significant broker CPU.

### Modifications

- When a complete scan window is skipped, use `ManagedCursorImpl.getNextAvailablePosition` to hop to the end of the containing individually deleted range.
- Preserve the existing next-position behavior when no cursor is associated with the read or when the window was skipped for a reason other than individual acknowledgment.
- Add a regression test with a closed ledger, a pinned mark-delete position, and a 19,996-entry contiguous individually deleted range. The test verifies both the returned entries and that the reader examines only a bounded number of positions.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- `./gradlew :managed-ledger:test --tests org.apache.bookkeeper.mledger.impl.ManagedCursorSkipDeletedEntriesTest --no-daemon`
- `./gradlew :managed-ledger:test --tests 'org.apache.bookkeeper.mledger.impl.ManagedCursorTest.testReadEntriesWithSkipDeletedEntriesAndWithSkipConditions' --no-daemon`
- `./gradlew quickCheck --no-daemon`

The regression test examines 20,002 positions and fails on the unpatched implementation. With this change, the test passes by hopping over the deleted range.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
