### PR TITLE
[fix][broker] Wait for in-flight snapshot creation when trimming orphaned delayed-delivery buckets

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTracker.java
@@ -902,6 +902,17 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
 
     private CompletableFuture<Void> deleteBucketSnapshot(String ledgerName,
                                                           Range<Long> range, ImmutableBucket bucket) {
+        // The bucket id is only known once the snapshot creation completes, so wait for an in-flight
+        // creation before deleting. When the creation failed the bucket has already been removed and
+        // downgraded to memory mode, so there is no snapshot left to delete.
+        return bucket.getSnapshotCreateFuture().orElse(NULL_LONG_PROMISE)
+                .thenCompose(bucketId -> INVALID_BUCKET_ID.equals(bucketId)
+                        ? CompletableFuture.<Void>completedFuture(null)
+                        : doDeleteBucketSnapshot(ledgerName, range, bucket));
+    }
+
+    private CompletableFuture<Void> doDeleteBucketSnapshot(String ledgerName,
+                                                           Range<Long> range, ImmutableBucket bucket) {
         return bucket.asyncDeleteBucketSnapshot(stats)
                 .handle((__, t) -> {
                     if (t != null) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTrackerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTrackerTest.java
@@ -28,6 +28,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotSame;
 import static org.testng.Assert.assertTrue;
 import static org.testng.AssertJUnit.assertFalse;
+import com.google.common.collect.Range;
 import io.netty.util.Timeout;
 import io.netty.util.Timer;
 import io.netty.util.TimerTask;
@@ -37,6 +38,7 @@ import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.NavigableMap;
 import java.util.NavigableSet;
 import java.util.Set;
@@ -57,6 +59,8 @@ import org.apache.commons.lang3.mutable.MutableLong;
 import org.apache.pulsar.broker.delayed.AbstractDeliveryTrackerTest;
 import org.apache.pulsar.broker.delayed.MockBucketSnapshotStorage;
 import org.apache.pulsar.broker.delayed.MockManagedCursor;
+import org.apache.pulsar.broker.delayed.proto.SnapshotMetadata;
+import org.apache.pulsar.broker.delayed.proto.SnapshotSegment;
 import org.apache.pulsar.broker.service.persistent.AbstractPersistentDispatcherMultipleConsumers;
 import org.awaitility.Awaitility;
 import org.roaringbitmap.RoaringBitmap;
@@ -602,6 +606,23 @@ public class BucketDelayedDeliveryTrackerTest extends AbstractDeliveryTrackerTes
         }
     }
 
+    /**
+     * Keeps every snapshot creation in flight until {@link #createGate} completes, so that bucket ids
+     * are still unknown while the trim runs.
+     */
+    private static class BlockingCreateStorage extends MockBucketSnapshotStorage {
+        final CompletableFuture<Void> createGate = new CompletableFuture<>();
+
+        @Override
+        public CompletableFuture<Long> createBucketSnapshot(SnapshotMetadata snapshotMetadata,
+                                                            List<SnapshotSegment> bucketSnapshotSegments,
+                                                            String bucketKey, String topicName, String cursorName) {
+            CompletableFuture<Long> createFuture = super.createBucketSnapshot(snapshotMetadata,
+                    bucketSnapshotSegments, bucketKey, topicName, cursorName);
+            return createGate.thenCompose(__ -> createFuture);
+        }
+    }
+
     private ImmutableBucket createMergeableBucket(TrackerWithStorage trackerWithStorage, long startLedgerId,
                                                   long endLedgerId, List<Long> firstScheduleTimestamps) {
         ImmutableBucket bucket = new ImmutableBucket(trackerWithStorage.tracker.getCtx(), startLedgerId, endLedgerId);
@@ -704,17 +725,18 @@ public class BucketDelayedDeliveryTrackerTest extends AbstractDeliveryTrackerTes
         for (int i = 1; i <= messageCount; i++) {
             ts.tracker.addMessage(i, i, i * 10);
         }
-        Awaitility.await().untilAsserted(() ->
-                Assert.assertTrue(ts.tracker.getImmutableBuckets().asMapOfRanges().values().stream()
-                        .noneMatch(x -> x.merging)));
-
-        int bucketCount = ts.tracker.getImmutableBuckets().asMapOfRanges().size();
-        assertTrue(bucketCount <= 5,
-                "Bucket count " + bucketCount + " should be <= maxNumBuckets=5 after trim+merge");
-
-        ts.tracker.getImmutableBuckets().asMapOfRanges().forEach((range, bucket) ->
-                assertTrue(range.lowerEndpoint() >= firstLedgerId,
-                        "Remaining bucket range " + range + " should be >= " + firstLedgerId));
+        // Trim and merge run asynchronously once the bucket exceeding maxNumBuckets is sealed.
+        Awaitility.await().untilAsserted(() -> {
+            synchronized (ts.tracker) {
+                Map<Range<Long>, ImmutableBucket> buckets = ts.tracker.getImmutableBuckets().asMapOfRanges();
+                Assert.assertTrue(buckets.values().stream().noneMatch(x -> x.merging));
+                assertTrue(buckets.size() <= 5,
+                        "Bucket count " + buckets.size() + " should be <= maxNumBuckets=5 after trim+merge");
+                buckets.forEach((range, bucket) ->
+                        assertTrue(range.lowerEndpoint() >= firstLedgerId,
+                                "Remaining bucket range " + range + " should be >= " + firstLedgerId));
+            }
+        });
 
         long messagesAfterTrim = ts.tracker.getNumberOfDelayedMessages();
         ts.clockTime.set(messageCount * 10);
@@ -724,6 +746,37 @@ public class BucketDelayedDeliveryTrackerTest extends AbstractDeliveryTrackerTes
         assertEquals(ts.tracker.getNumberOfDelayedMessages(), messagesAfterTrim - scheduledMessages.size());
 
         ts.close();
+    }
+
+    @Test
+    public void testTrimWaitsForInFlightSnapshotCreation() throws Exception {
+        long firstLedgerId = 31L;
+        BlockingCreateStorage storage = new BlockingCreateStorage();
+        TrackerWithStorage ts = createTrackerWithMockLedger(firstLedgerId, 5, storage);
+        try {
+            // Sealing the sixth bucket exceeds maxNumBuckets and triggers the trim while the snapshot
+            // creations are still in flight, so no bucket id is known yet.
+            for (int i = 1; i <= 31; i++) {
+                ts.tracker.addMessage(i, i, i * 10);
+            }
+            synchronized (ts.tracker) {
+                assertEquals(ts.tracker.getImmutableBuckets().asMapOfRanges().size(), 6,
+                        "No orphaned bucket can be deleted before its snapshot creation completes");
+            }
+
+            storage.createGate.complete(null);
+
+            // All six buckets precede the first active ledger, so the trim must delete every one of them.
+            Awaitility.await().untilAsserted(() -> {
+                synchronized (ts.tracker) {
+                    Map<Range<Long>, ImmutableBucket> buckets = ts.tracker.getImmutableBuckets().asMapOfRanges();
+                    assertTrue(buckets.isEmpty(),
+                            "Orphaned buckets " + buckets.keySet() + " should have been trimmed");
+                }
+            });
+        } finally {
+            ts.close();
+        }
     }
 
     @Test


### PR DESCRIPTION
### Motivation

`BucketDelayedDeliveryTracker` trims orphaned bucket snapshots — buckets whose ledger range lies entirely before the cursor's mark-delete ledger — whenever sealing a new bucket pushes the bucket count past `delayedDeliveryMaxNumBuckets`. The trim deletes those snapshots without waiting for their snapshot creation to finish.

A bucket id is only assigned once its snapshot creation completes. Until then, `ImmutableBucket.getAndUpdateBucketId()` falls back to a cursor property that has not been written yet:

```java
String bucketIdStr = ctx.cursor().getCursorProperties().get(bucketKey());
long bucketId = Long.parseLong(bucketIdStr);   // bucketIdStr == null
```

So deleting a bucket whose creation is still in flight throws `NumberFormatException` **synchronously**, from inside the sequential `CompletableFuture` chain that `asyncTrimImmutableBuckets()` builds. That chain deliberately stops at the first failure, so the remaining orphaned buckets are neither deleted from the snapshot storage nor removed from `immutableBuckets`: their snapshots leak, and the buckets stay in the range map until some later trim happens to succeed.

Every other snapshot-delete path already handles this — `ImmutableBucket.clear()` awaits the create future, `asyncMergeBucketSnapshot()` awaits the create futures of all merged buckets, and the segment-load path skips a bucket while `getSnapshotCreateFuture()` is not done. The trim path introduced in #25984 was the only one missing it.

This surfaced as a flaky `BucketDelayedDeliveryTrackerTest.testTrimRemovesOrphanedBuckets`:

```
java.lang.AssertionError: Remaining bucket range [1..5] should be >= 31 expected [true] but found [false]
```

with the cause visible in the same job's test report:

```
WARN  BucketDelayedDeliveryTracker - Failed to trim or merge bucket snapshots
java.util.concurrent.CompletionException: java.lang.NumberFormatException: Cannot parse null string
	at org.apache.pulsar.broker.delayed.bucket.ImmutableBucket.getAndUpdateBucketId(ImmutableBucket.java:125)
	at org.apache.pulsar.broker.delayed.bucket.ImmutableBucket.asyncDeleteBucketSnapshot(ImmutableBucket.java:322)
	at org.apache.pulsar.broker.delayed.bucket.BucketDelayedDeliveryTracker.deleteBucketSnapshot(BucketDelayedDeliveryTracker.java:905)
	at org.apache.pulsar.broker.delayed.bucket.BucketDelayedDeliveryTracker.lambda$asyncTrimImmutableBuckets$1(BucketDelayedDeliveryTracker.java:898)
```

Two orphaned buckets had been deleted before the chain aborted, which is why the bucket count was already within `maxNumBuckets` while `[1..5]` was still present.

The test additionally had a synchronization gap of its own: it only awaited the `merging` flag, which is satisfied immediately, and then asserted on `immutableBuckets` while the asynchronous trim was still mutating it from a snapshot-storage thread.

### Modifications

- `BucketDelayedDeliveryTracker.deleteBucketSnapshot()` now waits for the bucket's snapshot creation to settle before deleting it, and skips the delete when the creation failed (`INVALID_BUCKET_ID`), since `afterCreateImmutableBucket()` has already removed that bucket and downgraded it to memory mode. The existing delete-and-clean-up body moved unchanged into a new private `doDeleteBucketSnapshot()`.
- `testTrimRemovesOrphanedBuckets` now performs its assertions inside the `Awaitility` block and reads the range map under the tracker monitor, matching the existing `testMergeSupportsSmallMaxNumBuckets`. No assertion was weakened.
- Added `testTrimWaitsForInFlightSnapshotCreation`, which holds all snapshot creations in flight while the trim is triggered and then requires every orphaned bucket to be removed.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- `BucketDelayedDeliveryTrackerTest.testTrimWaitsForInFlightSnapshotCreation` fails deterministically without the production change (`Orphaned bucket [1..5] should have been trimmed`) and passes with it.
- `BucketDelayedDeliveryTrackerTest` is 46/46 green, including 25× `invocationCount` runs of both trim tests, and the `NumberFormatException` no longer appears anywhere in the class's output — it was also being logged by `testTrimHandlesDeleteFailure`.
- The whole `org.apache.pulsar.broker.delayed.*` package (92 tests) and `./gradlew quickCheck` are green.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
