### PR TITLE
[improve][broker] Add pulsar_subscription_storage_backlog_age_seconds metric

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1973,7 +1973,8 @@ exposeBundlesMetricsInPrometheus=false
 # Default is false.
 exposeCustomTopicMetricLabelsEnabled=false
 
-# Enable exposing the age of the oldest unacknowledged message for each subscription in Prometheus.
+# Enable computing the age of the oldest unacknowledged message for each subscription and exposing it
+# through topic stats and Prometheus.
 # When disabled, the broker skips computing per-subscription backlog age and the admin API field
 # SubscriptionStats.oldestBacklogMessageAgeSeconds remains -1. Default is false.
 exposeSubscriptionBacklogAgeInPrometheus=false

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1973,6 +1973,11 @@ exposeBundlesMetricsInPrometheus=false
 # Default is false.
 exposeCustomTopicMetricLabelsEnabled=false
 
+# Enable exposing the age of the oldest unacknowledged message for each subscription in Prometheus.
+# When disabled, the broker skips computing per-subscription backlog age and the admin API field
+# SubscriptionStats.oldestBacklogMessageAgeSeconds remains -1. Default is false.
+exposeSubscriptionBacklogAgeInPrometheus=false
+
 # A comma-separated list of Topic Property keys that are allowed to be exposed as metrics.
 # Only these keys can be set as custom metric labels on topics.
 # Example: sla_tier,data_sensitivity,cost_center,app_owner

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -1249,6 +1249,11 @@ exposePublisherStats=true
 # Default is false.
 exposePreciseBacklogInPrometheus=false
 
+# Enable exposing the age of the oldest unacknowledged message for each subscription in Prometheus.
+# When disabled, the broker skips computing per-subscription backlog age and the admin API field
+# SubscriptionStats.oldestBacklogMessageAgeSeconds remains -1. Default is false.
+exposeSubscriptionBacklogAgeInPrometheus=false
+
 # Enable splitting topic and partition label in Prometheus.
 # If enabled, a topic name will split into 2 parts, one is topic name without partition index,
 # another one is partition index, e.g. (topic=xxx, partition=0).

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -1249,7 +1249,8 @@ exposePublisherStats=true
 # Default is false.
 exposePreciseBacklogInPrometheus=false
 
-# Enable exposing the age of the oldest unacknowledged message for each subscription in Prometheus.
+# Enable computing the age of the oldest unacknowledged message for each subscription and exposing it
+# through topic stats and Prometheus.
 # When disabled, the broker skips computing per-subscription backlog age and the admin API field
 # SubscriptionStats.oldestBacklogMessageAgeSeconds remains -1. Default is false.
 exposeSubscriptionBacklogAgeInPrometheus=false

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -3839,7 +3839,8 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     @FieldContext(
             category = CATEGORY_METRICS,
-            doc = "Enable exposing the age of the oldest unacknowledged message for each subscription in Prometheus.\n"
+            doc = "Enable computing the age of the oldest unacknowledged message for each subscription and exposing "
+                    + "it through topic stats and Prometheus.\n"
                     + " When disabled, the broker skips computing per-subscription backlog age and "
                     + "SubscriptionStats.oldestBacklogMessageAgeSeconds remains -1. Default is false."
     )

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -3839,6 +3839,14 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     @FieldContext(
             category = CATEGORY_METRICS,
+            doc = "Enable exposing the age of the oldest unacknowledged message for each subscription in Prometheus.\n"
+                    + " When disabled, the broker skips computing per-subscription backlog age and "
+                    + "SubscriptionStats.oldestBacklogMessageAgeSeconds remains -1. Default is false."
+    )
+    private boolean exposeSubscriptionBacklogAgeInPrometheus = false;
+
+    @FieldContext(
+            category = CATEGORY_METRICS,
             doc = "Enable splitting topic and partition label in Prometheus.\n"
                     + " If enabled, a topic name will split into 2 parts, one is topic name without partition index,\n"
                     + " another one is partition index, e.g. (topic=xxx, partition=0).\n"

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -26,6 +26,7 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.pulsar.client.util.RetryMessageUtil.DLQ_GROUP_TOPIC_SUFFIX;
 import static org.apache.pulsar.client.util.RetryMessageUtil.RETRY_GROUP_TOPIC_SUFFIX;
 import static org.apache.pulsar.common.naming.SystemTopicNames.isTransactionInternalName;
+import static org.apache.pulsar.common.util.Runnables.catchingAndLoggingThrowables;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Queues;
 import com.google.common.util.concurrent.RateLimiter;
@@ -901,7 +902,8 @@ public class BrokerService implements Closeable {
                     .attr("intervalSeconds", interval)
                     .log("Scheduling a thread to refresh subscription backlog age in background");
             subscriptionBacklogAgeChecker.scheduleAtFixedRateNonConcurrently(
-                    () -> refreshSubscriptionBacklogAge().join(), interval, interval, TimeUnit.SECONDS);
+                    catchingAndLoggingThrowables(() -> refreshSubscriptionBacklogAge().join()), interval, interval,
+                    TimeUnit.SECONDS);
         } else {
             log.info("Subscription backlog age monitoring is disabled");
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -259,6 +259,7 @@ public class BrokerService implements Closeable {
 
     @Getter
     private final SingleThreadNonConcurrentFixedRateScheduler backlogQuotaChecker;
+    private final SingleThreadNonConcurrentFixedRateScheduler subscriptionBacklogAgeChecker;
 
     protected final AtomicReference<Semaphore> lookupRequestSemaphore;
     @Getter
@@ -402,6 +403,8 @@ public class BrokerService implements Closeable {
                 new SingleThreadNonConcurrentFixedRateScheduler("pulsar-consumed-ledgers-monitor");
         this.backlogQuotaManager = new BacklogQuotaManager(pulsar);
         this.backlogQuotaChecker = new SingleThreadNonConcurrentFixedRateScheduler("pulsar-backlog-quota-checker");
+        this.subscriptionBacklogAgeChecker =
+                new SingleThreadNonConcurrentFixedRateScheduler("pulsar-subscription-backlog-age-checker");
         this.authenticationService = new AuthenticationService(pulsar.getConfiguration(),
                 pulsar.getOpenTelemetry().getOpenTelemetry());
         this.topicFactory = createPersistentTopicFactory();
@@ -692,6 +695,7 @@ public class BrokerService implements Closeable {
         this.startCompactionMonitor();
         this.startConsumedLedgersMonitor();
         this.startBacklogQuotaChecker();
+        this.startSubscriptionBacklogAgeChecker();
         this.updateBrokerPublisherThrottlingMaxRate();
         this.updateBrokerDispatchThrottlingMaxRate();
         this.startCheckReplicationPolicies();
@@ -890,6 +894,19 @@ public class BrokerService implements Closeable {
 
     }
 
+    protected void startSubscriptionBacklogAgeChecker() {
+        if (pulsar().getConfiguration().isExposeSubscriptionBacklogAgeInPrometheus()) {
+            final int interval = pulsar().getConfiguration().getBacklogQuotaCheckIntervalInSeconds();
+            log.info()
+                    .attr("intervalSeconds", interval)
+                    .log("Scheduling a thread to refresh subscription backlog age in background");
+            subscriptionBacklogAgeChecker.scheduleAtFixedRateNonConcurrently(
+                    () -> refreshSubscriptionBacklogAge().join(), interval, interval, TimeUnit.SECONDS);
+        } else {
+            log.info("Subscription backlog age monitoring is disabled");
+        }
+    }
+
     public void close() throws IOException {
         try {
             closeAsync().get();
@@ -1043,6 +1060,7 @@ public class BrokerService implements Closeable {
                                                 compactionMonitor,
                                                 consumedLedgersMonitor,
                                                 backlogQuotaChecker,
+                                                subscriptionBacklogAgeChecker,
                                                 topicOrderedExecutor,
                                                 deduplicationSnapshotMonitor,
                                                 segmentLoadReporterMonitor)
@@ -2583,6 +2601,21 @@ public class BrokerService implements Closeable {
                 backlogQuotaCheckDuration.observe(
                         MILLISECONDS.toSeconds(System.currentTimeMillis() - startTimeMillis));
             });
+        });
+    }
+
+    public CompletableFuture<Void> refreshSubscriptionBacklogAge() {
+        if (!pulsar.getConfiguration().isExposeSubscriptionBacklogAgeInPrometheus()) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
+        forEachPersistentTopic(topic -> futures.add(topic.updateSubscriptionOldPositionInfo()));
+        return FutureUtil.waitForAll(futures).exceptionally(throwable -> {
+            log.warn()
+                    .exception(throwable)
+                    .log("Error when refreshSubscriptionBacklogAge()");
+            return null;
         });
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -1514,6 +1514,8 @@ public class PersistentSubscription extends AbstractSubscription {
             }
         }
         subStats.msgBacklog = getNumberOfEntriesInBacklog(getStatsOptions.isGetPreciseBacklog());
+        subStats.oldestBacklogMessageAgeSeconds =
+                topic.getBestEffortOldestUnacknowledgedMessageAgeSeconds(subName);
         if (getStatsOptions.isSubscriptionBacklogSize()) {
             subStats.backlogSize = topic.getManagedLedger()
                     .getEstimatedBacklogSize(cursor.getMarkDeletedPosition());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -317,7 +317,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             PersistentTopic.class,
             OldestPositionInfo.class,
             "oldestPositionInfo");
-    private final Map<String, OldestPositionInfo> subscriptionOldestPositionInfos = new ConcurrentHashMap<>();
+    private volatile Map<String, OldestPositionInfo> subscriptionOldestPositionInfos;
 
     @Value
     private static class OldestPositionInfo {
@@ -3955,12 +3955,40 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
     }
 
     long getBestEffortOldestUnacknowledgedMessageAgeSeconds(String subscriptionName) {
-        OldestPositionInfo positionInfo = subscriptionOldestPositionInfos.get(subscriptionName);
+        if (!brokerService.pulsar().getConfiguration().isExposeSubscriptionBacklogAgeInPrometheus()) {
+            return -1;
+        }
+        Map<String, OldestPositionInfo> positionInfos = subscriptionOldestPositionInfos;
+        if (positionInfos == null) {
+            return -1;
+        }
+        OldestPositionInfo positionInfo = positionInfos.get(subscriptionName);
         if (positionInfo == null) {
             return -1;
         } else {
             return TimeUnit.MILLISECONDS.toSeconds(
                     Clock.systemUTC().millis() - positionInfo.getPositionPublishTimestampInMillis());
+        }
+    }
+
+    private Map<String, OldestPositionInfo> getSubscriptionOldestPositionInfos() {
+        Map<String, OldestPositionInfo> positionInfos = subscriptionOldestPositionInfos;
+        if (positionInfos == null) {
+            synchronized (this) {
+                positionInfos = subscriptionOldestPositionInfos;
+                if (positionInfos == null) {
+                    positionInfos = new ConcurrentHashMap<>();
+                    subscriptionOldestPositionInfos = positionInfos;
+                }
+            }
+        }
+        return positionInfos;
+    }
+
+    private void clearSubscriptionOldestPositionInfos() {
+        Map<String, OldestPositionInfo> positionInfos = subscriptionOldestPositionInfos;
+        if (positionInfos != null) {
+            positionInfos.clear();
         }
     }
 
@@ -3979,7 +4007,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
     }
 
     private void updateSubscriptionResultIfNewer(String subscriptionName, OldestPositionInfo updatedResult) {
-        subscriptionOldestPositionInfos.compute(subscriptionName,
+        getSubscriptionOldestPositionInfos().compute(subscriptionName,
                 (__, existingResult) -> {
                     if (existingResult == null
                             || ManagedCursorContainer.DataVersion.compareVersions(
@@ -3992,14 +4020,19 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
     }
 
     private void clearSubscriptionResultIfNewer(String subscriptionName, long dataVersion) {
-        subscriptionOldestPositionInfos.computeIfPresent(subscriptionName,
+        Map<String, OldestPositionInfo> positionInfos = subscriptionOldestPositionInfos;
+        if (positionInfos == null) {
+            return;
+        }
+        positionInfos.computeIfPresent(subscriptionName,
                 (__, existingResult) ->
                         ManagedCursorContainer.DataVersion.compareVersions(
                                 dataVersion, existingResult.getDataVersion()) >= 0 ? null : existingResult);
     }
 
     private boolean isSubscriptionOldPositionInfoReusable(String subscriptionName, Position markDeletePosition) {
-        OldestPositionInfo positionInfo = subscriptionOldestPositionInfos.get(subscriptionName);
+        Map<String, OldestPositionInfo> positionInfos = subscriptionOldestPositionInfos;
+        OldestPositionInfo positionInfo = positionInfos == null ? null : positionInfos.get(subscriptionName);
         return positionInfo != null
                 && markDeletePosition.compareTo(positionInfo.getOldestCursorMarkDeletePosition()) == 0
                 && markDeletePosition.compareTo(ledger.getFirstPosition()) >= 0;
@@ -4007,14 +4040,20 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
     private CompletableFuture<Void> updateSubscriptionOldPositionInfos(ManagedCursorContainer managedCursorContainer,
                                                                        boolean preciseTimeBasedBacklogQuotaCheck) {
-        Map<String, Boolean> activeSubscriptionNames = new HashMap<>();
+        Set<String> activeSubscriptionNames = ConcurrentHashMap.newKeySet();
+        Set<String> failedSubscriptionNames = ConcurrentHashMap.newKeySet();
         List<CompletableFuture<Void>> futures = new ArrayList<>();
         CursorInfo oldestCursorInfo = managedCursorContainer.getCursorWithOldestPosition();
         long dataVersion = oldestCursorInfo == null ? 0 : oldestCursorInfo.getVersion();
 
-        for (ManagedCursor cursor : managedCursorContainer) {
-            String subscriptionName = Codec.decode(cursor.getName());
-            activeSubscriptionNames.put(subscriptionName, true);
+        for (Map.Entry<String, PersistentSubscription> subscriptionEntry : subscriptions.entrySet()) {
+            String subscriptionName = subscriptionEntry.getKey();
+            ManagedCursor cursor = subscriptionEntry.getValue().getCursor();
+            if (!cursor.isDurable()) {
+                clearSubscriptionResultIfNewer(subscriptionName, dataVersion);
+                continue;
+            }
+            activeSubscriptionNames.add(subscriptionName);
             Position markDeletePosition = cursor.getMarkDeletedPosition();
             if (markDeletePosition == null || !cursor.hasBacklog(preciseTimeBasedBacklogQuotaCheck)) {
                 clearSubscriptionResultIfNewer(subscriptionName, dataVersion);
@@ -4026,7 +4065,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
             if (preciseTimeBasedBacklogQuotaCheck) {
                 futures.add(updateSubscriptionOldPositionInfoPrecise(
-                        subscriptionName, cursor, markDeletePosition, dataVersion));
+                        subscriptionName, cursor, markDeletePosition, dataVersion, failedSubscriptionNames));
             } else {
                 try {
                     EstimateTimeBasedBacklogQuotaCheckResult checkResult =
@@ -4041,28 +4080,43 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                     } else {
                         clearSubscriptionResultIfNewer(subscriptionName, dataVersion);
                     }
-                } catch (Exception e) {
-                    log.error()
-                            .attr("subscriptionName", subscriptionName)
-                            .exceptionMessage(e)
-                            .log("Error updating subscription old position info");
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    failedSubscriptionNames.add(subscriptionName);
+                    clearSubscriptionResultIfNewer(subscriptionName, dataVersion);
+                    break;
+                } catch (ExecutionException e) {
+                    failedSubscriptionNames.add(subscriptionName);
                     clearSubscriptionResultIfNewer(subscriptionName, dataVersion);
                 }
             }
         }
 
-        subscriptionOldestPositionInfos.keySet().removeIf(subscriptionName ->
-                !activeSubscriptionNames.containsKey(subscriptionName));
+        Map<String, OldestPositionInfo> positionInfos = subscriptionOldestPositionInfos;
+        if (positionInfos != null) {
+            positionInfos.keySet().removeIf(subscriptionName -> !activeSubscriptionNames.contains(subscriptionName));
+        }
         if (futures.isEmpty()) {
+            logSubscriptionOldPositionInfoUpdateFailures(failedSubscriptionNames);
             return CompletableFuture.completedFuture(null);
         }
-        return FutureUtil.waitForAll(futures);
+        return FutureUtil.waitForAll(futures)
+                .thenRun(() -> logSubscriptionOldPositionInfoUpdateFailures(failedSubscriptionNames));
+    }
+
+    private void logSubscriptionOldPositionInfoUpdateFailures(Set<String> failedSubscriptionNames) {
+        if (!failedSubscriptionNames.isEmpty()) {
+            log.warn()
+                    .attr("failedSubscriptionCount", failedSubscriptionNames.size())
+                    .log("Failed to update subscription old position info for some subscriptions");
+        }
     }
 
     private CompletableFuture<Void> updateSubscriptionOldPositionInfoPrecise(String subscriptionName,
                                                                              ManagedCursor cursor,
                                                                              Position markDeletePosition,
-                                                                             long dataVersion) {
+                                                                             long dataVersion,
+                                                                             Set<String> failedSubscriptionNames) {
         Position position = ledger.getNextValidPosition(markDeletePosition);
         if (position.compareTo(ledger.getLastConfirmedEntry()) > 0) {
             clearSubscriptionResultIfNewer(subscriptionName, dataVersion);
@@ -4082,10 +4136,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                                     dataVersion));
                     future.complete(null);
                 } catch (Exception e) {
-                    log.error()
-                            .attr("subscriptionName", subscriptionName)
-                            .exceptionMessage(e)
-                            .log("Error deserializing message for subscription old position info");
+                    failedSubscriptionNames.add(subscriptionName);
                     clearSubscriptionResultIfNewer(subscriptionName, dataVersion);
                     future.complete(null);
                 } finally {
@@ -4095,10 +4146,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
             @Override
             public void readEntryFailed(ManagedLedgerException exception, Object ctx) {
-                log.error()
-                        .attr("subscriptionName", subscriptionName)
-                        .exceptionMessage(exception)
-                        .log("Error reading entry for subscription old position info");
+                failedSubscriptionNames.add(subscriptionName);
                 clearSubscriptionResultIfNewer(subscriptionName, dataVersion);
                 future.complete(null);
             }
@@ -4119,19 +4167,27 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         if (!hasBacklogs(preciseTimeBasedBacklogQuotaCheck)) {
             log.debug("No backlog. Update old position info is null");
             TIME_BASED_BACKLOG_QUOTA_CHECK_RESULT_UPDATER.set(this, null);
-            subscriptionOldestPositionInfos.clear();
+            clearSubscriptionOldestPositionInfos();
             return CompletableFuture.completedFuture(null);
         }
 
-        CompletableFuture<Void> subscriptionOldPositionInfoUpdateFuture =
-                updateSubscriptionOldPositionInfos(managedCursorContainer, preciseTimeBasedBacklogQuotaCheck);
+        boolean exposeSubscriptionBacklogAge =
+                brokerService.pulsar().getConfiguration().isExposeSubscriptionBacklogAgeInPrometheus();
+        CompletableFuture<Void> subscriptionOldPositionInfoUpdateFuture;
+        if (exposeSubscriptionBacklogAge) {
+            subscriptionOldPositionInfoUpdateFuture =
+                    updateSubscriptionOldPositionInfos(managedCursorContainer, preciseTimeBasedBacklogQuotaCheck);
+        } else {
+            clearSubscriptionOldestPositionInfos();
+            subscriptionOldPositionInfoUpdateFuture = CompletableFuture.completedFuture(null);
+        }
 
-        // If we have no durable cursor since `ledger.getCursors()` only managed durable cursors
+        // If the oldest-cursor heap has no durable cursor, there is no topic-level oldest backlog position.
         CursorInfo oldestMarkDeleteCursorInfo = managedCursorContainer.getCursorWithOldestPosition();
         if (oldestMarkDeleteCursorInfo == null || oldestMarkDeleteCursorInfo.getPosition() == null) {
             log.debug("No durable cursor found. Update old position info is null");
             TIME_BASED_BACKLOG_QUOTA_CHECK_RESULT_UPDATER.set(this, null);
-            subscriptionOldestPositionInfos.clear();
+            clearSubscriptionOldestPositionInfos();
             return subscriptionOldPositionInfoUpdateFuture;
         }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -4048,7 +4048,8 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
         for (Map.Entry<String, PersistentSubscription> subscriptionEntry : subscriptions.entrySet()) {
             String subscriptionName = subscriptionEntry.getKey();
-            ManagedCursor cursor = subscriptionEntry.getValue().getCursor();
+            PersistentSubscription subscription = subscriptionEntry.getValue();
+            ManagedCursor cursor = subscription.getCursor();
             if (!cursor.isDurable()) {
                 clearSubscriptionResultIfNewer(subscriptionName, dataVersion);
                 continue;
@@ -4069,7 +4070,8 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
             if (preciseTimeBasedBacklogQuotaCheck) {
                 futures.add(updateSubscriptionOldPositionInfoPrecise(
-                        subscriptionName, cursor, markDeletePosition, dataVersion, failedSubscriptionNames));
+                        subscriptionName, subscription, cursor, markDeletePosition, dataVersion,
+                        failedSubscriptionNames, preciseTimeBasedBacklogQuotaCheck));
             } else {
                 try {
                     EstimateTimeBasedBacklogQuotaCheckResult checkResult =
@@ -4117,10 +4119,12 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
     }
 
     private CompletableFuture<Void> updateSubscriptionOldPositionInfoPrecise(String subscriptionName,
+                                                                             PersistentSubscription subscription,
                                                                              ManagedCursor cursor,
                                                                              Position markDeletePosition,
                                                                              long dataVersion,
-                                                                             Set<String> failedSubscriptionNames) {
+                                                                             Set<String> failedSubscriptionNames,
+                                                                             boolean preciseBacklogQuotaCheck) {
         Position position = ledger.getNextValidPosition(markDeletePosition);
         if (position.compareTo(ledger.getLastConfirmedEntry()) > 0) {
             clearSubscriptionResultIfNewer(subscriptionName, dataVersion);
@@ -4132,12 +4136,16 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             @Override
             public void readEntryComplete(Entry entry, Object ctx) {
                 try {
-                    updateSubscriptionResultIfNewer(subscriptionName,
-                            new OldestPositionInfo(
-                                    markDeletePosition,
-                                    cursor.getName(),
-                                    entry.getEntryTimestamp(),
-                                    dataVersion));
+                    if (isSubscriptionOldPositionInfoReadResultStillValid(
+                            subscriptionName, subscription, cursor, markDeletePosition, dataVersion,
+                            preciseBacklogQuotaCheck)) {
+                        updateSubscriptionResultIfNewer(subscriptionName,
+                                new OldestPositionInfo(
+                                        markDeletePosition,
+                                        cursor.getName(),
+                                        entry.getEntryTimestamp(),
+                                        dataVersion));
+                    }
                     future.complete(null);
                 } catch (Exception e) {
                     failedSubscriptionNames.add(subscriptionName);
@@ -4158,6 +4166,53 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         return future;
     }
 
+    private boolean isSubscriptionOldPositionInfoReadResultStillValid(String subscriptionName,
+                                                                      PersistentSubscription subscription,
+                                                                      ManagedCursor cursor,
+                                                                      Position markDeletePosition,
+                                                                      long dataVersion,
+                                                                      boolean preciseTimeBasedBacklogQuotaCheck) {
+        PersistentSubscription currentSubscription = subscriptions.get(subscriptionName);
+        if (currentSubscription != subscription || currentSubscription.getCursor() != cursor) {
+            clearSubscriptionResultIfNewer(subscriptionName, dataVersion);
+            return false;
+        }
+        Position currentMarkDeletePosition = cursor.getMarkDeletedPosition();
+        if (currentMarkDeletePosition == null) {
+            clearSubscriptionResultIfNewer(subscriptionName, dataVersion);
+            return false;
+        }
+        if (currentMarkDeletePosition.compareTo(markDeletePosition) != 0) {
+            clearSubscriptionResultIfNewer(subscriptionName, dataVersion);
+            return false;
+        }
+        if (!cursor.hasBacklog(preciseTimeBasedBacklogQuotaCheck)) {
+            clearSubscriptionResultIfNewer(subscriptionName, dataVersion);
+            return false;
+        }
+        return true;
+    }
+
+    public CompletableFuture<Void> updateSubscriptionOldPositionInfo() {
+        if (!brokerService.pulsar().getConfiguration().isExposeSubscriptionBacklogAgeInPrometheus()) {
+            clearSubscriptionOldestPositionInfos();
+            return CompletableFuture.completedFuture(null);
+        }
+
+        if (!(ledger.getCursors() instanceof ManagedCursorContainer managedCursorContainer)) {
+            // TODO: support this method with a customized managed ledger implementation
+            return CompletableFuture.completedFuture(null);
+        }
+
+        boolean preciseTimeBasedBacklogQuotaCheck =
+                brokerService.pulsar().getConfiguration().isPreciseTimeBasedBacklogQuotaCheck();
+        if (!hasBacklogs(preciseTimeBasedBacklogQuotaCheck)) {
+            clearSubscriptionOldestPositionInfos();
+            return CompletableFuture.completedFuture(null);
+        }
+        return updateSubscriptionOldPositionInfos(managedCursorContainer, preciseTimeBasedBacklogQuotaCheck);
+    }
+
     public CompletableFuture<Void> updateOldPositionInfo() {
         TopicName topicName = TopicName.get(getName());
 
@@ -4171,19 +4226,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         if (!hasBacklogs(preciseTimeBasedBacklogQuotaCheck)) {
             log.debug("No backlog. Update old position info is null");
             TIME_BASED_BACKLOG_QUOTA_CHECK_RESULT_UPDATER.set(this, null);
-            clearSubscriptionOldestPositionInfos();
             return CompletableFuture.completedFuture(null);
-        }
-
-        boolean exposeSubscriptionBacklogAge =
-                brokerService.pulsar().getConfiguration().isExposeSubscriptionBacklogAgeInPrometheus();
-        CompletableFuture<Void> subscriptionOldPositionInfoUpdateFuture;
-        if (exposeSubscriptionBacklogAge) {
-            subscriptionOldPositionInfoUpdateFuture =
-                    updateSubscriptionOldPositionInfos(managedCursorContainer, preciseTimeBasedBacklogQuotaCheck);
-        } else {
-            clearSubscriptionOldestPositionInfos();
-            subscriptionOldPositionInfoUpdateFuture = CompletableFuture.completedFuture(null);
         }
 
         // If the oldest-cursor heap has no durable cursor, there is no topic-level oldest backlog position.
@@ -4191,8 +4234,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         if (oldestMarkDeleteCursorInfo == null || oldestMarkDeleteCursorInfo.getPosition() == null) {
             log.debug("No durable cursor found. Update old position info is null");
             TIME_BASED_BACKLOG_QUOTA_CHECK_RESULT_UPDATER.set(this, null);
-            clearSubscriptionOldestPositionInfos();
-            return subscriptionOldPositionInfoUpdateFuture;
+            return CompletableFuture.completedFuture(null);
         }
 
         Position oldestMarkDeletePosition = oldestMarkDeleteCursorInfo.getPosition();
@@ -4213,7 +4255,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                         .attr("name", oldestMarkDeleteCursorInfo.getCursor().getName())
                         .log("Updating cached old position info, " + "since cursor causing it has changed from to");
             }
-            return subscriptionOldPositionInfoUpdateFuture;
+            return CompletableFuture.completedFuture(null);
         }
         if (preciseTimeBasedBacklogQuotaCheck) {
             CompletableFuture<Void> future = new CompletableFuture<>();
@@ -4261,7 +4303,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                             future.completeExceptionally(exception);
                         }
                     }, null);
-            return FutureUtil.waitForAll(List.of(subscriptionOldPositionInfoUpdateFuture, future));
+            return future;
         } else {
             try {
                 EstimateTimeBasedBacklogQuotaCheckResult checkResult =
@@ -4277,7 +4319,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                     TIME_BASED_BACKLOG_QUOTA_CHECK_RESULT_UPDATER.set(this, null);
                 }
 
-                return subscriptionOldPositionInfoUpdateFuture;
+                return CompletableFuture.completedFuture(null);
             } catch (Exception e) {
                 log.error().exceptionMessage(e)
                         .log("Error reading entry for update old position");

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -3998,6 +3998,13 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                                 dataVersion, existingResult.getDataVersion()) >= 0 ? null : existingResult);
     }
 
+    private boolean isSubscriptionOldPositionInfoReusable(String subscriptionName, Position markDeletePosition) {
+        OldestPositionInfo positionInfo = subscriptionOldestPositionInfos.get(subscriptionName);
+        return positionInfo != null
+                && markDeletePosition.compareTo(positionInfo.getOldestCursorMarkDeletePosition()) == 0
+                && markDeletePosition.compareTo(ledger.getFirstPosition()) >= 0;
+    }
+
     private CompletableFuture<Void> updateSubscriptionOldPositionInfos(ManagedCursorContainer managedCursorContainer,
                                                                        boolean preciseTimeBasedBacklogQuotaCheck) {
         Map<String, Boolean> activeSubscriptionNames = new HashMap<>();
@@ -4011,6 +4018,9 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             Position markDeletePosition = cursor.getMarkDeletedPosition();
             if (markDeletePosition == null || !cursor.hasBacklog(preciseTimeBasedBacklogQuotaCheck)) {
                 clearSubscriptionResultIfNewer(subscriptionName, dataVersion);
+                continue;
+            }
+            if (isSubscriptionOldPositionInfoReusable(subscriptionName, markDeletePosition)) {
                 continue;
             }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -317,6 +317,8 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             PersistentTopic.class,
             OldestPositionInfo.class,
             "oldestPositionInfo");
+    private final Map<String, OldestPositionInfo> subscriptionOldestPositionInfos = new ConcurrentHashMap<>();
+
     @Value
     private static class OldestPositionInfo {
         Position oldestCursorMarkDeletePosition;
@@ -3952,6 +3954,16 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         }
     }
 
+    public long getBestEffortOldestUnacknowledgedMessageAgeSeconds(String subscriptionName) {
+        OldestPositionInfo positionInfo = subscriptionOldestPositionInfos.get(subscriptionName);
+        if (positionInfo == null) {
+            return -1;
+        } else {
+            return TimeUnit.MILLISECONDS.toSeconds(
+                    Clock.systemUTC().millis() - positionInfo.getPositionPublishTimestampInMillis());
+        }
+    }
+
     private void updateResultIfNewer(OldestPositionInfo updatedResult) {
         TIME_BASED_BACKLOG_QUOTA_CHECK_RESULT_UPDATER.updateAndGet(this,
                 existingResult -> {
@@ -3966,6 +3978,124 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
     }
 
+    private void updateSubscriptionResultIfNewer(String subscriptionName, OldestPositionInfo updatedResult) {
+        subscriptionOldestPositionInfos.compute(subscriptionName,
+                (__, existingResult) -> {
+                    if (existingResult == null
+                            || ManagedCursorContainer.DataVersion.compareVersions(
+                                    updatedResult.getDataVersion(), existingResult.getDataVersion()) > 0) {
+                        return updatedResult;
+                    } else {
+                        return existingResult;
+                    }
+                });
+    }
+
+    private void clearSubscriptionResultIfNewer(String subscriptionName, long dataVersion) {
+        subscriptionOldestPositionInfos.computeIfPresent(subscriptionName,
+                (__, existingResult) ->
+                        ManagedCursorContainer.DataVersion.compareVersions(
+                                dataVersion, existingResult.getDataVersion()) >= 0 ? null : existingResult);
+    }
+
+    private CompletableFuture<Void> updateSubscriptionOldPositionInfos(ManagedCursorContainer managedCursorContainer,
+                                                                       boolean preciseTimeBasedBacklogQuotaCheck) {
+        Map<String, Boolean> activeSubscriptionNames = new HashMap<>();
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
+        CursorInfo oldestCursorInfo = managedCursorContainer.getCursorWithOldestPosition();
+        long dataVersion = oldestCursorInfo == null ? 0 : oldestCursorInfo.getVersion();
+
+        for (ManagedCursor cursor : managedCursorContainer) {
+            String subscriptionName = Codec.decode(cursor.getName());
+            activeSubscriptionNames.put(subscriptionName, true);
+            Position markDeletePosition = cursor.getMarkDeletedPosition();
+            if (markDeletePosition == null || !cursor.hasBacklog(preciseTimeBasedBacklogQuotaCheck)) {
+                clearSubscriptionResultIfNewer(subscriptionName, dataVersion);
+                continue;
+            }
+
+            if (preciseTimeBasedBacklogQuotaCheck) {
+                futures.add(updateSubscriptionOldPositionInfoPrecise(
+                        subscriptionName, cursor, markDeletePosition, dataVersion));
+            } else {
+                try {
+                    EstimateTimeBasedBacklogQuotaCheckResult checkResult =
+                            estimatedTimeBasedBacklogQuotaCheck(markDeletePosition);
+                    if (checkResult.getEstimatedOldestUnacknowledgedMessageTimestamp() != null) {
+                        updateSubscriptionResultIfNewer(subscriptionName,
+                                new OldestPositionInfo(
+                                        markDeletePosition,
+                                        cursor.getName(),
+                                        checkResult.getEstimatedOldestUnacknowledgedMessageTimestamp(),
+                                        dataVersion));
+                    } else {
+                        clearSubscriptionResultIfNewer(subscriptionName, dataVersion);
+                    }
+                } catch (Exception e) {
+                    log.error()
+                            .attr("subscriptionName", subscriptionName)
+                            .exceptionMessage(e)
+                            .log("Error updating subscription old position info");
+                    clearSubscriptionResultIfNewer(subscriptionName, dataVersion);
+                }
+            }
+        }
+
+        subscriptionOldestPositionInfos.keySet().removeIf(subscriptionName ->
+                !activeSubscriptionNames.containsKey(subscriptionName));
+        if (futures.isEmpty()) {
+            return CompletableFuture.completedFuture(null);
+        }
+        return FutureUtil.waitForAll(futures);
+    }
+
+    private CompletableFuture<Void> updateSubscriptionOldPositionInfoPrecise(String subscriptionName,
+                                                                             ManagedCursor cursor,
+                                                                             Position markDeletePosition,
+                                                                             long dataVersion) {
+        Position position = ledger.getNextValidPosition(markDeletePosition);
+        if (position.compareTo(ledger.getLastConfirmedEntry()) > 0) {
+            clearSubscriptionResultIfNewer(subscriptionName, dataVersion);
+            return CompletableFuture.completedFuture(null);
+        }
+
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        ledger.asyncReadEntry(position, new AsyncCallbacks.ReadEntryCallback() {
+            @Override
+            public void readEntryComplete(Entry entry, Object ctx) {
+                try {
+                    updateSubscriptionResultIfNewer(subscriptionName,
+                            new OldestPositionInfo(
+                                    markDeletePosition,
+                                    cursor.getName(),
+                                    entry.getEntryTimestamp(),
+                                    dataVersion));
+                    future.complete(null);
+                } catch (Exception e) {
+                    log.error()
+                            .attr("subscriptionName", subscriptionName)
+                            .exceptionMessage(e)
+                            .log("Error deserializing message for subscription old position info");
+                    clearSubscriptionResultIfNewer(subscriptionName, dataVersion);
+                    future.complete(null);
+                } finally {
+                    entry.release();
+                }
+            }
+
+            @Override
+            public void readEntryFailed(ManagedLedgerException exception, Object ctx) {
+                log.error()
+                        .attr("subscriptionName", subscriptionName)
+                        .exceptionMessage(exception)
+                        .log("Error reading entry for subscription old position info");
+                clearSubscriptionResultIfNewer(subscriptionName, dataVersion);
+                future.complete(null);
+            }
+        }, null);
+        return future;
+    }
+
     public CompletableFuture<Void> updateOldPositionInfo() {
         TopicName topicName = TopicName.get(getName());
 
@@ -3974,18 +4104,25 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             return CompletableFuture.completedFuture(null);
         }
 
-        if (!hasBacklogs(brokerService.pulsar().getConfiguration().isPreciseTimeBasedBacklogQuotaCheck())) {
+        boolean preciseTimeBasedBacklogQuotaCheck =
+                brokerService.pulsar().getConfiguration().isPreciseTimeBasedBacklogQuotaCheck();
+        if (!hasBacklogs(preciseTimeBasedBacklogQuotaCheck)) {
             log.debug("No backlog. Update old position info is null");
             TIME_BASED_BACKLOG_QUOTA_CHECK_RESULT_UPDATER.set(this, null);
+            subscriptionOldestPositionInfos.clear();
             return CompletableFuture.completedFuture(null);
         }
+
+        CompletableFuture<Void> subscriptionOldPositionInfoUpdateFuture =
+                updateSubscriptionOldPositionInfos(managedCursorContainer, preciseTimeBasedBacklogQuotaCheck);
 
         // If we have no durable cursor since `ledger.getCursors()` only managed durable cursors
         CursorInfo oldestMarkDeleteCursorInfo = managedCursorContainer.getCursorWithOldestPosition();
         if (oldestMarkDeleteCursorInfo == null || oldestMarkDeleteCursorInfo.getPosition() == null) {
             log.debug("No durable cursor found. Update old position info is null");
             TIME_BASED_BACKLOG_QUOTA_CHECK_RESULT_UPDATER.set(this, null);
-            return CompletableFuture.completedFuture(null);
+            subscriptionOldestPositionInfos.clear();
+            return subscriptionOldPositionInfoUpdateFuture;
         }
 
         Position oldestMarkDeletePosition = oldestMarkDeleteCursorInfo.getPosition();
@@ -4006,9 +4143,9 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                         .attr("name", oldestMarkDeleteCursorInfo.getCursor().getName())
                         .log("Updating cached old position info, " + "since cursor causing it has changed from to");
             }
-            return CompletableFuture.completedFuture(null);
+            return subscriptionOldPositionInfoUpdateFuture;
         }
-        if (brokerService.pulsar().getConfiguration().isPreciseTimeBasedBacklogQuotaCheck()) {
+        if (preciseTimeBasedBacklogQuotaCheck) {
             CompletableFuture<Void> future = new CompletableFuture<>();
             // Check if first unconsumed message(first message after mark delete position)
             // for slowest cursor's has expired.
@@ -4054,7 +4191,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                             future.completeExceptionally(exception);
                         }
                     }, null);
-            return future;
+            return FutureUtil.waitForAll(List.of(subscriptionOldPositionInfoUpdateFuture, future));
         } else {
             try {
                 EstimateTimeBasedBacklogQuotaCheckResult checkResult =
@@ -4070,7 +4207,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                     TIME_BASED_BACKLOG_QUOTA_CHECK_RESULT_UPDATER.set(this, null);
                 }
 
-                return CompletableFuture.completedFuture(null);
+                return subscriptionOldPositionInfoUpdateFuture;
             } catch (Exception e) {
                 log.error().exceptionMessage(e)
                         .log("Error reading entry for update old position");

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -4055,11 +4055,15 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             }
             activeSubscriptionNames.add(subscriptionName);
             Position markDeletePosition = cursor.getMarkDeletedPosition();
-            if (markDeletePosition == null || !cursor.hasBacklog(preciseTimeBasedBacklogQuotaCheck)) {
+            if (markDeletePosition == null) {
                 clearSubscriptionResultIfNewer(subscriptionName, dataVersion);
                 continue;
             }
             if (isSubscriptionOldPositionInfoReusable(subscriptionName, markDeletePosition)) {
+                continue;
+            }
+            if (!cursor.hasBacklog(preciseTimeBasedBacklogQuotaCheck)) {
+                clearSubscriptionResultIfNewer(subscriptionName, dataVersion);
                 continue;
             }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -3954,7 +3954,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         }
     }
 
-    public long getBestEffortOldestUnacknowledgedMessageAgeSeconds(String subscriptionName) {
+    long getBestEffortOldestUnacknowledgedMessageAgeSeconds(String subscriptionName) {
         OldestPositionInfo positionInfo = subscriptionOldestPositionInfos.get(subscriptionName);
         if (positionInfo == null) {
             return -1;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/AggregatedSubscriptionStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/AggregatedSubscriptionStats.java
@@ -29,6 +29,8 @@ public class AggregatedSubscriptionStats {
 
     public long msgBacklogNoDelayed;
 
+    public long backlogAgeSeconds = -1;
+
     public boolean blockedSubscriptionOnUnackedMsgs;
 
     public double msgRateRedeliver;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregator.java
@@ -86,6 +86,8 @@ public class NamespaceStatsAggregator {
         Optional<CompactorMXBean> compactorMXBean = getCompactorMXBean(pulsar);
         LongAdder topicsCount = new LongAdder();
         Map<String, Long> localNamespaceTopicCount = new HashMap<>();
+        boolean exposeSubscriptionBacklogAge =
+                pulsar.getConfiguration().isExposeSubscriptionBacklogAgeInPrometheus();
         pulsar.getBrokerService().getMultiLayerTopicsMap().forEach((namespace, bundlesMap) -> {
             namespaceStats.reset();
             topicsCount.reset();
@@ -118,7 +120,7 @@ public class NamespaceStatsAggregator {
 
                     topicsCount.add(1);
                     TopicStats.printTopicStats(stream, topicStats, compactorMXBean, cluster, namespace, name,
-                        splitTopicAndPartitionIndexLabel, customLabelAndValues);
+                        splitTopicAndPartitionIndexLabel, exposeSubscriptionBacklogAge, customLabelAndValues);
                 } else {
                     namespaceStats.updateStats(topicStats);
                 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregator.java
@@ -152,6 +152,7 @@ public class NamespaceStatsAggregator {
         subsStats.bytesOutCounter = subscriptionStats.bytesOutCounter;
         subsStats.msgOutCounter = subscriptionStats.msgOutCounter;
         subsStats.msgBacklog = subscriptionStats.msgBacklog;
+        subsStats.backlogAgeSeconds = subscriptionStats.oldestBacklogMessageAgeSeconds;
         subsStats.msgDelayed = subscriptionStats.msgDelayed;
         subsStats.msgInReplay = subscriptionStats.msgInReplay;
         subsStats.msgRateExpired = subscriptionStats.msgRateExpired;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TopicStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TopicStats.java
@@ -148,6 +148,7 @@ class TopicStats {
     public static void printTopicStats(PrometheusMetricStreams stream, TopicStats stats,
                                        Optional<CompactorMXBean> compactorMXBean, String cluster, String namespace,
                                        String topic, boolean splitTopicAndPartitionIndexLabel,
+                                       boolean exposeSubscriptionBacklogAge,
                                        String[] customLabelsAndValues) {
         writeMetric(stream, "pulsar_subscriptions_count", stats.subscriptionsCount,
             cluster, namespace, topic, splitTopicAndPartitionIndexLabel, customLabelsAndValues);
@@ -324,9 +325,11 @@ class TopicStats {
             writeSubscriptionMetric(stream, "pulsar_subscription_back_log_no_delayed",
                 subsStats.msgBacklogNoDelayed, cluster, namespace, topic, sub, splitTopicAndPartitionIndexLabel,
                 customLabelsAndValues);
-            writeSubscriptionMetric(stream, "pulsar_subscription_storage_backlog_age_seconds",
-                subsStats.backlogAgeSeconds, cluster, namespace, topic, sub, splitTopicAndPartitionIndexLabel,
-                customLabelsAndValues);
+            if (exposeSubscriptionBacklogAge && subsStats.backlogAgeSeconds >= 0) {
+                writeSubscriptionMetric(stream, "pulsar_subscription_storage_backlog_age_seconds",
+                    subsStats.backlogAgeSeconds, cluster, namespace, topic, sub, splitTopicAndPartitionIndexLabel,
+                    customLabelsAndValues);
+            }
             writeSubscriptionMetric(stream, "pulsar_subscription_delayed",
                 subsStats.msgDelayed, cluster, namespace, topic, sub, splitTopicAndPartitionIndexLabel,
                 customLabelsAndValues);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TopicStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TopicStats.java
@@ -324,6 +324,9 @@ class TopicStats {
             writeSubscriptionMetric(stream, "pulsar_subscription_back_log_no_delayed",
                 subsStats.msgBacklogNoDelayed, cluster, namespace, topic, sub, splitTopicAndPartitionIndexLabel,
                 customLabelsAndValues);
+            writeSubscriptionMetric(stream, "pulsar_subscription_storage_backlog_age_seconds",
+                subsStats.backlogAgeSeconds, cluster, namespace, topic, sub, splitTopicAndPartitionIndexLabel,
+                customLabelsAndValues);
             writeSubscriptionMetric(stream, "pulsar_subscription_delayed",
                 subsStats.msgDelayed, cluster, namespace, topic, sub, splitTopicAndPartitionIndexLabel,
                 customLabelsAndValues);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerTest.java
@@ -947,7 +947,7 @@ public class BacklogQuotaManagerTest {
     @SuppressWarnings("deprecation")
 
     @Test
-    public void backlogsStatsNotPrecise() throws PulsarAdminException, PulsarClientException, InterruptedException {
+    public void backlogsStatsNotPrecise() throws Exception {
         config.setPreciseTimeBasedBacklogQuotaCheck(false);
         config.setExposeSubscriptionBacklogAgeInPrometheus(true);
         config.setManagedLedgerMaxEntriesPerLedger(6);
@@ -1018,6 +1018,7 @@ public class BacklogQuotaManagerTest {
             long unloadTime = System.currentTimeMillis();
 
             waitForQuotaCheckToRunTwice();
+            refreshSubscriptionBacklogAge(topic1);
 
             topicStats = getTopicStats(topic1);
             assertThat(topicStats.getOldestBacklogMessageSubscriptionName()).isEqualTo(subName2);
@@ -1040,6 +1041,7 @@ public class BacklogQuotaManagerTest {
             waitForMarkDeletePositionToChange(topic1, subName1, c1MarkDeletePositionBefore);
             waitForMarkDeletePositionToChange(topic1, subName2, c2MarkDeletePositionBefore);
             waitForQuotaCheckToRunTwice();
+            refreshSubscriptionBacklogAge(topic1);
 
             topicStats = getTopicStats(topic1);
             assertThat(topicStats.getOldestBacklogMessageSubscriptionName()).isEqualTo(subName2);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerTest.java
@@ -331,6 +331,12 @@ public class BacklogQuotaManagerTest {
                 admin.topics().getStats(topic1, GetStatsOptions.builder().getPreciseBacklog(getPreciseBacklog).build());
         return stats;
     }
+
+    private void refreshSubscriptionBacklogAge(String topic) throws Exception {
+        PersistentTopic topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topic).get();
+        topicRef.updateSubscriptionOldPositionInfo().get(5, SECONDS);
+    }
+
     @SuppressWarnings("deprecation")
 
     @Test
@@ -406,7 +412,7 @@ public class BacklogQuotaManagerTest {
     @SuppressWarnings("deprecation")
 
     @Test
-    public void backlogsStatsPrecise() throws PulsarAdminException, PulsarClientException, InterruptedException {
+    public void backlogsStatsPrecise() throws Exception {
         config.setPreciseTimeBasedBacklogQuotaCheck(true);
         config.setExposeSubscriptionBacklogAgeInPrometheus(true);
         final String namespace = "prop/ns-quota";
@@ -465,6 +471,7 @@ public class BacklogQuotaManagerTest {
             c1MarkDeletePositionBefore = waitForMarkDeletePositionToChange(topic1, subName1,
                     c1MarkDeletePositionBefore);
             waitForQuotaCheckToRunTwice();
+            refreshSubscriptionBacklogAge(topic1);
 
             Metrics metrics = prometheusMetricsClient.getMetrics();
             TopicStats topicStats = getTopicStats(topic1);
@@ -518,6 +525,7 @@ public class BacklogQuotaManagerTest {
             c1MarkDeletePositionBefore = waitForMarkDeletePositionToChange(topic1, subName1,
                     c1MarkDeletePositionBefore);
             waitForQuotaCheckToRunTwice();
+            refreshSubscriptionBacklogAge(topic1);
 
             metrics = prometheusMetricsClient.getMetrics();
             long actualAge = (long) metrics.findByNameAndLabels(
@@ -544,6 +552,7 @@ public class BacklogQuotaManagerTest {
             waitForMarkDeletePositionToChange(topic1, subName1,
                     c1MarkDeletePositionBefore);
             waitForQuotaCheckToRunTwice();
+            refreshSubscriptionBacklogAge(topic1);
 
             // Cache shouldn't be used, since position has changed
             long readEntries = getReadEntries(topic1);
@@ -558,6 +567,7 @@ public class BacklogQuotaManagerTest {
                     .isCloseTo(expectedMessageAgeSeconds, within(2L));
 
             waitForQuotaCheckToRunTwice();
+            refreshSubscriptionBacklogAge(topic1);
 
             // Cache should be used, since position hasn't changed
             assertThat(getReadEntries(topic1)).isEqualTo(readEntries);
@@ -575,6 +585,7 @@ public class BacklogQuotaManagerTest {
             log.info("Subscription 1 and 2 moved to end. Now should not backlog");
             waitForMarkDeletePositionToChange(topic1, subName1, c1MarkDeletePositionBefore);
             waitForQuotaCheckToRunTwice();
+            refreshSubscriptionBacklogAge(topic1);
 
             topicStats = getTopicStats(topic1);
             assertThat(topicStats.getBacklogSize()).isEqualTo(0);
@@ -617,7 +628,7 @@ public class BacklogQuotaManagerTest {
             producer.send(new byte[1024]);
 
             PersistentTopic topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topic1).get();
-            topicRef.updateOldPositionInfo().get(5, SECONDS);
+            topicRef.updateSubscriptionOldPositionInfo().get(5, SECONDS);
 
             TopicStats topicStats = getTopicStats(topic1);
             assertThat(topicStats.getSubscriptions().get(subName).getOldestBacklogMessageAgeSeconds()).isEqualTo(-1);
@@ -646,7 +657,7 @@ public class BacklogQuotaManagerTest {
             producer.send(new byte[1024]);
 
             PersistentTopic topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topic1).get();
-            topicRef.updateOldPositionInfo().get(5, SECONDS);
+            topicRef.updateSubscriptionOldPositionInfo().get(5, SECONDS);
 
             TopicStats topicStats = getTopicStats(topic1);
             assertThat(topicStats.getSubscriptions().get(subName).getOldestBacklogMessageAgeSeconds())
@@ -686,7 +697,7 @@ public class BacklogQuotaManagerTest {
             producer.send(new byte[1024]);
 
             PersistentTopic topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topic1).get();
-            topicRef.updateOldPositionInfo().get(5, SECONDS);
+            topicRef.updateSubscriptionOldPositionInfo().get(5, SECONDS);
 
             TopicStats topicStats = getTopicStats(topic1);
             assertThat(topicStats.getSubscriptions().get(subName1).getOldestBacklogMessageAgeSeconds())
@@ -695,12 +706,12 @@ public class BacklogQuotaManagerTest {
                     .isGreaterThanOrEqualTo(0L);
 
             consumer1.unsubscribe();
-            topicRef.updateOldPositionInfo().get(5, SECONDS);
+            topicRef.updateSubscriptionOldPositionInfo().get(5, SECONDS);
 
             client.newConsumer().topic(topic1).subscriptionName(subName1)
                     .acknowledgmentGroupTime(0, SECONDS)
                     .subscribe();
-            topicRef.updateOldPositionInfo().get(5, SECONDS);
+            topicRef.updateSubscriptionOldPositionInfo().get(5, SECONDS);
 
             topicStats = getTopicStats(topic1);
             assertThat(topicStats.getSubscriptions().get(subName1).getMsgBacklog()).isEqualTo(0);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerTest.java
@@ -41,6 +41,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
@@ -79,6 +80,7 @@ import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.common.policies.data.BacklogQuota;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats;
+import org.apache.pulsar.common.policies.data.SubscriptionStats;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.apache.pulsar.common.policies.data.TopicStats;
 import org.apache.pulsar.common.policies.data.TopicType;
@@ -203,6 +205,7 @@ public class BacklogQuotaManagerTest {
     @BeforeMethod(alwaysRun = true)
     void createNamespaces() throws Exception {
         config.setPreciseTimeBasedBacklogQuotaCheck(false);
+        config.setExposeSubscriptionBacklogAgeInPrometheus(false);
         createNamespaceForTest("prop/ns-quota");
         createNamespaceForTest("prop/quotahold");
         createNamespaceForTest("prop/quotaholdasync");
@@ -405,6 +408,7 @@ public class BacklogQuotaManagerTest {
     @Test
     public void backlogsStatsPrecise() throws PulsarAdminException, PulsarClientException, InterruptedException {
         config.setPreciseTimeBasedBacklogQuotaCheck(true);
+        config.setExposeSubscriptionBacklogAgeInPrometheus(true);
         final String namespace = "prop/ns-quota";
         assertEquals(admin.namespaces().getBacklogQuotaMap(namespace), new HashMap<>());
         final int sizeLimitBytes = 15 * 1024 * 1024;
@@ -474,6 +478,9 @@ public class BacklogQuotaManagerTest {
             assertThat(topicStats.getOldestBacklogMessageSubscriptionName()).isEqualTo(subName2);
             assertThat(topicStats.getSubscriptions().get(subName2).getOldestBacklogMessageAgeSeconds())
                     .isCloseTo(expectedMessageAgeSeconds, within(1L));
+            assertThat(topicStats.getSubscriptions().get(subName1).getOldestBacklogMessageAgeSeconds())
+                    .isGreaterThanOrEqualTo(0L)
+                    .isLessThan(expectedMessageAgeSeconds);
 
             Metric backlogAgeMetric =
                     metrics.findSingleMetricByNameAndLabels("pulsar_storage_backlog_age_seconds",
@@ -593,6 +600,116 @@ public class BacklogQuotaManagerTest {
             assertNotNull(producer2);
         }
     }
+
+    @Test
+    public void subscriptionBacklogAgeStatsDisabledByDefault() throws Exception {
+        config.setPreciseTimeBasedBacklogQuotaCheck(true);
+
+        try (PulsarClient client = PulsarClient.builder().serviceUrl(adminUrl.toString())
+                .statsInterval(0, SECONDS).build()) {
+            final String topic1 = "persistent://prop/ns-quota/topic-disabled" + UUID.randomUUID();
+            final String subName = "c1";
+
+            client.newConsumer().topic(topic1).subscriptionName(subName)
+                    .acknowledgmentGroupTime(0, SECONDS)
+                    .subscribe();
+            Producer<byte[]> producer = createProducer(client, topic1);
+            producer.send(new byte[1024]);
+
+            PersistentTopic topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topic1).get();
+            topicRef.updateOldPositionInfo().get(5, SECONDS);
+
+            TopicStats topicStats = getTopicStats(topic1);
+            assertThat(topicStats.getSubscriptions().get(subName).getOldestBacklogMessageAgeSeconds()).isEqualTo(-1);
+
+            Metrics metrics = prometheusMetricsClient.getMetrics();
+            assertThat(metrics.findByNameAndLabels("pulsar_subscription_storage_backlog_age_seconds",
+                    Pair.of("topic", topic1), Pair.of("subscription", subName))).isEmpty();
+        }
+    }
+
+    @Test
+    public void subscriptionBacklogAgeSkipsNonDurableReader() throws Exception {
+        config.setPreciseTimeBasedBacklogQuotaCheck(true);
+        config.setExposeSubscriptionBacklogAgeInPrometheus(true);
+
+        try (PulsarClient client = PulsarClient.builder().serviceUrl(adminUrl.toString())
+                .statsInterval(0, SECONDS).build()) {
+            final String topic1 = "persistent://prop/ns-quota/topic-reader" + UUID.randomUUID();
+            final String subName = "c1";
+
+            client.newConsumer().topic(topic1).subscriptionName(subName)
+                    .acknowledgmentGroupTime(0, SECONDS)
+                    .subscribe();
+            client.newReader().topic(topic1).startMessageId(MessageId.earliest).create();
+            Producer<byte[]> producer = createProducer(client, topic1);
+            producer.send(new byte[1024]);
+
+            PersistentTopic topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topic1).get();
+            topicRef.updateOldPositionInfo().get(5, SECONDS);
+
+            TopicStats topicStats = getTopicStats(topic1);
+            assertThat(topicStats.getSubscriptions().get(subName).getOldestBacklogMessageAgeSeconds())
+                    .isGreaterThanOrEqualTo(0L);
+
+            Map.Entry<String, ? extends SubscriptionStats> readerStats = topicStats.getSubscriptions().entrySet()
+                    .stream()
+                    .filter(entry -> !entry.getValue().isDurable())
+                    .findFirst()
+                    .orElseThrow();
+            assertThat(readerStats.getValue().getOldestBacklogMessageAgeSeconds()).isEqualTo(-1);
+
+            Metrics metrics = prometheusMetricsClient.getMetrics();
+            assertThat(metrics.findByNameAndLabels("pulsar_subscription_storage_backlog_age_seconds",
+                    Pair.of("topic", topic1), Pair.of("subscription", readerStats.getKey()))).isEmpty();
+        }
+    }
+
+    @Test
+    public void subscriptionBacklogAgeCacheRemovedAfterSubscriptionDeleteAndRecreate() throws Exception {
+        config.setPreciseTimeBasedBacklogQuotaCheck(true);
+        config.setExposeSubscriptionBacklogAgeInPrometheus(true);
+
+        try (PulsarClient client = PulsarClient.builder().serviceUrl(adminUrl.toString())
+                .statsInterval(0, SECONDS).build()) {
+            final String topic1 = "persistent://prop/ns-quota/topic-recreated" + UUID.randomUUID();
+            final String subName1 = "c1";
+            final String subName2 = "c2";
+
+            Consumer<byte[]> consumer1 = client.newConsumer().topic(topic1).subscriptionName(subName1)
+                    .acknowledgmentGroupTime(0, SECONDS)
+                    .subscribe();
+            client.newConsumer().topic(topic1).subscriptionName(subName2)
+                    .acknowledgmentGroupTime(0, SECONDS)
+                    .subscribe();
+            Producer<byte[]> producer = createProducer(client, topic1);
+            producer.send(new byte[1024]);
+
+            PersistentTopic topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topic1).get();
+            topicRef.updateOldPositionInfo().get(5, SECONDS);
+
+            TopicStats topicStats = getTopicStats(topic1);
+            assertThat(topicStats.getSubscriptions().get(subName1).getOldestBacklogMessageAgeSeconds())
+                    .isGreaterThanOrEqualTo(0L);
+            assertThat(topicStats.getSubscriptions().get(subName2).getOldestBacklogMessageAgeSeconds())
+                    .isGreaterThanOrEqualTo(0L);
+
+            consumer1.unsubscribe();
+            topicRef.updateOldPositionInfo().get(5, SECONDS);
+
+            client.newConsumer().topic(topic1).subscriptionName(subName1)
+                    .acknowledgmentGroupTime(0, SECONDS)
+                    .subscribe();
+            topicRef.updateOldPositionInfo().get(5, SECONDS);
+
+            topicStats = getTopicStats(topic1);
+            assertThat(topicStats.getSubscriptions().get(subName1).getMsgBacklog()).isEqualTo(0);
+            assertThat(topicStats.getSubscriptions().get(subName1).getOldestBacklogMessageAgeSeconds()).isEqualTo(-1);
+            assertThat(topicStats.getSubscriptions().get(subName2).getOldestBacklogMessageAgeSeconds())
+                    .isGreaterThanOrEqualTo(0L);
+        }
+    }
+
     @SuppressWarnings("deprecation")
 
     @Test
@@ -821,6 +938,7 @@ public class BacklogQuotaManagerTest {
     @Test
     public void backlogsStatsNotPrecise() throws PulsarAdminException, PulsarClientException, InterruptedException {
         config.setPreciseTimeBasedBacklogQuotaCheck(false);
+        config.setExposeSubscriptionBacklogAgeInPrometheus(true);
         config.setManagedLedgerMaxEntriesPerLedger(6);
         final String namespace = "prop/ns-quota";
         assertEquals(admin.namespaces().getBacklogQuotaMap(namespace), new HashMap<>());
@@ -895,6 +1013,8 @@ public class BacklogQuotaManagerTest {
             // age is measured against the ledger closing time
             long expectedAge = MILLISECONDS.toSeconds(System.currentTimeMillis() - unloadTime);
             assertThat(topicStats.getOldestBacklogMessageAgeSeconds()).isCloseTo(expectedAge, within(1L));
+            assertThat(topicStats.getSubscriptions().get(subName2).getOldestBacklogMessageAgeSeconds())
+                    .isCloseTo(expectedAge, within(1L));
 
             String c2MarkDeletePositionBefore =
                     admin.topics().getInternalStats(topic1).cursors.get(subName2).markDeletePosition;
@@ -914,6 +1034,8 @@ public class BacklogQuotaManagerTest {
             assertThat(topicStats.getOldestBacklogMessageSubscriptionName()).isEqualTo(subName2);
             expectedAge = MILLISECONDS.toSeconds(System.currentTimeMillis() - unloadTime);
             assertThat(topicStats.getOldestBacklogMessageAgeSeconds()).isCloseTo(expectedAge, within(1L));
+            assertThat(topicStats.getSubscriptions().get(subName2).getOldestBacklogMessageAgeSeconds())
+                    .isCloseTo(expectedAge, within(1L));
 
             // Unsubscribe consume1 and consumer2
             consumer1.unsubscribe();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerTest.java
@@ -472,6 +472,8 @@ public class BacklogQuotaManagerTest {
             assertThat(topicStats.getOldestBacklogMessageAgeSeconds())
                     .isCloseTo(expectedMessageAgeSeconds, within(1L));
             assertThat(topicStats.getOldestBacklogMessageSubscriptionName()).isEqualTo(subName2);
+            assertThat(topicStats.getSubscriptions().get(subName2).getOldestBacklogMessageAgeSeconds())
+                    .isCloseTo(expectedMessageAgeSeconds, within(1L));
 
             Metric backlogAgeMetric =
                     metrics.findSingleMetricByNameAndLabels("pulsar_storage_backlog_age_seconds",
@@ -481,6 +483,15 @@ public class BacklogQuotaManagerTest {
                     entry("namespace", namespace),
                     entry("topic", topic1));
             assertThat((long) backlogAgeMetric.value).isCloseTo(expectedMessageAgeSeconds, within(2L));
+            Metric subBacklogAgeMetric =
+                    metrics.findSingleMetricByNameAndLabels("pulsar_subscription_storage_backlog_age_seconds",
+                            Pair.of("topic", topic1), Pair.of("subscription", subName2));
+            assertThat(subBacklogAgeMetric.tags).containsExactly(
+                    entry("cluster", CLUSTER_NAME),
+                    entry("namespace", namespace),
+                    entry("subscription", subName2),
+                    entry("topic", topic1));
+            assertThat((long) subBacklogAgeMetric.value).isCloseTo(expectedMessageAgeSeconds, within(2L));
 
             // Move subscription 2 away from being the oldest mark delete
             //     S2/S1
@@ -536,6 +547,8 @@ public class BacklogQuotaManagerTest {
                     MILLISECONDS.toSeconds(System.currentTimeMillis() - secondOldestMessage.getPublishTime());
             assertThat(topicStats.getOldestBacklogMessageAgeSeconds()).isCloseTo(expectedMessageAgeSeconds, within(2L));
             assertThat(topicStats.getOldestBacklogMessageSubscriptionName()).isEqualTo(subName2);
+            assertThat(topicStats.getSubscriptions().get(subName2).getOldestBacklogMessageAgeSeconds())
+                    .isCloseTo(expectedMessageAgeSeconds, within(2L));
 
             waitForQuotaCheckToRunTwice();
 
@@ -560,6 +573,8 @@ public class BacklogQuotaManagerTest {
             assertThat(topicStats.getBacklogSize()).isEqualTo(0);
             assertThat(topicStats.getSubscriptions().get(subName1).getMsgBacklog()).isEqualTo(0);
             assertThat(topicStats.getSubscriptions().get(subName2).getMsgBacklog()).isEqualTo(0);
+            assertThat(topicStats.getSubscriptions().get(subName1).getOldestBacklogMessageAgeSeconds()).isEqualTo(-1);
+            assertThat(topicStats.getSubscriptions().get(subName2).getOldestBacklogMessageAgeSeconds()).isEqualTo(-1);
             assertThat(topicStats.getOldestBacklogMessageAgeSeconds()).isEqualTo(-1);
             assertThat(topicStats.getOldestBacklogMessageSubscriptionName()).isNull();
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregatorTest.java
@@ -108,6 +108,8 @@ public class NamespaceStatsAggregatorTest {
         PrometheusMetricStreams metricStreams = Mockito.spy(new PrometheusMetricStreams());
 
         // Populate subscriptions stats
+        ServiceConfiguration config = pulsar.getConfiguration();
+        doReturn(true).when(config).isExposeSubscriptionBacklogAgeInPrometheus();
         subStats.blockedSubscriptionOnUnackedMsgs = true;
         subStats.oldestBacklogMessageAgeSeconds = 123;
         consumerStats.blockedConsumerOnUnackedMsgs = false; // should not affect blockedSubscriptionOnUnackedMsgs

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregatorTest.java
@@ -109,6 +109,7 @@ public class NamespaceStatsAggregatorTest {
 
         // Populate subscriptions stats
         subStats.blockedSubscriptionOnUnackedMsgs = true;
+        subStats.oldestBacklogMessageAgeSeconds = 123;
         consumerStats.blockedConsumerOnUnackedMsgs = false; // should not affect blockedSubscriptionOnUnackedMsgs
         consumerStats.unackedMessages = 1;
         consumerStats.msgRateRedeliver = 0.7;
@@ -124,6 +125,7 @@ public class NamespaceStatsAggregatorTest {
 
         verifySubscriptionMetric(metricStreams, "pulsar_subscription_msg_rate_redeliver", 0.7);
         verifySubscriptionMetric(metricStreams, "pulsar_subscription_unacked_messages", 1L);
+        verifySubscriptionMetric(metricStreams, "pulsar_subscription_storage_backlog_age_seconds", 123L);
     }
 
     private void verifySubscriptionMetric(PrometheusMetricStreams metricStreams, String metricName, Number value) {

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/SubscriptionStats.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/SubscriptionStats.java
@@ -58,11 +58,11 @@ public interface SubscriptionStats {
     long getEarliestMsgPublishTimeInBacklog();
 
     /**
-     * Age of oldest unacknowledged message, as recorded in last backlog quota check interval.
+     * Age of oldest unacknowledged message for this subscription, in seconds.
      * <p>
-     * The age of the oldest unacknowledged (i.e. backlog) message for this subscription, measured by the time elapsed
-     * from its published time, in seconds. This value is recorded every backlog quota check interval, hence it
-     * represents the value seen in the last check.
+     * This is a best-effort cached value from the broker's periodic subscription backlog-age refresh. The value is
+     * {@code -1} when it is unknown, not applicable, the subscription has no backlog, or the broker has disabled
+     * subscription backlog-age computation.
      * </p>
      */
     default long getOldestBacklogMessageAgeSeconds() {

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/SubscriptionStats.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/SubscriptionStats.java
@@ -57,6 +57,16 @@ public interface SubscriptionStats {
     /** Get the publish time of the earliest message in the backlog. */
     long getEarliestMsgPublishTimeInBacklog();
 
+    /**
+     * Age of oldest unacknowledged message, as recorded in last backlog quota check interval.
+     * <p>
+     * The age of the oldest unacknowledged (i.e. backlog) message for this subscription, measured by the time elapsed
+     * from its published time, in seconds. This value is recorded every backlog quota check interval, hence it
+     * represents the value seen in the last check.
+     * </p>
+     */
+    long getOldestBacklogMessageAgeSeconds();
+
     /** Number of entries in the subscription backlog that do not contain the delay messages. */
     long getMsgBacklogNoDelayed();
 

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/SubscriptionStats.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/SubscriptionStats.java
@@ -65,7 +65,9 @@ public interface SubscriptionStats {
      * represents the value seen in the last check.
      * </p>
      */
-    long getOldestBacklogMessageAgeSeconds();
+    default long getOldestBacklogMessageAgeSeconds() {
+        return -1;
+    }
 
     /** Number of entries in the subscription backlog that do not contain the delay messages. */
     long getMsgBacklogNoDelayed();

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/SubscriptionStatsImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/SubscriptionStatsImpl.java
@@ -65,6 +65,16 @@ public class SubscriptionStatsImpl implements SubscriptionStats {
     /** Get the publish time of the earliest message in the backlog. */
     public long earliestMsgPublishTimeInBacklog;
 
+    /**
+     * Age of oldest unacknowledged message, as recorded in last backlog quota check interval.
+     * <p>
+     * The age of the oldest unacknowledged (i.e. backlog) message for this subscription, measured by the time elapsed
+     * from its published time, in seconds. This value is recorded every backlog quota check interval, hence it
+     * represents the value seen in the last check.
+     * </p>
+     */
+    public long oldestBacklogMessageAgeSeconds = -1;
+
     /** Number of entries in the subscription backlog that do not contain the delay messages. */
     public long msgBacklogNoDelayed;
 
@@ -224,6 +234,7 @@ public class SubscriptionStatsImpl implements SubscriptionStats {
         nonContiguousDeletedMessagesRanges = 0;
         nonContiguousDeletedMessagesRangesSerializedSize = 0;
         earliestMsgPublishTimeInBacklog = 0L;
+        oldestBacklogMessageAgeSeconds = -1;
         delayedMessageIndexSizeInBytes = 0;
         subscriptionProperties.clear();
         filterProcessedMsgCount = 0;
@@ -290,6 +301,8 @@ public class SubscriptionStatsImpl implements SubscriptionStats {
                     stats.earliestMsgPublishTimeInBacklog
             );
         }
+        this.oldestBacklogMessageAgeSeconds = Math.max(
+                this.oldestBacklogMessageAgeSeconds, stats.oldestBacklogMessageAgeSeconds);
         this.delayedMessageIndexSizeInBytes += stats.delayedMessageIndexSizeInBytes;
         this.subscriptionProperties.putAll(stats.subscriptionProperties);
         this.filterProcessedMsgCount += stats.filterProcessedMsgCount;

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/SubscriptionStatsImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/SubscriptionStatsImpl.java
@@ -66,11 +66,11 @@ public class SubscriptionStatsImpl implements SubscriptionStats {
     public long earliestMsgPublishTimeInBacklog;
 
     /**
-     * Age of oldest unacknowledged message, as recorded in last backlog quota check interval.
+     * Age of oldest unacknowledged message for this subscription, in seconds.
      * <p>
-     * The age of the oldest unacknowledged (i.e. backlog) message for this subscription, measured by the time elapsed
-     * from its published time, in seconds. This value is recorded every backlog quota check interval, hence it
-     * represents the value seen in the last check.
+     * This is a best-effort cached value from the broker's periodic subscription backlog-age refresh. The value is
+     * {@code -1} when it is unknown, not applicable, the subscription has no backlog, or the broker has disabled
+     * subscription backlog-age computation.
      * </p>
      */
     public long oldestBacklogMessageAgeSeconds = -1;

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/stats/SubscriptionStatsImplTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/stats/SubscriptionStatsImplTest.java
@@ -27,8 +27,10 @@ public class SubscriptionStatsImplTest {
     public void testReset() {
         SubscriptionStatsImpl stats = new SubscriptionStatsImpl();
         stats.earliestMsgPublishTimeInBacklog = 1L;
+        stats.oldestBacklogMessageAgeSeconds = 10L;
         stats.reset();
         assertEquals(stats.earliestMsgPublishTimeInBacklog, 0L);
+        assertEquals(stats.oldestBacklogMessageAgeSeconds, -1L);
 
     }
 
@@ -78,5 +80,20 @@ public class SubscriptionStatsImplTest {
 
         SubscriptionStatsImpl aggregate = stats1.add(stats2);
         assertEquals(aggregate.earliestMsgPublishTimeInBacklog, 0L);
+    }
+
+    @Test
+    public void testAdd_OldestBacklogMessageAgeSeconds() {
+        SubscriptionStatsImpl stats1 = new SubscriptionStatsImpl();
+        stats1.oldestBacklogMessageAgeSeconds = -1L;
+
+        SubscriptionStatsImpl stats2 = new SubscriptionStatsImpl();
+        stats2.oldestBacklogMessageAgeSeconds = 20L;
+
+        SubscriptionStatsImpl stats3 = new SubscriptionStatsImpl();
+        stats3.oldestBacklogMessageAgeSeconds = 10L;
+
+        SubscriptionStatsImpl aggregate = stats1.add(stats2).add(stats3);
+        assertEquals(aggregate.oldestBacklogMessageAgeSeconds, 20L);
     }
 }


### PR DESCRIPTION

### Motivation

Pulsar currently exposes `pulsar_storage_backlog_age_seconds` to report the age of the oldest unacknowledged message for a topic. This metric is useful for detecting consumer lag based on actual message age instead of only backlog size.

However, the metric is only available at the topic level. When a topic has multiple subscriptions, operators cannot tell which subscription is contributing to the backlog age. This is a common production case because different subscriptions on the same topic can have different latency expectations. Some subscriptions are expected to consume messages in real time, while others may intentionally retain backlog for a longer period.

Without a subscription-level backlog age metric, users have to either alert on the topic-level metric and tolerate false positives, or build complex Prometheus rules to exclude known slow subscriptions. This makes monitoring harder and less accurate.

This change adds `pulsar_subscription_storage_backlog_age_seconds`, allowing users to monitor backlog age per subscription and configure alerts based on each subscription's expected latency.

### Modifications

<!-- Describe the modifications you've done. -->

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment