### PR TITLE
[improve][misc] Upgrade Conscrypt to 2.6.1 to add aarch64 native support

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -261,7 +261,7 @@ The Apache Software License, Version 2.0
      - com.fasterxml.jackson.datatype-jackson-datatype-jsr310-2.21.5.jar
      - com.fasterxml.jackson.module-jackson-module-parameter-names-2.21.5.jar
  * Caffeine -- com.github.ben-manes.caffeine-caffeine-3.2.4.jar
- * Conscrypt -- org.conscrypt-conscrypt-openjdk-uber-2.5.2.jar
+ * Conscrypt -- org.conscrypt-conscrypt-openjdk-uber-2.6.1.jar
  * Fastutil -- it.unimi.dsi:fastutil (only the classes used by Pulsar, bundled within pulsar-broker-fastutil-minimized)
  * LMAX Disruptor -- com.lmax-disruptor-4.0.0.jar
  * Proto Google Common Protos -- com.google.api.grpc-proto-google-common-protos-2.63.2.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -325,7 +325,7 @@ The Apache Software License, Version 2.0
      - jackson-datatype-jsr310-2.21.5.jar
      - jackson-module-parameter-names-2.21.5.jar
  * Caffeine -- caffeine-3.2.4.jar
- * Conscrypt -- conscrypt-openjdk-uber-2.5.2.jar
+ * Conscrypt -- conscrypt-openjdk-uber-2.6.1.jar
  * Gson
     - gson-2.13.2.jar
  * Guava

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -67,7 +67,7 @@ snakeyaml = "2.6"
 vertx = "4.5.28"
 # Networking / HTTP
 asynchttpclient = "3.0.10"
-conscrypt = "2.5.2"
+conscrypt = "2.6.1"
 okhttp3 = "5.3.2"
 okio = "3.17.0"
 netty-tcnative = "2.0.81.Final"

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/SecurityUtility.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/SecurityUtility.java
@@ -68,7 +68,6 @@ import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import lombok.CustomLog;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.pulsar.common.classification.InterfaceAudience;
 import org.apache.pulsar.common.tls.TlsHostnameVerifier;
 
 /**
@@ -161,10 +160,11 @@ public class SecurityUtility {
         //
         // more details of Conscrypt's hostname verification:
         // https://github.com/google/conscrypt/blob/master/IMPLEMENTATION_NOTES.md#hostname-verification
-        // there's a bug in Conscrypt while setting a custom HostnameVerifier,
-        // https://github.com/google/conscrypt/issues/1015 and therefore this solution alone
-        // isn't sufficient to configure Conscrypt's hostname verifier. The method processConscryptTrustManager
-        // contains the workaround.
+        //
+        // Setting the default is sufficient on its own since Conscrypt 2.6.0: TrustManagerImpl used to ignore
+        // the default verifier (https://github.com/google/conscrypt/issues/1015), which forced Pulsar to copy it
+        // onto every TrustManager instance, but https://github.com/google/conscrypt/pull/1060 made it fall back
+        // to the default, so that workaround has been removed.
         try {
             HostnameVerifier hostnameVerifier = new TlsHostnameVerifier();
             Object wrappedHostnameVerifier = conscryptClazz
@@ -394,53 +394,8 @@ public class SecurityUtility {
             }
 
             trustManagers = tmf.getTrustManagers();
-
-            for (TrustManager trustManager : trustManagers) {
-                processConscryptTrustManager(trustManager);
-            }
         }
         return trustManagers;
-    }
-
-    /***
-     * Conscrypt TrustManager instances will be configured to use the Pulsar {@link TlsHostnameVerifier}
-     * class.
-     * This method is used as a workaround for https://github.com/google/conscrypt/issues/1015
-     * when Conscrypt / OpenSSL is used as the TLS security provider.
-     *
-     * @param trustManagers the array of TrustManager instances to process.
-     * @return same instance passed as parameter
-     */
-    @InterfaceAudience.Private
-    public static TrustManager[] processConscryptTrustManagers(TrustManager[] trustManagers) {
-        for (TrustManager trustManager : trustManagers) {
-            processConscryptTrustManager(trustManager);
-        }
-        return trustManagers;
-    }
-
-    // workaround https://github.com/google/conscrypt/issues/1015
-    private static void processConscryptTrustManager(TrustManager trustManager) {
-        if (trustManager.getClass().getName().equals("org.conscrypt.TrustManagerImpl")) {
-            try {
-                Class<?> conscryptClazz = Class.forName("org.conscrypt.Conscrypt");
-                Object hostnameVerifier = conscryptClazz.getMethod("getHostnameVerifier",
-                        new Class<?>[]{TrustManager.class}).invoke(null, trustManager);
-                if (hostnameVerifier == null) {
-                    Object defaultHostnameVerifier = conscryptClazz.getMethod("getDefaultHostnameVerifier",
-                            new Class<?>[]{TrustManager.class}).invoke(null, trustManager);
-                    if (defaultHostnameVerifier != null) {
-                        conscryptClazz.getMethod("setHostnameVerifier", new Class<?>[]{
-                                TrustManager.class,
-                                Class.forName("org.conscrypt.ConscryptHostnameVerifier")
-                        }).invoke(null, trustManager, defaultHostnameVerifier);
-                    }
-                }
-            } catch (ReflectiveOperationException e) {
-                log.warn().exception(e)
-                        .log("Unable to set hostname verifier for Conscrypt TrustManager implementation");
-            }
-        }
     }
 
     public static X509Certificate[] loadCertificatesFromPemFile(String certFilePath) throws KeyManagementException {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/keystoretls/KeyStoreSSLContext.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/keystoretls/KeyStoreSSLContext.java
@@ -170,7 +170,7 @@ public class KeyStoreSSLContext {
 
         TrustManager[] trustManagers = null;
         if (trustManagerFactory != null) {
-            trustManagers = SecurityUtility.processConscryptTrustManagers(trustManagerFactory.getTrustManagers());
+            trustManagers = trustManagerFactory.getTrustManagers();
         }
 
         // init

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/tls/JcaProviders.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/tls/JcaProviders.java
@@ -28,7 +28,6 @@ import java.util.Optional;
 import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.TrustManager;
 import lombok.CustomLog;
 import org.apache.commons.lang3.StringUtils;
 
@@ -297,16 +296,17 @@ public final class JcaProviders {
 
         // Unlike the PIP-337 loader this one installs NO custom hostname verifier, so Conscrypt keeps its
         // built-in default: standard RFC 2818 (SAN-based) verification, matching PIP-478's removal of the
-        // deprecated CN-based matching. The bug-1015 workaround in processConscryptTrustManager propagates
-        // whatever Conscrypt's DEFAULT verifier is onto each TrustManager.
+        // deprecated CN-based matching. Since Conscrypt 2.6.0 a TrustManagerImpl falls back to the default
+        // verifier on its own (https://github.com/google/conscrypt/pull/1060 fixing issue 1015), so nothing
+        // has to be propagated onto the individual trust managers.
         //
         // CAVEAT while both TLS stacks coexist: Conscrypt.setDefaultHostnameVerifier is process-global, and
         // SecurityUtility's static initializer (still the wired PIP-337 path) sets it to the CN-tolerant
-        // TlsHostnameVerifier. Whenever that class has been loaded, the "default" propagated above is that
-        // relaxed verifier, not Conscrypt's own. Nothing routes through this class yet so no deployment is
-        // affected today; the PR that turns SAN-only hostname verification on by default must neutralize that
-        // global (or land together with SecurityUtility's removal) for the SAN-only guarantee to hold on a
-        // Conscrypt-pinned deployment.
+        // TlsHostnameVerifier. Whenever that class has been loaded, that relaxed verifier — not Conscrypt's
+        // own — is the default the trust managers fall back to. Nothing routes through this class yet so no
+        // deployment is affected today; the PR that turns SAN-only hostname verification on by default must
+        // neutralize that global (or land together with SecurityUtility's removal) for the SAN-only guarantee
+        // to hold on a Conscrypt-pinned deployment.
 
         Security.addProvider(provider);
         log.debug().attr("provider", provider.getName()).attr("class", CONSCRYPT_PROVIDER_CLASS)
@@ -452,44 +452,4 @@ public final class JcaProviders {
         return provider;
     }
 
-    /**
-     * Ensures each Conscrypt {@link TrustManager} performs standard SAN-based (RFC 2818) hostname verification by
-     * propagating Conscrypt's default {@code ConscryptHostnameVerifier} onto the trust manager instance. This is a
-     * workaround for https://github.com/google/conscrypt/issues/1015, where a Conscrypt {@code TrustManagerImpl}
-     * obtained through the standard JSSE {@link javax.net.ssl.TrustManagerFactory} does not automatically pick up
-     * the default hostname verifier, when Conscrypt / OpenSSL is used as the TLS security provider.
-     *
-     * @param trustManagers the array of TrustManager instances to process.
-     * @return same instance passed as parameter
-     */
-    static TrustManager[] processConscryptTrustManagers(TrustManager[] trustManagers) {
-        for (TrustManager trustManager : trustManagers) {
-            processConscryptTrustManager(trustManager);
-        }
-        return trustManagers;
-    }
-
-    // workaround https://github.com/google/conscrypt/issues/1015
-    private static void processConscryptTrustManager(TrustManager trustManager) {
-        if (trustManager.getClass().getName().equals("org.conscrypt.TrustManagerImpl")) {
-            try {
-                Class<?> conscryptClazz = Class.forName("org.conscrypt.Conscrypt");
-                Object hostnameVerifier = conscryptClazz.getMethod("getHostnameVerifier",
-                        new Class<?>[]{TrustManager.class}).invoke(null, trustManager);
-                if (hostnameVerifier == null) {
-                    Object defaultHostnameVerifier = conscryptClazz.getMethod("getDefaultHostnameVerifier",
-                            new Class<?>[]{TrustManager.class}).invoke(null, trustManager);
-                    if (defaultHostnameVerifier != null) {
-                        conscryptClazz.getMethod("setHostnameVerifier", new Class<?>[]{
-                                TrustManager.class,
-                                Class.forName("org.conscrypt.ConscryptHostnameVerifier")
-                        }).invoke(null, trustManager, defaultHostnameVerifier);
-                    }
-                }
-            } catch (ReflectiveOperationException e) {
-                log.warn().exception(e)
-                        .log("Unable to set hostname verifier for Conscrypt TrustManager implementation");
-            }
-        }
-    }
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/tls/JdkSslContexts.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/tls/JdkSslContexts.java
@@ -316,7 +316,7 @@ public final class JdkSslContexts {
             tmf.init(ksh.getKeyStore());
         }
 
-        return JcaProviders.processConscryptTrustManagers(tmf.getTrustManagers());
+        return tmf.getTrustManagers();
     }
 
     /**


### PR DESCRIPTION
### Motivation

`org.conscrypt:conscrypt-openjdk-uber` has been pinned at 2.5.2, which ships natives for only four platforms and **none for aarch64**:

```
2.5.2: conscrypt_openjdk_jni-windows-x86.dll
       conscrypt_openjdk_jni-windows-x86_64.dll
       libconscrypt_openjdk_jni-linux-x86_64.so
       libconscrypt_openjdk_jni-osx-x86_64.dylib
```

This matters more than it looks, because Conscrypt is a **shipped default**, not an opt-in: `webServiceTlsProvider=Conscrypt` in `conf/broker.conf`, `conf/proxy.conf` and `conf/standalone.conf`, and `tlsProvider=Conscrypt` in `conf/websocket.conf`.

On ARM64 that default has never been honoured. `Conscrypt.checkAvailability()` throws `UnsatisfiedLinkError`, the provider is never registered, and `SecurityUtility.resolveProvider` silently substitutes the JDK default:

```java
provider = Security.getProvider(providerName);   // null - Conscrypt never registered
if (provider == null) {
    provider = SSLContext.getDefault().getProvider();
}
```

The fallback is logged at `DEBUG` only, so ARM64 operators get the JDK JSSE provider while their configuration says Conscrypt, with no indication anything was substituted.

Conscrypt 2.6.0 adds `linux-aarch_64` and `osx-aarch_64` natives, which fixes this. Two secondary reasons to move now:

- **Jetty already expects 2.6.0.** `jetty-project:12.1.12` declares `<conscrypt.version>2.6.0</conscrypt.version>`, so our catalog pin was *downgrading* Jetty's dependency to 2.5.2. After this change it upgrades it to 2.6.1 instead.
- **The `google/conscrypt#1015` workaround becomes dead code.** Conscrypt 2.6.0 includes google/conscrypt#1060, which fixes that bug upstream.

### Modifications

**1. Bump the version catalog** — `conscrypt = "2.5.2"` → `"2.6.1"`, plus the jar name in both `LICENSE.bin.txt` files (server and shell use different naming conventions, both updated).

**2. Remove the obsolete `google/conscrypt#1015` workaround.** Pulsar sets a process-global CN-tolerant hostname verifier via `Conscrypt.setDefaultHostnameVerifier(...)`, but under 2.5.2 `TrustManagerImpl` ignored it, so Pulsar had to copy it onto every `TrustManager` instance by hand. google/conscrypt#1060 added the missing fallback. Comparing `TrustManagerImpl.getHttpsVerifier()` — the sole consumer of that field — across the two jars:

| | 2.5.2 | 2.6.1 |
|---|---|---|
| `getHttpsVerifier()` | `hostnameVerifier` → `Platform.getDefaultHostnameVerifier()` | `hostnameVerifier` → **`defaultHostnameVerifier`** → `Platform.getDefaultHostnameVerifier()` |

2.5.2 never reads the static `defaultHostnameVerifier` field; 2.6.1 does. So `processConscryptTrustManager(s)` is removed from both `SecurityUtility` (the wired PIP-337 path) and `JcaProviders` (the PIP-478 path), along with the two call sites in `KeyStoreSSLContext` and `JdkSslContexts`. The `setDefaultHostnameVerifier` call itself is **kept** — that is what installs the verifier; only the redundant per-instance propagation is gone.

Net: **+18 / −103**.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests — 138 TLS tests in `pulsar-common` (`JcaProvidersTest`, `JdkSslContextsTest`, `JcaProviderPinningTest`, `DefaultPulsarSslFactoryTest`, `FileBasedTlsFactoryTest`, keystore-TLS) and 37 in `pulsar-broker-common`, all green before and after the removal. `./gradlew sanityCheck` is green across all 582 tasks, which also confirms nothing outside `pulsar-common` referenced the removed `public` method.

`./gradlew checkBinaryLicense` passes for both distributions. As a negative control, reverting just the server `LICENSE.bin.txt` line to 2.5.2 fails as expected — which confirms both that the check is real and that 2.6.1 is the version actually resolved and bundled:

```
org.conscrypt-conscrypt-openjdk-uber-2.6.1.jar unaccounted for in LICENSE
org.conscrypt-conscrypt-openjdk-uber-2.5.2.jar mentioned in LICENSE, but not bundled
```

The API surface was verified rather than assumed: Pulsar reaches Conscrypt **reflectively**, so the compiler cannot catch breakage. All reflectively-referenced members still resolve in 2.6.1 with identical signatures (`checkAvailability`, `wrapHostnameVerifier`, `set`/`getDefaultHostnameVerifier`, `set`/`getHostnameVerifier`, plus `OpenSSLProvider` and `TrustManagerImpl`).

The `#1015` fix was also confirmed at runtime — same JVM, only the jar swapped, workaround deliberately not applied:

```
conscrypt 2.5.2 -> EFFECTIVE getHttpsVerifier() = org.conscrypt.OkHostnameVerifier@32e6e9c3
                   default verifier honoured WITHOUT workaround = false
conscrypt 2.6.1 -> EFFECTIVE getHttpsVerifier() = PULSAR_CUSTOM_VERIFIER
                   default verifier honoured WITHOUT workaround = true
```

Native loading was smoke-tested in Pulsar's actual container base images (load + `SSLContext` + TLSv1.3):

| Image | 2.5.2 | 2.6.1 |
|---|---|---|
| Alpine arm64 (musl + `gcompat`) | `UnsatisfiedLinkError` | OK |
| Alpine x86_64 (musl + `gcompat`) | OK | OK |
| Wolfi arm64 (glibc 2.43) | not run (no aarch64 native in 2.5.2) | OK |
| Ubuntu 20.04 x86_64 (glibc 2.31) | OK | `GLIBC_2.35' not found` |

### Notes for reviewers

Three consequences of the upgrade that are worth an explicit decision:

**1. glibc 2.35 floor on `linux-x86_64` (tarball installs only).** The 2.6.1 `linux-x86_64` native references `_dl_find_object@GLIBC_2.35` (2.5.2 topped out at 2.14). On glibc < 2.35 hosts — Ubuntu 20.04, Debian 11, RHEL/CentOS 8, Amazon Linux 2 — Conscrypt now fails to load and TLS falls back to the JDK provider. This is a **silent performance degradation, not an outage**: the fallback shown in the Motivation section keeps TLS working, and the failure is logged at `DEBUG`. Worth a release note.

Both shipped Docker images are unaffected: Wolfi has glibc 2.43, and the Alpine image already installs `gcompat` with `LD_PRELOAD=/lib/libgcompat.so.0`, under which the native loads fine on both architectures (verified above). The `linux-aarch_64` native tops out at `GLIBC_2.34`, so the floor is x86_64-only.

**2. Hostname verification becomes more lenient in code paths Pulsar does not own.** This follows from the upgrade itself, not from the workaround removal. `setDefaultHostnameVerifier` is process-global. Under 2.5.2 that global was inert, so Pulsar's CN-tolerant `TlsHostnameVerifier` only reached the `TrustManager`s Pulsar explicitly post-processed. Under 2.6.1 *every* Conscrypt `TrustManagerImpl` in the JVM falls back to it — including ones created by Jetty, connectors or offloaders, which previously got Conscrypt's stricter SAN-only `OkHostnameVerifier`. Removing the workaround is behaviour-neutral here; keeping it would not prevent the widening. Flagging it because it runs opposite to PIP-478's move to SAN-only verification, so it may deserve a follow-up.

**3. Smaller packaging notes.** The uber jar grows ~9.7 MB → ~14 MB (`docker/pulsar/build-scripts/remove-unnecessary-native-binaries.sh` prunes netty-tcnative and RocksDB but not Conscrypt — could be a follow-up). 32-bit Windows (`windows-x86`) loses Conscrypt, as 2.6.0 dropped that native. 2.5.2 was a signed jar and 2.6.1 is not. The bytecode floor rises from Java 7 to Java 8, well under Pulsar's minimum. No new license obligations: neither jar bundles a `META-INF/LICENSE` or `NOTICE`, and BoringSSL was already statically embedded in 2.5.2.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [x] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [x] Anything that affects deployment

**Dependencies:** `org.conscrypt:conscrypt-openjdk-uber` 2.5.2 → 2.6.1.

**Deployment:** ARM64 deployments start actually using Conscrypt where they previously fell back to the JDK provider, and tarball installs on glibc < 2.35 now fall back where they previously used Conscrypt. See *Notes for reviewers*.

**Public API:** `SecurityUtility.processConscryptTrustManagers` was `public` but annotated `@InterfaceAudience.Private`, so its removal is not a public-API break under Pulsar's compatibility policy. `sanityCheck` confirms it had no callers outside `pulsar-common`.
