### PR TITLE
[fix][test] Fix flaky AuditorPeriodicCheckTest.testFailedWriteRecovery

### DIFF
--- a/pulsar-metadata/src/test/java/org/apache/bookkeeper/replication/AuditorPeriodicCheckTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/bookkeeper/replication/AuditorPeriodicCheckTest.java
@@ -960,7 +960,8 @@ public class AuditorPeriodicCheckTest extends BookKeeperClusterTestCase {
         }
     }
 
-    private BookieId replaceBookieWithWriteFailingBookie(LedgerHandle lh) throws Exception {
+    private BookieId replaceBookieWithWriteFailingBookie(LedgerHandle lh, CountDownLatch releaseWriteFailures)
+            throws Exception {
         int bookieIdx = -1;
         Long entryId = lh.getLedgerMetadata().getAllEnsembles().firstKey();
         List<BookieId> curEnsemble = lh.getLedgerMetadata().getAllEnsembles().get(entryId);
@@ -985,11 +986,13 @@ public class AuditorPeriodicCheckTest extends BookKeeperClusterTestCase {
                     throws IOException, BookieException {
                 try {
                     log.info("Failing write to entry ");
-                    // sleep a bit so that writes to other bookies succeed before
-                    // the client hears about the failure on this bookie. If the
-                    // client gets ack-quorum number of acks first, it won't care
-                    // about any failures and won't reform the ensemble.
-                    Thread.sleep(100);
+                    // Hold the failure back until the test has the ack-quorum number of acks from the
+                    // other bookies. The add operation is complete by then, so the client won't care
+                    // about this failure and won't reform the ensemble. Reporting it any earlier makes
+                    // the client replace this bookie, and the ledger never becomes under replicated.
+                    // The wait is bounded so that a stalled test cannot block this bookie thread
+                    // indefinitely; the write is failed either way.
+                    releaseWriteFailures.await(30, TimeUnit.SECONDS);
                     throw new IOException();
                 } catch (InterruptedException ie) {
                     // ignore, only interrupted if shutting down,
@@ -1015,29 +1018,36 @@ public class AuditorPeriodicCheckTest extends BookKeeperClusterTestCase {
 
         // kill one of the bookies and replace it with one that rejects write;
         // This way we get into the under replication state
-        BookieId replacedBookie = replaceBookieWithWriteFailingBookie(lh);
+        CountDownLatch releaseWriteFailures = new CountDownLatch(1);
+        BookieId replacedBookie = replaceBookieWithWriteFailingBookie(lh, releaseWriteFailures);
 
-        // Write a few entries; this should cause under replication
+        // Write a few entries; this should cause under replication. Each add completes as soon as the
+        // remaining bookie acknowledges it, since the ack quorum is 1.
         byte[] data = "foobar".getBytes();
-        data = "foobar".getBytes();
         lh.addEntry(data);
         lh.addEntry(data);
         lh.addEntry(data);
+
+        // All the adds are complete now, so letting the writes fail can no longer trigger an ensemble
+        // change: the failures are recorded as delayed write failures, and those are only acted upon
+        // when a subsequent entry is added, which this test doesn't do.
+        releaseWriteFailures.countDown();
 
         lh.close();
+
+        // The closed ledger must still list the write failing bookie in its ensemble. If the client
+        // reformed the ensemble instead, the entries were rewritten to a healthy bookie and the ledger
+        // never becomes under replicated, so the rest of this test would be meaningless.
+        assertTrue("Write failing bookie was replaced in the ensemble",
+                lh.getLedgerMetadata().getAllEnsembles().values().stream()
+                        .anyMatch(ensemble -> ensemble.contains(replacedBookie)));
 
         // enable under replication detection and wait for it to report
         // under replicated ledger
         underReplicationManager.enableLedgerReplication();
-        long underReplicatedLedger = -1;
-        for (int i = 0; i < 5; i++) {
-            underReplicatedLedger = underReplicationManager.pollLedgerToRereplicate();
-            if (underReplicatedLedger != -1) {
-                break;
-            }
-            Thread.sleep(CHECK_INTERVAL * 1000);
-        }
-        assertEquals("Ledger should be under replicated", lh.getId(), underReplicatedLedger);
+        Awaitility.await().atMost(30, TimeUnit.SECONDS).untilAsserted(() ->
+                assertEquals("Ledger should be under replicated", lh.getId(),
+                        underReplicationManager.pollLedgerToRereplicate()));
 
         // now start the replication workers
         List<ReplicationWorker> l = new ArrayList<ReplicationWorker>();


### PR DESCRIPTION
### Motivation

`AuditorPeriodicCheckTest.testFailedWriteRecovery` fails intermittently in CI with:

```
java.lang.AssertionError: Ledger should be under replicated expected:<0> but was:<-1>
	at org.apache.bookkeeper.replication.AuditorPeriodicCheckTest.testFailedWriteRecovery(AuditorPeriodicCheckTest.java:1040)
```

Example: [Pulsar CI / CI - Unit - Pulsar Metadata](https://github.com/apache/pulsar/actions/runs/31613924786/job/94173513846). It failed on both the original attempt and the CI retry in that run, so it is not a rare race — the runner was simply slow enough to lose the timing bet described below every time.

The test creates a `(ensembleSize=2, writeQuorum=2, ackQuorum=1)` ledger, kills one ensemble bookie and replaces it with a bookie whose `addEntry` sleeps 100ms and then throws `IOException`. The existing comment explains the intent:

> sleep a bit so that writes to other bookies succeed before the client hears about the failure on this bookie. If the client gets ack-quorum number of acks first, it won't care about any failures and won't reform the ensemble.

That intent is correct, but 100ms of wall clock is not a reliable way to achieve it. In `PendingAddOp.writeComplete`, a bookie error is only harmless once the add has completed: the `completed == true` branch just records the failure via `LedgerHandle.notifyWriteFailed`, whereas an error arriving earlier falls through to `lh.handleBookieFailure(...)`, which reforms the ensemble.

On the CI runner the first write to the surviving bookie (fresh connection plus a cold journal fsync) took longer than 100ms, so the failure arrived first:

```
15:58:04,895 PendingAddOp  - Failed to write entry to bookie {bookieAddr=127.0.0.1:45937, entryId=0}
15:58:04,914 LedgerHandle  - New Ensemble {ledgerId=0, newEnsemble=[127.0.0.1:43561, 127.0.0.1:34849]}
```

Because the failure hit while `lastAddConfirmed` was still -1, the ensemble change *replaced* the ledger's only ensemble instead of appending a fragment. The write-failing bookie was no longer part of the ledger at all and the entries had been rewritten to a healthy bookie, so the ledger was fully replicated. The auditor's periodic check had nothing to report and `pollLedgerToRereplicate()` correctly returned -1 until the test gave up. In other words, when the machine is slow the test silently stops testing anything and then fails on an assertion that points away from the real cause.

This is a test bug, not a product bug — no broker or BookKeeper client behaviour is at fault.

Note: this test was migrated from BookKeeper in #21188, and the same pattern is still present upstream — `AuditorPeriodicCheckTest$5` in `bookkeeper-server-4.18.0-tests.jar` contains the identical `Thread.sleep(100)` followed by `throw new IOException()`. I will report it there separately. No other test in this repository uses this pattern (this is the only `addEntry(ByteBuf ...)` override in the tree).

### Modifications

`pulsar-metadata/src/test/java/org/apache/bookkeeper/replication/AuditorPeriodicCheckTest.java`:

1. **Replaced the timing bet with an explicit handshake.** The write-failing bookie now blocks on a `CountDownLatch` that the test counts down only after all three `lh.addEntry()` calls have returned — that is, after ack quorum has been met for every entry. Each failure is therefore reported when `PendingAddOp.completed` is already `true`, so it is recorded as a delayed write failure instead of triggering an ensemble change. Delayed write failures are only drained by `LedgerHandle.maybeHandleDelayedWriteBookieFailure()`, whose single caller is `PendingAddOp.initiate()`, and this test adds no further entries — `lh.close()` does not add one. The outcome no longer depends on how fast the surviving bookie is. The latch wait is bounded at 30s so that a test that fails before the countdown cannot leave a bookie thread parked indefinitely; the write fails either way.

2. **Added an assertion pinning the precondition.** After the ledger is closed, its metadata must still list the write-failing bookie in an ensemble. This is the invariant whose violation caused the CI failure, so a regression now reports `Write failing bookie was replaced in the ensemble` instead of the misleading `expected:<0> but was:<-1>`. The check is `anyMatch` over all ensembles on purpose: an ensemble change taken once `lastAddConfirmed >= 0` appends a fragment and leaves the original ensemble (and hence the missing entries) in place, which is still a valid run of this test — only the LAC == -1 replacement, the case that actually broke CI, invalidates it.

3. **Widened the detection wait**, which was a second, smaller gap: the hand-rolled loop allowed only 5 polls at 1s (about 4-5s), whereas the sibling tests in this file allow 10 and 15 iterations for the same auditor. It is now `Awaitility.await().atMost(30, TimeUnit.SECONDS).untilAsserted(...)`, which also keeps the original assertion message on timeout. This is a robustness improvement, not the root-cause fix.

Also removed a duplicated `data = "foobar".getBytes();` statement in the lines being rewritten.

### Verifying this change

This change is a fix to an existing test; it is verified by that test.

- **Reproduced the CI failure locally** before changing anything: setting the injected sleep to 0 (removing the timing margin the test depended on) produces exactly the CI assertion, `Ledger should be under replicated expected:<0> but was:<-1>`.
- **Mutation-tested the fix in both directions.** With the fix in place, moving `releaseWriteFailures.countDown()` to *before* the adds — which reproduces the CI ordering — fails on the new assertion with `Write failing bookie was replaced in the ensemble`; restoring the correct order passes. This shows the ordering, rather than a longer delay, is what makes the test deterministic, and that the new assertion actually catches the regression it is meant to catch.
- 15 consecutive invocations of `testFailedWriteRecovery` green (verified from the results XML: 15 `<testcase>` entries, zero `<failure>`/`<error>`).
- The full `AuditorPeriodicCheckTest` class passes.
- `./gradlew spotlessCheck checkstyleMain checkstyleTest` passes.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

- [ ] `doc-not-needed`

Test-only change.
