### PR TITLE
[fix][sec] Pin httpclient5 to 5.6.4 and httpcore5 to 5.4.3

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -73,6 +73,8 @@ okio = "3.17.0"
 netty-tcnative = "2.0.81.Final"
 httpcomponents-httpclient = "4.5.14"
 httpcomponents-httpcore = "4.4.16"
+httpcomponents-httpclient5 = "5.6.4"
+httpcomponents-httpcore5 = "5.4.3"
 # Pinned so that async-http-client's 1.0.3 dependency does not downgrade it
 reactive-streams = "1.0.4"
 # Google libraries (transitive deps)
@@ -358,6 +360,9 @@ okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
 httpcomponents-httpclient = { module = "org.apache.httpcomponents:httpclient", version.ref = "httpcomponents-httpclient" }
 reactive-streams = { module = "org.reactivestreams:reactive-streams", version.ref = "reactive-streams" }
 httpcomponents-httpcore = { module = "org.apache.httpcomponents:httpcore", version.ref = "httpcomponents-httpcore" }
+httpcomponents-httpclient5 = { module = "org.apache.httpcomponents.client5:httpclient5", version.ref = "httpcomponents-httpclient5" }
+httpcomponents-httpcore5 = { module = "org.apache.httpcomponents.core5:httpcore5", version.ref = "httpcomponents-httpcore5" }
+httpcomponents-httpcore5-h2 = { module = "org.apache.httpcomponents.core5:httpcore5-h2", version.ref = "httpcomponents-httpcore5" }
 jakarta-annotation-api = { module = "jakarta.annotation:jakarta.annotation-api", version.ref = "jakarta-annotation" }
 snakeyaml = { module = "org.yaml:snakeyaml", version.ref = "snakeyaml" }
 ant = { module = "org.apache.ant:ant", version.ref = "ant" }


### PR DESCRIPTION
### Motivation

Apache HttpComponents 5 enters the build transitively through `com.yahoo.athenz:athenz-zts-java-client:1.12.42`, which is a dependency of the two Athenz auth plugins (`pulsar-client-auth-athenz`, `pulsar-broker-auth-athenz`).

It requested versions that are affected by published CVEs:

| Artifact | Resolved before | Requested by | CVE |
|---|---|---|---|
| `org.apache.httpcomponents.client5:httpclient5` | 5.6.1 | `athenz-zts-java-client:1.12.42` | CVE-2026-64607 |
| `org.apache.httpcomponents.core5:httpcore5` | 5.4 | `httpclient5-parent:5.6.1` | CVE-2026-54428, CVE-2026-54399 |
| `org.apache.httpcomponents.core5:httpcore5-h2` | 5.4 | `httpclient5-parent:5.6.1` | (same release train as `httpcore5`) |

Neither artifact had a version catalog entry, so nothing constrained them and the transitive request won.

Note this is distinct from the HttpComponents **4.x** artifacts (`org.apache.httpcomponents:httpclient` / `:httpcore`), which are already pinned in the catalog and are **not** changed here.

### Modifications

Added version catalog entries for the three artifacts in `gradle/libs.versions.toml`:

```toml
httpcomponents-httpclient5 = "5.6.4"
httpcomponents-httpcore5 = "5.4.3"
```
```toml
httpcomponents-httpclient5 = { module = "org.apache.httpcomponents.client5:httpclient5", version.ref = "httpcomponents-httpclient5" }
httpcomponents-httpcore5 = { module = "org.apache.httpcomponents.core5:httpcore5", version.ref = "httpcomponents-httpcore5" }
httpcomponents-httpcore5-h2 = { module = "org.apache.httpcomponents.core5:httpcore5-h2", version.ref = "httpcomponents-httpcore5" }
```

That is the entire change. The `pulsar-dependencies` enforced platform iterates every catalog library and turns it into a version constraint (the Gradle equivalent of Maven's `dependencyManagement`), so adding the catalog entries pins the transitive resolution build-wide — no per-module dependency declarations are needed.

`httpcore5-h2` is pinned alongside `httpcore5` because `httpclient5` pulls it in and both ship from the same release train; pinning only `httpcore5` would have left `httpcore5-h2` behind on 5.4.

Both target versions are the newest stable releases in their respective lines on Maven Central (`5.7-alpha1` and `5.5-beta2` are pre-release).

**No LICENSE file changes are required.** The Athenz auth plugins are not bundled in any distribution, so no HttpComponents 5 jar ships in a binary distribution — see *Verifying this change* below.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a dependency version pin without new test coverage. It was verified as follows:

- **Resolution, build-wide.** Scanned every resolvable configuration in every project via an init script. The Athenz plugins are the only consumers, and all four classpaths (`compileClasspath`, `runtimeClasspath`, `testCompileClasspath`, `testRuntimeClasspath`) in both modules now resolve `httpclient5:5.6.4`, `httpcore5:5.4.3` and `httpcore5-h2:5.4.3`. `dependencyInsight` reports the selection reason as *"By constraint, Forced"*, over the `5.6.1` request from `athenz-zts-java-client`.

- **Compilation and tests.** `:pulsar-client-auth-athenz:test` and `:pulsar-broker-auth-athenz:test` pass against the pinned versions.

- **Binary LICENSE.** `checkBinaryLicense` passes for `:distribution:pulsar-server-distribution` and `:distribution:pulsar-shell-distribution` (the only two modules applying `pulsar.binary-license-check-conventions`). Inspecting the built tarballs directly confirms the reason: the server distribution ships only the 4.x artifacts (`httpclient-4.5.14.jar`, `httpcore-4.4.16.jar`, already listed in `LICENSE.bin.txt`) and no `httpclient5`/`httpcore5`/`httpcore5-h2` jar appears in either tarball.

- **`quickCheck`** and **`spotlessCheck checkstyleMain checkstyleTest`** pass.

For completeness: the other path by which HttpComponents 5 could reach a classpath is `org.apache.thrift:libthrift` via `distributedlog-core`, but a component metadata rule in `pulsar.java-conventions.gradle.kts` already strips those dependencies, so it is unaffected either way.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [x] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

`httpclient5` 5.6.1 → 5.6.4 and `httpcore5` / `httpcore5-h2` 5.4 → 5.4.3, both patch-level bumps within the same minor line, affecting only the Athenz auth plugin classpaths.
