### PR TITLE
[fix][test] Fix flaky TestReplicationWorker.testRepairedNotAdheringPlacementPolicyLedgerFragmentsOnRack

### DIFF
--- a/pulsar-metadata/src/test/java/org/apache/bookkeeper/replication/AuditorPlacementPolicyCheckTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/bookkeeper/replication/AuditorPlacementPolicyCheckTest.java
@@ -59,6 +59,7 @@ import org.apache.bookkeeper.test.TestStatsProvider.TestStatsLogger;
 import org.apache.bookkeeper.util.StaticDNSResolver;
 import org.apache.commons.lang3.mutable.MutableObject;
 import org.apache.zookeeper.KeeperException;
+import org.awaitility.Awaitility;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -436,6 +437,16 @@ public class AuditorPlacementPolicyCheckTest extends BookKeeperClusterTestCase {
                     .getGauge(ReplicationStats.NUM_LEDGERS_SOFTLY_ADHERING_TO_PLACEMENT_POLICY);
             assertEquals("NUM_LEDGERS_SOFTLY_ADHERING_TO_PLACEMENT_POLICY guage value",
                     0, ledgersSoftlyAdheringToPlacementPolicyGuage.getSample());
+            /*
+             * placementPolicyCheck marks the ledger underreplicated with a fire-and-forget async write which
+             * it doesn't await before recording its stats, so the mark isn't necessarily visible once the
+             * check reports success. pollLedgerToRereplicate() is a one-shot scan, so poll it until the mark
+             * shows up, and do so while the auditor is still up so that the wait doesn't race auditor
+             * shutdown and the periodic check can retry a write that failed.
+             */
+            LedgerUnderreplicationManager underreplicationManager = mFactory.newLedgerUnderreplicationManager();
+            Awaitility.await().untilAsserted(
+                    () -> assertEquals(1L, underreplicationManager.pollLedgerToRereplicate()));
         } finally {
             Auditor auditor = auditorRef.getValue();
             if (auditor != null) {
@@ -443,9 +454,6 @@ public class AuditorPlacementPolicyCheckTest extends BookKeeperClusterTestCase {
             }
             regManager.close();
         }
-        LedgerUnderreplicationManager underreplicationManager = mFactory.newLedgerUnderreplicationManager();
-        long unnderReplicateLedgerId = underreplicationManager.pollLedgerToRereplicate();
-        assertEquals(unnderReplicateLedgerId, 1L);
     }
 
     @Test

--- a/pulsar-metadata/src/test/java/org/apache/bookkeeper/replication/TestReplicationWorker.java
+++ b/pulsar-metadata/src/test/java/org/apache/bookkeeper/replication/TestReplicationWorker.java
@@ -1086,6 +1086,9 @@ public class TestReplicationWorker extends BookKeeperClusterTestCase {
         servConf.setAuditorPeriodicPlacementPolicyCheckInterval(1000);
         servConf.setRepairedPlacementPolicyNotAdheringBookieEnable(true);
 
+        ZooKeeper zk = getZk((PulsarMetadataClientDriver) bkc.getMetadataClientDriver());
+        String urLedgerPath = "/ledgers/underreplication/ledgers/0000/0000/0000/0000/urL0000000000";
+
         MutableObject<Auditor> auditorRef = new MutableObject<Auditor>();
         try {
             TestStatsLogger statsLogger = startAuditorAndWaitForPlacementPolicyCheck(servConf, auditorRef);
@@ -1097,6 +1100,13 @@ public class TestReplicationWorker extends BookKeeperClusterTestCase {
                     .getGauge(ReplicationStats.NUM_LEDGERS_SOFTLY_ADHERING_TO_PLACEMENT_POLICY);
             assertEquals("NUM_LEDGERS_SOFTLY_ADHERING_TO_PLACEMENT_POLICY guage value",
                     0, ledgersSoftlyAdheringToPlacementPolicyGuage.getSample());
+            /*
+             * placementPolicyCheck marks the ledger underreplicated with a fire-and-forget async write which
+             * it doesn't await before recording its stats, so the znode isn't necessarily there yet once the
+             * check reports success. Poll for it, and do so while the auditor is still up so that the wait
+             * doesn't race auditor shutdown and the periodic check can retry a write that failed.
+             */
+            Awaitility.await().untilAsserted(() -> assertNotNull(zk.exists(urLedgerPath, false)));
         } finally {
             Auditor auditor = auditorRef.getValue();
             if (auditor != null) {
@@ -1104,13 +1114,18 @@ public class TestReplicationWorker extends BookKeeperClusterTestCase {
             }
         }
 
-        ZooKeeper zk = getZk((PulsarMetadataClientDriver) bkc.getMetadataClientDriver());
-
-
-        Stat stat = zk.exists("/ledgers/underreplication/ledgers/0000/0000/0000/0000/urL0000000000", false);
-        assertNotNull(stat);
-
-        baseConf.setRepairedPlacementPolicyNotAdheringBookieEnable(true);
+        /*
+         * The worker's first replication attempt necessarily fails, since the only /rack2 bookie is started
+         * afterwards. That failure defers the ledger lock release by
+         * lockReleaseOfFailedLedgerGracePeriod / 2^5, i.e. 9375ms with the default grace period, and the run
+         * loop then backs off for rwRereplicateBackoffMs, i.e. another 5000ms. Both delays would be spent
+         * inside the awaits below, leaving them a few hundred milliseconds of their default 10s timeout, so
+         * shorten them here the way the other ReplicationWorker tests in this class do.
+         */
+        ServerConfiguration rwConf = new ServerConfiguration(baseConf);
+        rwConf.setRepairedPlacementPolicyNotAdheringBookieEnable(true);
+        rwConf.setLockReleaseOfFailedLedgerGracePeriod("64");
+        rwConf.setRwRereplicateBackoffMs(100);
         BookKeeper bookKeeper = new PulsarBookKeeperTestClient(baseClientConf) {
             @Override
             protected EnsemblePlacementPolicy initializeEnsemblePlacementPolicy(ClientConfiguration conf,
@@ -1133,7 +1148,7 @@ public class TestReplicationWorker extends BookKeeperClusterTestCase {
         };
         TestStatsProvider statsProvider = new TestStatsProvider();
         TestStatsLogger statsLogger = statsProvider.getStatsLogger(REPLICATION_SCOPE);
-        ReplicationWorker rw = new ReplicationWorker(baseConf, bookKeeper, false, statsLogger);
+        ReplicationWorker rw = new ReplicationWorker(rwConf, bookKeeper, false, statsLogger);
 
         if (checkReplicationStats != null) {
             checkReplicationStats.accept(true, rw);
@@ -1155,7 +1170,7 @@ public class TestReplicationWorker extends BookKeeperClusterTestCase {
         });
 
         Awaitility.await().untilAsserted(() -> {
-            Stat stat1 = zk.exists("/ledgers/underreplication/ledgers/0000/0000/0000/0000/urL0000000000", false);
+            Stat stat1 = zk.exists(urLedgerPath, false);
             assertNull(stat1);
         });
 
@@ -1168,7 +1183,6 @@ public class TestReplicationWorker extends BookKeeperClusterTestCase {
         if (checkReplicationStats == null) {
             rw.shutdown();
         }
-        baseConf.setRepairedPlacementPolicyNotAdheringBookieEnable(false);
         bookKeeper.close();
     }
 


### PR DESCRIPTION
Fixes #26307

### Motivation

`TestReplicationWorker.testRepairedNotAdheringPlacementPolicyLedgerFragmentsOnRack` failed both TestNG
attempts in [this `CI - Unit - Pulsar Metadata` run](https://github.com/apache/pulsar/actions/runs/31364318604/job/93381096376),
on `assertNotNull(stat)`. The shared helper `testRepairedNotAdheringPlacementPolicyLedgerFragments(...)`
that backs it (and `testReplicationStats`) has two independent timing problems.

**1. The underreplication mark is read before it is written.**

`AuditorPlacementPolicyCheckTask.doPlacementPolicyCheck()` fires
`ledgerUnderreplicationManager.markLedgerUnderreplicatedAsync(...)` and immediately calls
`iterCallback.processResult(OK, ...)` without awaiting it. So the `placementPolicyCheck` latch, the
`NUM_LEDGERS_NOT_ADHERING_TO_PLACEMENT_POLICY` gauge and the `PLACEMENT_POLICY_CHECK_TIME` success
count — the only signals the test waits on — are all recorded while the ZooKeeper write creating
`/ledgers/underreplication/ledgers/0000/0000/0000/0000/urL0000000000` may still be in flight. The test
then read that znode with a bare `zk.exists(...)`.

In the failing run the mark was issued at `07:16:30,762` and the assertion ran ~490ms later, on an
attempt where the one-ledger check alone reported `durationMs=409` amid ZK session churn. The test
report contains no delete of that znode and no "mark to under replication manager failed" error, so
the write had simply not landed yet.

`AuditorPlacementPolicyCheckTest.testPlacementPolicyCheckWithLedgersNotAdheringToPlacementPolicyAndMarkToUnderreplication`
has the identical defect — a one-shot `pollLedgerToRereplicate()` after `auditor.close()` — so it is
fixed here too rather than left as a known twin.

**2. The later awaits were running on a few hundred milliseconds of slack.**

In the `OnRack` variant the `ReplicationWorker` is started *before* the `/rack2` bookie exists, so its
first replication attempt necessarily fails and defers the ledger lock release by
`lockReleaseOfFailedLedgerGracePeriod / 2^5` = 9375ms (BookKeeper's default grace period is 300000),
after which the run loop backs off for another `rwRereplicateBackoffMs` = 5000ms. Those delays are
spent inside the `Awaitility.await()` calls that follow, which use the default 10s timeout. Every local
invocation took ~11.1s and logged `deferring the ledger lock release {delayMs=9375}`. A second failed
attempt would defer 18750ms, which the 10s await cannot survive at all.

The fire-and-forget write is upstream BookKeeper behaviour, present on apache/bookkeeper master as
well; this PR only fixes the tests.

### Modifications

- `TestReplicationWorker`: hoist the znode path and the `ZooKeeper` handle above the `try`, and wait for
  the underreplication mark with `Awaitility` *inside* it, while the auditor is still running — so the
  wait does not race auditor shutdown and the 1s periodic placement policy check can retry a failed
  write. The second use of the path literal now reuses the local.
- `TestReplicationWorker`: build the test's `ReplicationWorker` from a dedicated `ServerConfiguration`
  with `lockReleaseOfFailedLedgerGracePeriod=64` and `rwRereplicateBackoffMs=100`, the way the other
  `ReplicationWorker` tests in this class already do, so the awaits are not competing with ~14s of fixed
  delay. This also stops the helper mutating (and having to restore) the shared `baseConf`.
- `AuditorPlacementPolicyCheckTest`: move the `pollLedgerToRereplicate()` assertion into the `try` block
  and poll it with `Awaitility`, mirroring the fix above. The assertion's argument order is corrected to
  `AssertJUnit`'s `(expected, actual)`.

No assertion was weakened or removed: the same znode/ledger id, the same expectations.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as
`TestReplicationWorker.testRepairedNotAdheringPlacementPolicyLedgerFragmentsOnRack`,
`TestReplicationWorker.testReplicationStats` and
`AuditorPlacementPolicyCheckTest.testPlacementPolicyCheckWithLedgersNotAdheringToPlacementPolicyAndMarkToUnderreplication`.

Verified locally with a temporary `invocationCount` (removed before this PR): 10/10, 5/5 and 10/10
passes respectively. The deferred lock release drops from `delayMs=9375` to `delayMs=2`, and the
flaking test from ~11.1s to ~1.9s per invocation, so the awaits now have ~9.8s of headroom instead of
~0.5s. Both full test classes pass (`TestReplicationWorker` 14/14, `AuditorPlacementPolicyCheckTest`
8/8), and `./gradlew quickCheck` is clean.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

- [ ] `doc-required`
- [x] `doc-not-needed`
- [ ] `doc`
- [ ] `doc-complete`

Test-only change.
