### PR TITLE
fix: run alignAcknowledgeStatus for every flushed entry, not just the last one

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -2462,10 +2462,20 @@ public class ManagedCursorImpl implements ManagedCursor {
                         mdEntry.newPosition, null);
 
                 // Remove from the individual deleted messages all the entries before the new mark delete
-                // point.
+                // point. When several mark-delete requests where flushed together (callbackGroup), apply
+                // the in-memory state mutation of EVERY request in the group, not just the last one.
+                // Otherwise a cursor reset that was queued before a later ack would have its
+                // alignAcknowledgeStatusAfterPersisted silently dropped while the reset still reports
+                // success, leaving the cursor un-moved (see issue #26304).
                 lock.writeLock().lock();
                 try {
-                    mdEntry.alignAcknowledgeStatus();
+                    if (mdEntry.callbackGroup != null) {
+                        for (MarkDeleteEntry e : mdEntry.callbackGroup) {
+                            e.alignAcknowledgeStatus();
+                        }
+                    } else {
+                        mdEntry.alignAcknowledgeStatus();
+                    }
                 } finally {
                     lock.writeLock().unlock();
                 }


### PR DESCRIPTION
### Motivation

When a durable cursor reset and a mark-delete (individual ack) are enqueued together in `pendingMarkDeleteOps` while `PENDING_READ_OPS > 0`, `internalFlushPendingMarkDeletes` picks only the **last** entry and persists it. On persist completion, only the last entry's `alignAcknowledgeStatus()` runs — so the earlier entry's state mutation is silently dropped, even though `triggerComplete()` fans out the callbacks, making the reset report success while the cursor never moved.

### Root Cause

Since #25047, the cursor reset's state mutation lives in a per-`MarkDeleteEntry` runnable (`alignAcknowledgeStatusAfterPersisted`), not in the reset's completion callback. When two entries are flushed together:

1. Reset entry **R** is queued first (PENDING_READ_OPS > 0)
2. Ack entry **A** is queued behind it
3. `internalFlushPendingMarkDeletes` calls `pendingMarkDeleteOps.getLast()` -> **A**
4. On persist, only **A**'s `alignAcknowledgeStatus()` runs
5. **R**'s reset runnable is dropped, but `triggerComplete()` still fires the reset callback -> success is reported

### Fix

In the persist completion callback, when `mdEntry.callbackGroup` is set (meaning multiple entries were flushed together), iterate the group and call `alignAcknowledgeStatus()` on every entry, not just the last one. This ensures that each request's in-memory state mutation is applied, while the persist position still comes from the last entry.

### Testing

The existing test suite covers the basic reset and mark-delete paths. A targeted test for the displacement scenario (reset + ack queued, ack flushed last) is tracked in the issue's reproduction sketch.

### Issue

Closes #26304
