### PR TITLE
[fix][sec][branch-4.2] Upgrade Netty to 4.1.137 to address several CVEs and bugs

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -294,33 +294,33 @@ The Apache Software License, Version 2.0
     - org.apache.commons-commons-lang3-3.19.0.jar
     - org.apache.commons-commons-text-1.15.0.jar
  * Netty
-    - io.netty-netty-buffer-4.1.136.Final.jar
-    - io.netty-netty-codec-4.1.136.Final.jar
-    - io.netty-netty-codec-dns-4.1.136.Final.jar
-    - io.netty-netty-codec-http-4.1.136.Final.jar
-    - io.netty-netty-codec-http2-4.1.136.Final.jar
-    - io.netty-netty-codec-socks-4.1.136.Final.jar
-    - io.netty-netty-codec-haproxy-4.1.136.Final.jar
-    - io.netty-netty-common-4.1.136.Final.jar
-    - io.netty-netty-handler-4.1.136.Final.jar
-    - io.netty-netty-handler-proxy-4.1.136.Final.jar
-    - io.netty-netty-resolver-4.1.136.Final.jar
-    - io.netty-netty-resolver-dns-4.1.136.Final.jar
-    - io.netty-netty-resolver-dns-classes-macos-4.1.136.Final.jar
-    - io.netty-netty-resolver-dns-native-macos-4.1.136.Final-osx-aarch_64.jar
-    - io.netty-netty-resolver-dns-native-macos-4.1.136.Final-osx-x86_64.jar
-    - io.netty-netty-transport-4.1.136.Final.jar
-    - io.netty-netty-transport-classes-epoll-4.1.136.Final.jar
-    - io.netty-netty-transport-native-epoll-4.1.136.Final-linux-aarch_64.jar
-    - io.netty-netty-transport-native-epoll-4.1.136.Final-linux-x86_64.jar
-    - io.netty-netty-transport-native-unix-common-4.1.136.Final.jar
-    - io.netty-netty-tcnative-boringssl-static-2.0.78.Final.jar
-    - io.netty-netty-tcnative-boringssl-static-2.0.78.Final-linux-aarch_64.jar
-    - io.netty-netty-tcnative-boringssl-static-2.0.78.Final-linux-x86_64.jar
-    - io.netty-netty-tcnative-boringssl-static-2.0.78.Final-osx-aarch_64.jar
-    - io.netty-netty-tcnative-boringssl-static-2.0.78.Final-osx-x86_64.jar
-    - io.netty-netty-tcnative-boringssl-static-2.0.78.Final-windows-x86_64.jar
-    - io.netty-netty-tcnative-classes-2.0.78.Final.jar
+    - io.netty-netty-buffer-4.1.137.Final.jar
+    - io.netty-netty-codec-4.1.137.Final.jar
+    - io.netty-netty-codec-dns-4.1.137.Final.jar
+    - io.netty-netty-codec-http-4.1.137.Final.jar
+    - io.netty-netty-codec-http2-4.1.137.Final.jar
+    - io.netty-netty-codec-socks-4.1.137.Final.jar
+    - io.netty-netty-codec-haproxy-4.1.137.Final.jar
+    - io.netty-netty-common-4.1.137.Final.jar
+    - io.netty-netty-handler-4.1.137.Final.jar
+    - io.netty-netty-handler-proxy-4.1.137.Final.jar
+    - io.netty-netty-resolver-4.1.137.Final.jar
+    - io.netty-netty-resolver-dns-4.1.137.Final.jar
+    - io.netty-netty-resolver-dns-classes-macos-4.1.137.Final.jar
+    - io.netty-netty-resolver-dns-native-macos-4.1.137.Final-osx-aarch_64.jar
+    - io.netty-netty-resolver-dns-native-macos-4.1.137.Final-osx-x86_64.jar
+    - io.netty-netty-transport-4.1.137.Final.jar
+    - io.netty-netty-transport-classes-epoll-4.1.137.Final.jar
+    - io.netty-netty-transport-native-epoll-4.1.137.Final-linux-aarch_64.jar
+    - io.netty-netty-transport-native-epoll-4.1.137.Final-linux-x86_64.jar
+    - io.netty-netty-transport-native-unix-common-4.1.137.Final.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.81.Final.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.81.Final-linux-aarch_64.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.81.Final-linux-x86_64.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.81.Final-osx-aarch_64.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.81.Final-osx-x86_64.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.81.Final-windows-x86_64.jar
+    - io.netty-netty-tcnative-classes-2.0.81.Final.jar
     - io.netty.incubator-netty-incubator-transport-classes-io_uring-0.0.26.Final.jar
     - io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.26.Final-linux-x86_64.jar
     - io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.26.Final-linux-aarch_64.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -345,35 +345,35 @@ The Apache Software License, Version 2.0
     - commons-text-1.15.0.jar
     - commons-compress-1.28.0.jar
  * Netty
-    - netty-buffer-4.1.136.Final.jar
-    - netty-codec-4.1.136.Final.jar
-    - netty-codec-dns-4.1.136.Final.jar
-    - netty-codec-http-4.1.136.Final.jar
-    - netty-codec-socks-4.1.136.Final.jar
-    - netty-codec-haproxy-4.1.136.Final.jar
-    - netty-common-4.1.136.Final.jar
-    - netty-handler-4.1.136.Final.jar
-    - netty-handler-proxy-4.1.136.Final.jar
-    - netty-resolver-4.1.136.Final.jar
-    - netty-resolver-dns-4.1.136.Final.jar
-    - netty-transport-4.1.136.Final.jar
-    - netty-transport-classes-epoll-4.1.136.Final.jar
-    - netty-transport-native-epoll-4.1.136.Final-linux-aarch_64.jar
-    - netty-transport-native-epoll-4.1.136.Final-linux-x86_64.jar
-    - netty-transport-native-unix-common-4.1.136.Final.jar
-    - netty-tcnative-boringssl-static-2.0.78.Final.jar
-    - netty-tcnative-boringssl-static-2.0.78.Final-linux-aarch_64.jar
-    - netty-tcnative-boringssl-static-2.0.78.Final-linux-x86_64.jar
-    - netty-tcnative-boringssl-static-2.0.78.Final-osx-aarch_64.jar
-    - netty-tcnative-boringssl-static-2.0.78.Final-osx-x86_64.jar
-    - netty-tcnative-boringssl-static-2.0.78.Final-windows-x86_64.jar
-    - netty-tcnative-classes-2.0.78.Final.jar
+    - netty-buffer-4.1.137.Final.jar
+    - netty-codec-4.1.137.Final.jar
+    - netty-codec-dns-4.1.137.Final.jar
+    - netty-codec-http-4.1.137.Final.jar
+    - netty-codec-socks-4.1.137.Final.jar
+    - netty-codec-haproxy-4.1.137.Final.jar
+    - netty-common-4.1.137.Final.jar
+    - netty-handler-4.1.137.Final.jar
+    - netty-handler-proxy-4.1.137.Final.jar
+    - netty-resolver-4.1.137.Final.jar
+    - netty-resolver-dns-4.1.137.Final.jar
+    - netty-transport-4.1.137.Final.jar
+    - netty-transport-classes-epoll-4.1.137.Final.jar
+    - netty-transport-native-epoll-4.1.137.Final-linux-aarch_64.jar
+    - netty-transport-native-epoll-4.1.137.Final-linux-x86_64.jar
+    - netty-transport-native-unix-common-4.1.137.Final.jar
+    - netty-tcnative-boringssl-static-2.0.81.Final.jar
+    - netty-tcnative-boringssl-static-2.0.81.Final-linux-aarch_64.jar
+    - netty-tcnative-boringssl-static-2.0.81.Final-linux-x86_64.jar
+    - netty-tcnative-boringssl-static-2.0.81.Final-osx-aarch_64.jar
+    - netty-tcnative-boringssl-static-2.0.81.Final-osx-x86_64.jar
+    - netty-tcnative-boringssl-static-2.0.81.Final-windows-x86_64.jar
+    - netty-tcnative-classes-2.0.81.Final.jar
     - netty-incubator-transport-classes-io_uring-0.0.26.Final.jar
     - netty-incubator-transport-native-io_uring-0.0.26.Final-linux-aarch_64.jar
     - netty-incubator-transport-native-io_uring-0.0.26.Final-linux-x86_64.jar
-    - netty-resolver-dns-classes-macos-4.1.136.Final.jar
-    - netty-resolver-dns-native-macos-4.1.136.Final-osx-aarch_64.jar
-    - netty-resolver-dns-native-macos-4.1.136.Final-osx-x86_64.jar
+    - netty-resolver-dns-classes-macos-4.1.137.Final.jar
+    - netty-resolver-dns-native-macos-4.1.137.Final-osx-aarch_64.jar
+    - netty-resolver-dns-native-macos-4.1.137.Final-osx-x86_64.jar
  * Prometheus client
     - simpleclient-0.16.0.jar
     - simpleclient_log4j2-0.16.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -189,7 +189,7 @@ flexible messaging model and an intuitive client API.</description>
     <snappy.version>1.1.10.8</snappy.version> <!-- ZooKeeper server -->
     <dropwizardmetrics.version>4.1.12.1</dropwizardmetrics.version> <!-- ZooKeeper server -->
     <curator.version>5.7.1</curator.version>
-    <netty.version>4.1.136.Final</netty.version>
+    <netty.version>4.1.137.Final</netty.version>
     <netty-iouring.version>0.0.26.Final</netty-iouring.version>
     <jetty.version>12.1.11</jetty.version>
     <!-- Jetty 9 is used in tiered-storage/file-system tests and pulsar-io/alluxio -->


### PR DESCRIPTION
### Motivation

[Netty 4.1.137.Final](https://netty.io/news/2026/08/06/4-1-137-Final.html) is a bug-fix and security
release, and upstream "strongly recommends" upgrading. It is the 4.1 counterpart of 4.2.17.Final,
which is being upgraded on master in #26300.

**Security fixes.** It resolves the same seven advisories as 4.2.17.Final — every one of them lists
`<= 4.1.136.Final` as a vulnerable range, so branch-4.2 is affected by all of them. Five still have
their CVE id pending assignment upstream, so the release notes show `CVE-2026-XXXXX`:

| Advisory | Severity | Netty artifact | Summary |
| --- | --- | --- | --- |
| [GHSA-p85m-gvr3-788c](https://github.com/netty/netty/security/advisories/GHSA-p85m-gvr3-788c) | High | `netty-handler` | Hostname verification disabled on the OpenSSL client path when trust-manager wrapping is unavailable (Java 25+) |
| [GHSA-c4c3-7fpv-j4q5](https://github.com/netty/netty/security/advisories/GHSA-c4c3-7fpv-j4q5) | High | `netty-handler` | SNI routing bypass via fragmented TLS ClientHello causing fallback to the default `SslContext` |
| [GHSA-fccg-mwvh-qqg4](https://github.com/netty/netty/security/advisories/GHSA-fccg-mwvh-qqg4) | Medium | `netty-handler` | Fragmented ClientHello records trigger quadratic pre-handshake reassembly in default SNI parsing |
| [GHSA-cc6x-ffm5-83wf](https://github.com/netty/netty/security/advisories/GHSA-cc6x-ffm5-83wf) | Medium | `netty-codec-socks` | SOCKS4/5 proxy encoder NUL byte and credential injection |
| [CVE-2026-59903](https://github.com/netty/netty/security/advisories/GHSA-8c42-7qj2-3j46) | Medium | `netty-codec-http` | Cache poisoning and information disclosure via CORS `Vary` header overwrite |
| [CVE-2026-59902](https://github.com/netty/netty/security/advisories/GHSA-2qj4-mmr9-4v2f) | High | `netty-transport-sctp` | Memory exhaustion in `SctpMessageCompletionHandler` |
| [GHSA-43fm-7cxg-hf3j](https://github.com/netty/netty/security/advisories/GHSA-43fm-7cxg-hf3j) | Low | `netty-codec-mqtt` | MQTT topic name and client id validation bypass |

`netty-transport-sctp` and `netty-codec-mqtt` are not bundled in Pulsar's distributions (they don't
appear in either `LICENSE.bin.txt`), so the last two are listed only for completeness.
`netty-handler`, `netty-codec-socks` and `netty-codec-http` are all shipped.

GHSA-p85m-gvr3-788c is the one worth calling out, with a branch-4.2 caveat. Netty's earlier
CVE-2026-50010 fix added hostname verification to a plain `X509TrustManager` by wrapping it, and on
the `SslProvider.OPENSSL` path that wrapping is `Unsafe`-based reflection. `Unsafe` is not available
by default on Java 25+, so the wrapper degrades to a no-op and an OpenSSL **client** configured with
a plain (non-extended) `X509TrustManager` ends up doing no hostname verification.

The OpenSSL half of that precondition is met by default on branch-4.2: `tlsProvider` is unset in
`conf/broker.conf`, `DefaultPulsarSslFactory` then passes `null` to `SslContextBuilder`, and Netty
falls back to `SslContext.defaultClientProvider()`, which is `OPENSSL` whenever the native engine is
available — and it is, since Pulsar bundles `netty-tcnative-boringssl-static`. The Java 25+ half is
*not* met by default here: branch-4.2 builds and ships on JDK 21 (`IMAGE_JDK_MAJOR_VERSION=21`, and
the CI default is 21), unlike master which has moved to JDK 25 (#26070). So this only reaches
deployments that both run a 4.2 broker/client on a Java 25+ runtime and supply a plain rather than
extended trust manager via a custom `PulsarTlsFactory`. Lower exposure than on master, but the
upgrade removes the question either way.

**Non-security fixes.** 4.1.137.Final also carries several fixes in areas Pulsar leans on heavily:

- Fix buddy cache evicting chunks with live buffers ([#17176](https://github.com/netty/netty/pull/17176))
- Adaptive allocator backports ([#17206](https://github.com/netty/netty/pull/17206))
- Reject negative `maxOrder` in `PooledByteBufAllocator` ([#17095](https://github.com/netty/netty/pull/17095))
- Fix `AdaptiveByteBuf._setLongLE` calling checked `setLongLE` ([#17102](https://github.com/netty/netty/pull/17102))
- `SslHandler`: fix possible buffer leak when an OOME is thrown during allocation ([#17078](https://github.com/netty/netty/pull/17078))
- Weakly reference engines from the OpenSSL engine map ([#17205](https://github.com/netty/netty/pull/17205))
- Avoid classloader leak via `GlobalEventExecutor` terminationFuture failure ([#17189](https://github.com/netty/netty/pull/17189))
- `HttpObjectEncoder` / `DefaultHttp2FrameWriter`: fix buffer leak when a `Throwable` is thrown during header encoding ([#17178](https://github.com/netty/netty/pull/17178))
- `HttpServerCodec`: do not consume the method queue for 1xx interim responses ([#17203](https://github.com/netty/netty/pull/17203))
- Do not write the WebSocket handshake response to the tail of the pipeline ([#17200](https://github.com/netty/netty/pull/17200))
- `AsciiString.cached(String)` sanitization and the follow-up performance regression fix ([#17075](https://github.com/netty/netty/pull/17075), [#17080](https://github.com/netty/netty/pull/17080), [#17083](https://github.com/netty/netty/pull/17083))
- Compression decoder hardening: guard the Snappy decoder against invalid chunk lengths ([#17110](https://github.com/netty/netty/pull/17110)), use the safe decompressor in `Lz4FrameDecoder` ([#17121](https://github.com/netty/netty/pull/17121)), fix `maxAllocation` for brotli-encoded content in `HttpContentDecompressor` ([#17124](https://github.com/netty/netty/pull/17124)) and prevent duplicate `BrotliEncoder` close scheduling ([#17193](https://github.com/netty/netty/pull/17193))

**netty-tcnative.** Bumped 2.0.78.Final → 2.0.81.Final. Pulsar's `pom.xml` does not pin tcnative
separately — it is managed by the imported `netty-bom`, which declares
`<tcnative.version>2.0.81.Final</tcnative.version>` in 4.1.137.Final (it was 2.0.78.Final in
4.1.136.Final), so the bump comes along with the `netty.version` change.
[The changes across those three tcnative releases](https://github.com/netty/netty-tcnative/compare/netty-tcnative-parent-2.0.78.Final...netty-tcnative-parent-2.0.81.Final)
are:

- Clear the certificate chain in `setKeyMaterial` ([netty-tcnative#987](https://github.com/netty/netty-tcnative/pull/987))
- Drop checks on `SSL_CREDENTIAL` support for older BoringSSL ([netty-tcnative#980](https://github.com/netty/netty-tcnative/pull/980))
- Add `SSL.getGroupName(...)`, returning the named group used by the most recently completed handshake ([netty-tcnative#991](https://github.com/netty/netty-tcnative/pull/991)) — the Netty-side `OpenSslSession` accessor built on it ([netty#17058](https://github.com/netty/netty/pull/17058)) landed on the 4.2 branch only, so on 4.1.137 this is just the tcnative bump ([netty#17122](https://github.com/netty/netty/pull/17122))
- Link the linux `aarch_64` and `x86_64` `openssl-dynamic` artifacts against OpenSSL 3.x ([netty-tcnative#986](https://github.com/netty/netty-tcnative/pull/986), [netty-tcnative#989](https://github.com/netty/netty-tcnative/pull/989)) — not applicable to Pulsar, which bundles `netty-tcnative-boringssl-static`

### Modifications

- `pom.xml`: `netty.version` 4.1.136.Final → 4.1.137.Final. netty-tcnative moves 2.0.78.Final →
  2.0.81.Final transitively via the `netty-bom` import; there is no separate version property to
  update on this branch.
- Update the bundled jar lists in `distribution/server/src/assemble/LICENSE.bin.txt` and
  `distribution/shell/src/assemble/LICENSE.bin.txt` to the new versions

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests. In addition to CI, `src/check-binary-license.sh`
was run locally against both `distribution/server/target/apache-pulsar-4.2.5-SNAPSHOT-bin.tar.gz`
and `distribution/shell/target/apache-pulsar-shell-4.2.5-SNAPSHOT-bin.tar.gz` (both exit 0) to
confirm the `LICENSE.bin.txt` entries match the jars that are actually bundled.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [x] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

Netty is upgraded from 4.1.136.Final to 4.1.137.Final and netty-tcnative from 2.0.78.Final to
2.0.81.Final.
