### PR TITLE
[fix][broker] Cancel queued transaction snapshot recovery on topic close

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/AbstractSnapshotAbortedTxnProcessor.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/AbstractSnapshotAbortedTxnProcessor.java
@@ -27,7 +27,8 @@ import org.apache.pulsar.broker.service.BrokerServiceException;
 import org.apache.pulsar.broker.transaction.buffer.AbortedTxnProcessor;
 
 /**
- * Coordinates snapshot recovery and resource closure so resources remain available until recovery stops.
+ * Coordinates snapshot recovery and resource closure so resources remain available until processor-owned recovery
+ * work finishes.
  */
 abstract class AbstractSnapshotAbortedTxnProcessor implements AbortedTxnProcessor {
 
@@ -44,71 +45,94 @@ abstract class AbstractSnapshotAbortedTxnProcessor implements AbortedTxnProcesso
     private volatile State state = State.OPEN;
     private Future<?> recoveryTask;
     private CompletableFuture<Position> recoveryFuture = CompletableFuture.completedFuture(null);
-    private CompletableFuture<Void> recoveryStoppedFuture = CompletableFuture.completedFuture(null);
+    // Completes before the recovery result, so close waits only for processor-owned work.
+    private CompletableFuture<Void> recoveryWorkFinishedFuture = CompletableFuture.completedFuture(null);
     private final CompletableFuture<Void> closeFuture = new CompletableFuture<>();
 
-    protected AbstractSnapshotAbortedTxnProcessor(ScheduledExecutorService recoveryExecutor) {
+    AbstractSnapshotAbortedTxnProcessor(ScheduledExecutorService recoveryExecutor) {
         this.recoveryExecutor = recoveryExecutor;
     }
 
     @Override
-    public final synchronized CompletableFuture<Position> recoverFromSnapshot() {
-        if (this.state == State.CLOSED) {
-            return CompletableFuture.failedFuture(closedException());
+    public CompletableFuture<Position> recoverFromSnapshot() {
+        CompletableFuture<Position> newRecoveryFuture;
+        CompletableFuture<Void> newRecoveryWorkFinishedFuture;
+        RejectedExecutionException submissionFailure = null;
+        synchronized (this) {
+            if (this.state == State.CLOSED) {
+                return CompletableFuture.failedFuture(closedException());
+            }
+            if (!recoveryFuture.isDone()) {
+                return recoveryFuture.copy();
+            }
+            // Bind the task to this recovery attempt so a later retry cannot complete the wrong future.
+            newRecoveryFuture = new CompletableFuture<>();
+            newRecoveryWorkFinishedFuture = new CompletableFuture<>();
+            this.recoveryFuture = newRecoveryFuture;
+            this.recoveryWorkFinishedFuture = newRecoveryWorkFinishedFuture;
+            this.state = State.RECOVERY_QUEUED;
+            try {
+                this.recoveryTask = recoveryExecutor.submit(
+                        () -> runRecovery(newRecoveryFuture, newRecoveryWorkFinishedFuture));
+            } catch (RejectedExecutionException e) {
+                this.state = State.RECOVERY_FINISHED;
+                submissionFailure = e;
+            }
         }
-        if (!recoveryFuture.isDone()) {
-            return recoveryFuture.copy();
-        }
-        // Bind the task to this recovery attempt so a later retry cannot complete the wrong future.
-        CompletableFuture<Position> future = new CompletableFuture<>();
-        CompletableFuture<Void> stoppedFuture = new CompletableFuture<>();
-        this.recoveryFuture = future;
-        this.recoveryStoppedFuture = stoppedFuture;
-        this.state = State.RECOVERY_QUEUED;
-        try {
-            this.recoveryTask = recoveryExecutor.submit(() -> runRecovery(future, stoppedFuture));
-        } catch (RejectedExecutionException e) {
-            this.state = State.RECOVERY_FINISHED;
-            future.completeExceptionally(e);
-            stoppedFuture.complete(null);
+        if (submissionFailure != null) {
+            newRecoveryWorkFinishedFuture.complete(null);
+            newRecoveryFuture.completeExceptionally(submissionFailure);
         }
         // Do not let callers complete the internal recovery result.
-        return future.copy();
+        return newRecoveryFuture.copy();
     }
 
-    private void runRecovery(CompletableFuture<Position> future, CompletableFuture<Void> stoppedFuture) {
+    private void runRecovery(CompletableFuture<Position> recoveryResult,
+                             CompletableFuture<Void> recoveryWorkFinished) {
+        Position recoveredPosition = null;
+        Throwable recoveryFailure = null;
+        boolean closeWon = false;
         try {
             if (!tryStartRecovery()) {
-                future.completeExceptionally(closedException());
-                return;
-            }
-            Position recoveredPosition = doRecoverFromSnapshot(recoveryExecutor);
-            if (tryMarkRecoveryFinished()) {
-                future.complete(recoveredPosition);
+                closeWon = true;
             } else {
-                future.completeExceptionally(closedException());
+                recoveredPosition = doRecoverFromSnapshot(recoveryExecutor);
+                if (!tryMarkRecoveryFinished()) {
+                    closeWon = true;
+                }
             }
         } catch (Throwable throwable) {
-            future.completeExceptionally(tryMarkRecoveryFinished() ? throwable : closedException());
-        } finally {
-            stoppedFuture.complete(null);
+            if (tryMarkRecoveryFinished()) {
+                recoveryFailure = throwable;
+            } else {
+                closeWon = true;
+            }
+        }
+        recoveryWorkFinished.complete(null);
+        if (closeWon) {
+            failRecoveryAfterClose(recoveryResult);
+        } else if (recoveryFailure == null) {
+            recoveryResult.complete(recoveredPosition);
+        } else {
+            recoveryResult.completeExceptionally(recoveryFailure);
         }
     }
 
     /**
      * Recovers the processor state synchronously on the recovery executor thread.
+     * If closure wins while this method is running, its result is discarded and recovery fails as closed.
      *
      * @param executor executor used by recovery-related operations
      * @return the recovery position, or {@code null} when no snapshot exists
      */
-    protected abstract Position doRecoverFromSnapshot(ScheduledExecutorService executor) throws Exception;
+    abstract Position doRecoverFromSnapshot(ScheduledExecutorService executor) throws Exception;
 
-    protected final boolean isClosed() {
+    final boolean isClosed() {
         return this.state == State.CLOSED;
     }
 
     private synchronized boolean tryStartRecovery() {
-        if (this.state == State.CLOSED) {
+        if (this.state != State.RECOVERY_QUEUED) {
             return false;
         }
         this.state = State.RECOVERY_RUNNING;
@@ -116,7 +140,7 @@ abstract class AbstractSnapshotAbortedTxnProcessor implements AbortedTxnProcesso
     }
 
     private synchronized boolean tryMarkRecoveryFinished() {
-        if (this.state == State.CLOSED) {
+        if (this.state != State.RECOVERY_RUNNING) {
             return false;
         }
         this.state = State.RECOVERY_FINISHED;
@@ -124,29 +148,23 @@ abstract class AbstractSnapshotAbortedTxnProcessor implements AbortedTxnProcesso
     }
 
     @Override
-    public final CompletableFuture<Void> closeAsync() {
-        boolean recoveryOwnsFutureCompletion;
+    public CompletableFuture<Void> closeAsync() {
+        State previousState;
         CompletableFuture<Position> currentRecoveryFuture;
-        CompletableFuture<Void> currentRecoveryStoppedFuture;
+        CompletableFuture<Void> currentRecoveryWorkFinishedFuture;
         synchronized (this) {
             if (this.state == State.CLOSED) {
                 return closeFuture;
             }
-            State previousState = this.state;
+            previousState = this.state;
             this.state = State.CLOSED;
-            recoveryOwnsFutureCompletion = previousState == State.RECOVERY_RUNNING
-                    || previousState == State.RECOVERY_FINISHED;
             currentRecoveryFuture = this.recoveryFuture;
-            currentRecoveryStoppedFuture = this.recoveryStoppedFuture;
+            currentRecoveryWorkFinishedFuture = this.recoveryWorkFinishedFuture;
             if (this.recoveryTask != null && previousState == State.RECOVERY_QUEUED) {
                 this.recoveryTask.cancel(false);
             }
         }
-        if (!recoveryOwnsFutureCompletion) {
-            currentRecoveryFuture.completeExceptionally(closedException());
-            currentRecoveryStoppedFuture.complete(null);
-        }
-        currentRecoveryStoppedFuture.thenCompose(v -> closeResources())
+        currentRecoveryWorkFinishedFuture.thenCompose(v -> closeResources())
                 .whenComplete((v, throwable) -> {
                     if (throwable != null) {
                         closeFuture.completeExceptionally(throwable);
@@ -154,16 +172,26 @@ abstract class AbstractSnapshotAbortedTxnProcessor implements AbortedTxnProcesso
                         closeFuture.complete(null);
                     }
                 });
+        if (previousState == State.RECOVERY_QUEUED) {
+            failRecoveryAfterClose(currentRecoveryFuture);
+        }
+        if (previousState != State.RECOVERY_RUNNING) {
+            currentRecoveryWorkFinishedFuture.complete(null);
+        }
         return closeFuture;
     }
 
+    private void failRecoveryAfterClose(CompletableFuture<Position> recoveryResult) {
+        closeFuture.whenComplete((__, ___) -> recoveryResult.completeExceptionally(closedException()));
+    }
+
     /**
-     * Closes resources after recovery has stopped.
+     * Closes resources after processor-owned recovery work has finished.
      *
      * <p>This method may be invoked on the caller of {@link #closeAsync()} or on the recovery executor thread.
      * Implementations must not rely on thread affinity and should return without blocking.
      */
-    protected abstract CompletableFuture<Void> closeResources();
+    abstract CompletableFuture<Void> closeResources();
 
     private static BrokerServiceException closedException() {
         return new BrokerServiceException.ServiceUnitNotReadyException(

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/AbstractSnapshotAbortedTxnProcessor.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/AbstractSnapshotAbortedTxnProcessor.java
@@ -44,6 +44,7 @@ abstract class AbstractSnapshotAbortedTxnProcessor implements AbortedTxnProcesso
     private volatile State state = State.OPEN;
     private Future<?> recoveryTask;
     private CompletableFuture<Position> recoveryFuture = CompletableFuture.completedFuture(null);
+    private CompletableFuture<Void> recoveryStoppedFuture = CompletableFuture.completedFuture(null);
     private final CompletableFuture<Void> closeFuture = new CompletableFuture<>();
 
     protected AbstractSnapshotAbortedTxnProcessor(ScheduledExecutorService recoveryExecutor) {
@@ -60,19 +61,22 @@ abstract class AbstractSnapshotAbortedTxnProcessor implements AbortedTxnProcesso
         }
         // Bind the task to this recovery attempt so a later retry cannot complete the wrong future.
         CompletableFuture<Position> future = new CompletableFuture<>();
+        CompletableFuture<Void> stoppedFuture = new CompletableFuture<>();
         this.recoveryFuture = future;
+        this.recoveryStoppedFuture = stoppedFuture;
         this.state = State.RECOVERY_QUEUED;
         try {
-            this.recoveryTask = recoveryExecutor.submit(() -> runRecovery(future));
+            this.recoveryTask = recoveryExecutor.submit(() -> runRecovery(future, stoppedFuture));
         } catch (RejectedExecutionException e) {
             this.state = State.RECOVERY_FINISHED;
             future.completeExceptionally(e);
+            stoppedFuture.complete(null);
         }
-        // Do not expose the internal future used to determine when recovery has stopped.
+        // Do not let callers complete the internal recovery result.
         return future.copy();
     }
 
-    private void runRecovery(CompletableFuture<Position> future) {
+    private void runRecovery(CompletableFuture<Position> future, CompletableFuture<Void> stoppedFuture) {
         try {
             if (!tryStartRecovery()) {
                 future.completeExceptionally(closedException());
@@ -86,6 +90,8 @@ abstract class AbstractSnapshotAbortedTxnProcessor implements AbortedTxnProcesso
             }
         } catch (Throwable throwable) {
             future.completeExceptionally(tryMarkRecoveryFinished() ? throwable : closedException());
+        } finally {
+            stoppedFuture.complete(null);
         }
     }
 
@@ -121,6 +127,7 @@ abstract class AbstractSnapshotAbortedTxnProcessor implements AbortedTxnProcesso
     public final CompletableFuture<Void> closeAsync() {
         boolean recoveryOwnsFutureCompletion;
         CompletableFuture<Position> currentRecoveryFuture;
+        CompletableFuture<Void> currentRecoveryStoppedFuture;
         synchronized (this) {
             if (this.state == State.CLOSED) {
                 return closeFuture;
@@ -130,15 +137,16 @@ abstract class AbstractSnapshotAbortedTxnProcessor implements AbortedTxnProcesso
             recoveryOwnsFutureCompletion = previousState == State.RECOVERY_RUNNING
                     || previousState == State.RECOVERY_FINISHED;
             currentRecoveryFuture = this.recoveryFuture;
+            currentRecoveryStoppedFuture = this.recoveryStoppedFuture;
             if (this.recoveryTask != null && previousState == State.RECOVERY_QUEUED) {
                 this.recoveryTask.cancel(false);
             }
         }
         if (!recoveryOwnsFutureCompletion) {
             currentRecoveryFuture.completeExceptionally(closedException());
+            currentRecoveryStoppedFuture.complete(null);
         }
-        currentRecoveryFuture.handle((v, throwable) -> null)
-                .thenCompose(v -> closeResources())
+        currentRecoveryStoppedFuture.thenCompose(v -> closeResources())
                 .whenComplete((v, throwable) -> {
                     if (throwable != null) {
                         closeFuture.completeExceptionally(throwable);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/AbstractSnapshotAbortedTxnProcessor.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/AbstractSnapshotAbortedTxnProcessor.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.transaction.buffer.impl;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import org.apache.bookkeeper.mledger.Position;
+import org.apache.pulsar.broker.service.BrokerServiceException;
+import org.apache.pulsar.broker.transaction.buffer.AbortedTxnProcessor;
+
+/**
+ * Coordinates snapshot recovery and resource closure so resources remain available until recovery stops.
+ */
+abstract class AbstractSnapshotAbortedTxnProcessor implements AbortedTxnProcessor {
+
+    private enum State {
+        OPEN,
+        RECOVERY_QUEUED,
+        RECOVERY_RUNNING,
+        RECOVERY_FINISHED,
+        CLOSED
+    }
+
+    private final ScheduledExecutorService recoveryExecutor;
+
+    private volatile State state = State.OPEN;
+    private Future<?> recoveryTask;
+    private CompletableFuture<Position> recoveryFuture = CompletableFuture.completedFuture(null);
+    private final CompletableFuture<Void> closeFuture = new CompletableFuture<>();
+
+    protected AbstractSnapshotAbortedTxnProcessor(ScheduledExecutorService recoveryExecutor) {
+        this.recoveryExecutor = recoveryExecutor;
+    }
+
+    @Override
+    public final synchronized CompletableFuture<Position> recoverFromSnapshot() {
+        if (this.state == State.CLOSED) {
+            return CompletableFuture.failedFuture(closedException());
+        }
+        if (!recoveryFuture.isDone()) {
+            return recoveryFuture.copy();
+        }
+        // Bind the task to this recovery attempt so a later retry cannot complete the wrong future.
+        CompletableFuture<Position> future = new CompletableFuture<>();
+        this.recoveryFuture = future;
+        this.state = State.RECOVERY_QUEUED;
+        try {
+            this.recoveryTask = recoveryExecutor.submit(() -> runRecovery(future));
+        } catch (RejectedExecutionException e) {
+            this.state = State.RECOVERY_FINISHED;
+            future.completeExceptionally(e);
+        }
+        // Do not expose the internal future used to determine when recovery has stopped.
+        return future.copy();
+    }
+
+    private void runRecovery(CompletableFuture<Position> future) {
+        try {
+            if (!tryStartRecovery()) {
+                future.completeExceptionally(closedException());
+                return;
+            }
+            Position recoveredPosition = doRecoverFromSnapshot(recoveryExecutor);
+            if (tryMarkRecoveryFinished()) {
+                future.complete(recoveredPosition);
+            } else {
+                future.completeExceptionally(closedException());
+            }
+        } catch (Throwable throwable) {
+            future.completeExceptionally(tryMarkRecoveryFinished() ? throwable : closedException());
+        }
+    }
+
+    /**
+     * Recovers the processor state synchronously on the recovery executor thread.
+     *
+     * @param executor executor used by recovery-related operations
+     * @return the recovery position, or {@code null} when no snapshot exists
+     */
+    protected abstract Position doRecoverFromSnapshot(ScheduledExecutorService executor) throws Exception;
+
+    protected final boolean isClosed() {
+        return this.state == State.CLOSED;
+    }
+
+    private synchronized boolean tryStartRecovery() {
+        if (this.state == State.CLOSED) {
+            return false;
+        }
+        this.state = State.RECOVERY_RUNNING;
+        return true;
+    }
+
+    private synchronized boolean tryMarkRecoveryFinished() {
+        if (this.state == State.CLOSED) {
+            return false;
+        }
+        this.state = State.RECOVERY_FINISHED;
+        return true;
+    }
+
+    @Override
+    public final CompletableFuture<Void> closeAsync() {
+        boolean recoveryOwnsFutureCompletion;
+        CompletableFuture<Position> currentRecoveryFuture;
+        synchronized (this) {
+            if (this.state == State.CLOSED) {
+                return closeFuture;
+            }
+            State previousState = this.state;
+            this.state = State.CLOSED;
+            recoveryOwnsFutureCompletion = previousState == State.RECOVERY_RUNNING
+                    || previousState == State.RECOVERY_FINISHED;
+            currentRecoveryFuture = this.recoveryFuture;
+            if (this.recoveryTask != null && previousState == State.RECOVERY_QUEUED) {
+                this.recoveryTask.cancel(false);
+            }
+        }
+        if (!recoveryOwnsFutureCompletion) {
+            currentRecoveryFuture.completeExceptionally(closedException());
+        }
+        currentRecoveryFuture.handle((v, throwable) -> null)
+                .thenCompose(v -> closeResources())
+                .whenComplete((v, throwable) -> {
+                    if (throwable != null) {
+                        closeFuture.completeExceptionally(throwable);
+                    } else {
+                        closeFuture.complete(null);
+                    }
+                });
+        return closeFuture;
+    }
+
+    /**
+     * Closes resources after recovery has stopped.
+     *
+     * <p>This method may be invoked on the caller of {@link #closeAsync()} or on the recovery executor thread.
+     * Implementations must not rely on thread affinity and should return without blocking.
+     */
+    protected abstract CompletableFuture<Void> closeResources();
+
+    private static BrokerServiceException closedException() {
+        return new BrokerServiceException.ServiceUnitNotReadyException(
+                "Transaction buffer snapshot processor is closed");
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/AbstractSnapshotAbortedTxnProcessor.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/AbstractSnapshotAbortedTxnProcessor.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.pulsar.broker.service.BrokerServiceException;
 import org.apache.pulsar.broker.transaction.buffer.AbortedTxnProcessor;
+import org.apache.pulsar.common.util.FutureUtil;
 
 /**
  * Coordinates snapshot recovery and resource closure so resources remain available until processor-owned recovery
@@ -33,16 +34,15 @@ import org.apache.pulsar.broker.transaction.buffer.AbortedTxnProcessor;
 abstract class AbstractSnapshotAbortedTxnProcessor implements AbortedTxnProcessor {
 
     private enum State {
-        OPEN,
+        IDLE,
         RECOVERY_QUEUED,
         RECOVERY_RUNNING,
-        RECOVERY_FINISHED,
         CLOSED
     }
 
     private final ScheduledExecutorService recoveryExecutor;
 
-    private volatile State state = State.OPEN;
+    private volatile State state = State.IDLE;
     private Future<?> recoveryTask;
     private CompletableFuture<Position> recoveryFuture = CompletableFuture.completedFuture(null);
     // Completes before the recovery result, so close waits only for processor-owned work.
@@ -75,7 +75,7 @@ abstract class AbstractSnapshotAbortedTxnProcessor implements AbortedTxnProcesso
                 this.recoveryTask = recoveryExecutor.submit(
                         () -> runRecovery(newRecoveryFuture, newRecoveryWorkFinishedFuture));
             } catch (RejectedExecutionException e) {
-                this.state = State.RECOVERY_FINISHED;
+                this.state = State.IDLE;
                 submissionFailure = e;
             }
         }
@@ -91,25 +91,17 @@ abstract class AbstractSnapshotAbortedTxnProcessor implements AbortedTxnProcesso
                              CompletableFuture<Void> recoveryWorkFinished) {
         Position recoveredPosition = null;
         Throwable recoveryFailure = null;
-        boolean closeWon = false;
-        try {
-            if (!tryStartRecovery()) {
-                closeWon = true;
-            } else {
+        boolean recoveryFinished = false;
+        if (tryStartRecovery()) {
+            try {
                 recoveredPosition = doRecoverFromSnapshot(recoveryExecutor);
-                if (!tryMarkRecoveryFinished()) {
-                    closeWon = true;
-                }
-            }
-        } catch (Throwable throwable) {
-            if (tryMarkRecoveryFinished()) {
+            } catch (Throwable throwable) {
                 recoveryFailure = throwable;
-            } else {
-                closeWon = true;
             }
+            recoveryFinished = tryMarkRecoveryFinished();
         }
         recoveryWorkFinished.complete(null);
-        if (closeWon) {
+        if (!recoveryFinished) {
             failRecoveryAfterClose(recoveryResult);
         } else if (recoveryFailure == null) {
             recoveryResult.complete(recoveredPosition);
@@ -143,7 +135,7 @@ abstract class AbstractSnapshotAbortedTxnProcessor implements AbortedTxnProcesso
         if (this.state != State.RECOVERY_RUNNING) {
             return false;
         }
-        this.state = State.RECOVERY_FINISHED;
+        this.state = State.IDLE;
         return true;
     }
 
@@ -164,14 +156,8 @@ abstract class AbstractSnapshotAbortedTxnProcessor implements AbortedTxnProcesso
                 this.recoveryTask.cancel(false);
             }
         }
-        currentRecoveryWorkFinishedFuture.thenCompose(v -> closeResources())
-                .whenComplete((v, throwable) -> {
-                    if (throwable != null) {
-                        closeFuture.completeExceptionally(throwable);
-                    } else {
-                        closeFuture.complete(null);
-                    }
-                });
+        FutureUtil.completeAfter(closeFuture,
+                currentRecoveryWorkFinishedFuture.thenCompose(v -> closeResources()));
         if (previousState == State.RECOVERY_QUEUED) {
             failRecoveryAfterClose(currentRecoveryFuture);
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/AbstractSnapshotAbortedTxnProcessor.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/AbstractSnapshotAbortedTxnProcessor.java
@@ -54,7 +54,7 @@ abstract class AbstractSnapshotAbortedTxnProcessor implements AbortedTxnProcesso
     }
 
     @Override
-    public CompletableFuture<Position> recoverFromSnapshot() {
+    public final CompletableFuture<Position> recoverFromSnapshot() {
         CompletableFuture<Position> newRecoveryFuture;
         CompletableFuture<Void> newRecoveryWorkFinishedFuture;
         RejectedExecutionException submissionFailure = null;
@@ -140,7 +140,7 @@ abstract class AbstractSnapshotAbortedTxnProcessor implements AbortedTxnProcesso
     }
 
     @Override
-    public CompletableFuture<Void> closeAsync() {
+    public final CompletableFuture<Void> closeAsync() {
         State previousState;
         CompletableFuture<Position> currentRecoveryFuture;
         CompletableFuture<Void> currentRecoveryWorkFinishedFuture;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SingleSnapshotAbortedTxnProcessorImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SingleSnapshotAbortedTxnProcessorImpl.java
@@ -89,7 +89,7 @@ public class SingleSnapshotAbortedTxnProcessorImpl extends AbstractSnapshotAbort
     }
 
     @Override
-    protected Position doRecoverFromSnapshot(ScheduledExecutorService executor) throws Exception {
+    Position doRecoverFromSnapshot(ScheduledExecutorService executor) throws Exception {
         final var pulsar = topic.getBrokerService().getPulsar();
         final var snapshot = pulsar.getTransactionBufferSnapshotServiceFactory().getTxnBufferSnapshotService()
                 .getTableView(executor).readLatest(topic.getName());
@@ -165,7 +165,7 @@ public class SingleSnapshotAbortedTxnProcessorImpl extends AbstractSnapshotAbort
     }
 
     @Override
-    protected CompletableFuture<Void> closeResources() {
+    CompletableFuture<Void> closeResources() {
         takeSnapshotWriter.release();
         return CompletableFuture.completedFuture(null);
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SingleSnapshotAbortedTxnProcessorImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SingleSnapshotAbortedTxnProcessorImpl.java
@@ -30,7 +30,6 @@ import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.service.SystemTopicTxnBufferSnapshotService.ReferenceCountedWriter;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.broker.systopic.NamespaceEventsSystemTopicFactory;
-import org.apache.pulsar.broker.transaction.buffer.AbortedTxnProcessor;
 import org.apache.pulsar.broker.transaction.buffer.metadata.AbortTxnMetadata;
 import org.apache.pulsar.broker.transaction.buffer.metadata.TransactionBufferSnapshot;
 import org.apache.pulsar.client.api.transaction.TxnID;
@@ -40,7 +39,7 @@ import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.TransactionBufferStats;
 
 @CustomLog
-public class SingleSnapshotAbortedTxnProcessorImpl implements AbortedTxnProcessor {
+public class SingleSnapshotAbortedTxnProcessorImpl extends AbstractSnapshotAbortedTxnProcessor {
     private final PersistentTopic topic;
     private final ReferenceCountedWriter<TransactionBufferSnapshot> takeSnapshotWriter;
     /**
@@ -51,11 +50,11 @@ public class SingleSnapshotAbortedTxnProcessorImpl implements AbortedTxnProcesso
 
     private volatile long lastSnapshotTimestamps;
 
-    private volatile boolean isClosed = false;
-
     public SingleSnapshotAbortedTxnProcessorImpl(PersistentTopic topic) {
+        super(topic.getBrokerService().getPulsar().getTransactionSnapshotRecoverExecutorProvider()
+                .chooseThread(TopicName.get(topic.getName()).getNamespace()));
         this.topic = topic;
-        this.takeSnapshotWriter = this.topic.getBrokerService().getPulsar()
+        this.takeSnapshotWriter = topic.getBrokerService().getPulsar()
                 .getTransactionBufferSnapshotServiceFactory()
                 .getTxnBufferSnapshotService().getReferenceWriter(TopicName.get(topic.getName()).getNamespaceObject());
         this.takeSnapshotWriter.getFuture().exceptionally((ex) -> {
@@ -90,29 +89,18 @@ public class SingleSnapshotAbortedTxnProcessorImpl implements AbortedTxnProcesso
     }
 
     @Override
-    public CompletableFuture<Position> recoverFromSnapshot() {
-        final var future = new CompletableFuture<Position>();
+    protected Position doRecoverFromSnapshot(ScheduledExecutorService executor) throws Exception {
         final var pulsar = topic.getBrokerService().getPulsar();
-        final String namespace = TopicName.get(topic.getName()).getNamespace();
-        final ScheduledExecutorService scheduledExecutor = pulsar.getTransactionSnapshotRecoverExecutorProvider()
-                .chooseThread(namespace);
-        scheduledExecutor.execute(() -> {
-            try {
-                final var snapshot = pulsar.getTransactionBufferSnapshotServiceFactory().getTxnBufferSnapshotService()
-                        .getTableView(scheduledExecutor).readLatest(topic.getName());
-                if (snapshot != null) {
-                    handleSnapshot(snapshot);
-                    final var startReadCursorPosition = PositionFactory.create(snapshot.getMaxReadPositionLedgerId(),
-                            snapshot.getMaxReadPositionEntryId());
-                    future.complete(startReadCursorPosition);
-                } else {
-                    future.complete(null);
-                }
-            } catch (Throwable e) {
-                future.completeExceptionally(e);
-            }
-        });
-        return future;
+        final var snapshot = pulsar.getTransactionBufferSnapshotServiceFactory().getTxnBufferSnapshotService()
+                .getTableView(executor).readLatest(topic.getName());
+        if (isClosed()) {
+            return null;
+        }
+        if (snapshot == null) {
+            return null;
+        }
+        handleSnapshot(snapshot);
+        return PositionFactory.create(snapshot.getMaxReadPositionLedgerId(), snapshot.getMaxReadPositionEntryId());
     }
 
     @Override
@@ -177,11 +165,8 @@ public class SingleSnapshotAbortedTxnProcessorImpl implements AbortedTxnProcesso
     }
 
     @Override
-    public synchronized CompletableFuture<Void> closeAsync() {
-        if (!isClosed) {
-            isClosed = true;
-            takeSnapshotWriter.release();
-        }
+    protected CompletableFuture<Void> closeResources() {
+        takeSnapshotWriter.release();
         return CompletableFuture.completedFuture(null);
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SingleSnapshotAbortedTxnProcessorImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SingleSnapshotAbortedTxnProcessorImpl.java
@@ -93,10 +93,7 @@ public class SingleSnapshotAbortedTxnProcessorImpl extends AbstractSnapshotAbort
         final var pulsar = topic.getBrokerService().getPulsar();
         final var snapshot = pulsar.getTransactionBufferSnapshotServiceFactory().getTxnBufferSnapshotService()
                 .getTableView(executor).readLatest(topic.getName());
-        if (isClosed()) {
-            return null;
-        }
-        if (snapshot == null) {
+        if (isClosed() || snapshot == null) {
             return null;
         }
         handleSnapshot(snapshot);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotSegmentAbortedTxnProcessorImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotSegmentAbortedTxnProcessorImpl.java
@@ -49,7 +49,6 @@ import org.apache.pulsar.broker.service.SystemTopicTxnBufferSnapshotService.Refe
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.broker.systopic.NamespaceEventsSystemTopicFactory;
 import org.apache.pulsar.broker.systopic.SystemTopicClient;
-import org.apache.pulsar.broker.transaction.buffer.AbortedTxnProcessor;
 import org.apache.pulsar.broker.transaction.buffer.metadata.TransactionBufferSnapshot;
 import org.apache.pulsar.broker.transaction.buffer.metadata.v2.TransactionBufferSnapshotIndex;
 import org.apache.pulsar.broker.transaction.buffer.metadata.v2.TransactionBufferSnapshotIndexes;
@@ -71,10 +70,11 @@ import org.apache.pulsar.common.policies.data.TransactionBufferStats;
 import org.apache.pulsar.common.protocol.Commands;
 import org.apache.pulsar.common.util.FutureUtil;
 
-public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcessor {
+public class SnapshotSegmentAbortedTxnProcessorImpl extends AbstractSnapshotAbortedTxnProcessor {
 
     private static final Logger LOG = Logger.get(SnapshotSegmentAbortedTxnProcessorImpl.class);
     private final Logger log;
+    private final PersistentTopic topic;
 
     /**
      * Stored the unsealed aborted transaction IDs Whose size is always less than the snapshotSegmentCapacity.
@@ -120,8 +120,6 @@ public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcess
      */
     private final LinkedMap<Position, TransactionBufferSnapshotIndex> indexes = new LinkedMap<>();
 
-    private final PersistentTopic topic;
-
     private volatile long lastSnapshotTimestamps;
 
     private volatile long lastTakedSnapshotSegmentTimestamp;
@@ -144,6 +142,8 @@ public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcess
     private static final String SNAPSHOT_PREFIX = "multiple-";
 
     public SnapshotSegmentAbortedTxnProcessorImpl(PersistentTopic topic) {
+        super(topic.getBrokerService().getPulsar().getTransactionSnapshotRecoverExecutorProvider()
+                .chooseThread(TopicName.get(topic.getName()).getNamespace()));
         this.topic = topic;
         this.log = LOG.with().attr("topic", topic.getName()).build();
         this.persistentWorker = new PersistentWorker(topic);
@@ -231,48 +231,45 @@ public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcess
     }
 
     @Override
-    public CompletableFuture<Position> recoverFromSnapshot() {
+    protected Position doRecoverFromSnapshot(ScheduledExecutorService executor) throws Exception {
         final var pulsar = topic.getBrokerService().getPulsar();
-        final var future = new CompletableFuture<Position>();
-        final String namespace = TopicName.get(topic.getName()).getNamespace();
-        final ScheduledExecutorService scheduledExecutor = pulsar.getTransactionSnapshotRecoverExecutorProvider()
-                .chooseThread(namespace);
-        scheduledExecutor.execute(() -> {
-            try {
-                final var indexes = pulsar.getTransactionBufferSnapshotServiceFactory()
-                        .getTxnBufferSnapshotIndexService().getTableView(scheduledExecutor)
-                        .readLatest(topic.getName());
-                if (indexes == null) {
-                    // Try recovering from the old format snapshot
-                    future.complete(recoverOldSnapshot());
-                    return;
-                }
-                final var snapshot = indexes.getSnapshot();
-                final var startReadCursorPosition = PositionFactory.create(snapshot.getMaxReadPositionLedgerId(),
-                        snapshot.getMaxReadPositionEntryId());
-                this.unsealedTxnIds = convertTypeToTxnID(snapshot.getAborts());
-                // Read snapshot segment to recover aborts
-                final var snapshotSegmentTopicName = TopicName.get(TopicDomain.persistent.toString(),
-                        TopicName.get(topic.getName()).getNamespaceObject(),
-                        SystemTopicNames.TRANSACTION_BUFFER_SNAPSHOT_SEGMENTS);
-                readSegmentEntries(snapshotSegmentTopicName, indexes);
-                if (!this.indexes.isEmpty()) {
-                    // If there is no segment index, the persistent worker will write segment begin from 0.
-                    persistentWorker.sequenceID.set(this.indexes.get(this.indexes.lastKey()).sequenceID + 1);
-                }
-                unsealedTxnIds.forEach(txnID -> aborts.put(txnID, txnID));
-                future.complete(startReadCursorPosition);
-            } catch (Throwable throwable) {
-                future.completeExceptionally(throwable);
-            }
-        });
-        return future;
+        final var indexes = pulsar.getTransactionBufferSnapshotServiceFactory()
+                .getTxnBufferSnapshotIndexService().getTableView(executor)
+                .readLatest(topic.getName());
+        if (isClosed()) {
+            return null;
+        }
+        if (indexes == null) {
+            // Try recovering from the old format snapshot
+            return recoverOldSnapshot(executor);
+        }
+        final var snapshot = indexes.getSnapshot();
+        final var startReadCursorPosition = PositionFactory.create(snapshot.getMaxReadPositionLedgerId(),
+                snapshot.getMaxReadPositionEntryId());
+        this.unsealedTxnIds = convertTypeToTxnID(snapshot.getAborts());
+        // Read snapshot segment to recover aborts
+        final var snapshotSegmentTopicName = TopicName.get(TopicDomain.persistent.toString(),
+                TopicName.get(topic.getName()).getNamespaceObject(),
+                SystemTopicNames.TRANSACTION_BUFFER_SNAPSHOT_SEGMENTS);
+        readSegmentEntries(snapshotSegmentTopicName, indexes);
+        if (isClosed()) {
+            return null;
+        }
+        if (!this.indexes.isEmpty()) {
+            // If there is no segment index, the persistent worker will write segment begin from 0.
+            persistentWorker.sequenceID.set(this.indexes.get(this.indexes.lastKey()).sequenceID + 1);
+        }
+        unsealedTxnIds.forEach(txnID -> aborts.put(txnID, txnID));
+        return startReadCursorPosition;
     }
 
     private void readSegmentEntries(TopicName topicName, TransactionBufferSnapshotIndexes indexes) throws Exception {
         final var managedLedger = openReadOnlyManagedLedger(topicName);
         boolean hasInvalidIndex = false;
         for (var index : indexes.getIndexList()) {
+            if (isClosed()) {
+                return;
+            }
             final var position = PositionFactory.create(index.getSegmentLedgerID(), index.getSegmentEntryID());
             final var abortedPosition = PositionFactory.create(index.abortedMarkLedgerID, index.abortedMarkEntryID);
             try {
@@ -350,22 +347,24 @@ public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcess
     }
 
     // This method will be deprecated and removed in version 4.x.0
-    private Position recoverOldSnapshot() throws Exception {
-        final String namespace = TopicName.get(topic.getName()).getNamespace();
-        final ScheduledExecutorService scheduledExecutor = topic.getBrokerService().getPulsar()
-                .getTransactionSnapshotRecoverExecutorProvider()
-                .chooseThread(namespace);
+    private Position recoverOldSnapshot(ScheduledExecutorService executor) throws Exception {
+        if (isClosed()) {
+            return null;
+        }
         final var pulsar = topic.getBrokerService().getPulsar();
         final var topicName = TopicName.get(topic.getName());
         final var topics = wait(pulsar.getPulsarResources().getTopicResources().listPersistentTopicsAsync(
                 NamespaceName.get(topicName.getNamespace())), "list persistent topics");
+        if (isClosed()) {
+            return null;
+        }
         if (!topics.contains(TopicDomain.persistent + "://" + topicName.getNamespace() + "/"
                 + SystemTopicNames.TRANSACTION_BUFFER_SNAPSHOT)) {
             return null;
         }
         final var snapshot = pulsar.getTransactionBufferSnapshotServiceFactory().getTxnBufferSnapshotService()
-                .getTableView(scheduledExecutor).readLatest(topic.getName());
-        if (snapshot == null) {
+                .getTableView(executor).readLatest(topic.getName());
+        if (isClosed() || snapshot == null) {
             return null;
         }
         handleOldSnapshot(snapshot);
@@ -413,7 +412,7 @@ public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcess
     }
 
     @Override
-    public CompletableFuture<Void> closeAsync() {
+    protected CompletableFuture<Void> closeResources() {
         return persistentWorker.closeAsync();
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotSegmentAbortedTxnProcessorImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotSegmentAbortedTxnProcessorImpl.java
@@ -264,6 +264,9 @@ public class SnapshotSegmentAbortedTxnProcessorImpl extends AbstractSnapshotAbor
     }
 
     private void readSegmentEntries(TopicName topicName, TransactionBufferSnapshotIndexes indexes) throws Exception {
+        if (isClosed()) {
+            return;
+        }
         final var managedLedger = openReadOnlyManagedLedger(topicName);
         boolean hasInvalidIndex = false;
         for (var index : indexes.getIndexList()) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotSegmentAbortedTxnProcessorImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotSegmentAbortedTxnProcessorImpl.java
@@ -138,6 +138,7 @@ public class SnapshotSegmentAbortedTxnProcessorImpl extends AbstractSnapshotAbor
      * <p>    Clear all snapshot segment. </p>
      */
     private final PersistentWorker persistentWorker;
+    private CompletableFuture<Void> recoveryIndexUpdateFuture = CompletableFuture.completedFuture(null);
 
     private static final String SNAPSHOT_PREFIX = "multiple-";
 
@@ -299,7 +300,7 @@ public class SnapshotSegmentAbortedTxnProcessorImpl extends AbstractSnapshotAbor
         }
         if (hasInvalidIndex) {
             // Update the snapshot segment index if there exist invalid indexes.
-            persistentWorker.appendTask(PersistentWorker.OperationType.UpdateIndex,
+            recoveryIndexUpdateFuture = persistentWorker.appendTask(PersistentWorker.OperationType.UpdateIndex,
                     () -> persistentWorker.updateSnapshotIndex(indexes.getSnapshot()));
         }
     }
@@ -416,7 +417,8 @@ public class SnapshotSegmentAbortedTxnProcessorImpl extends AbstractSnapshotAbor
 
     @Override
     protected CompletableFuture<Void> closeResources() {
-        return persistentWorker.closeAsync();
+        return recoveryIndexUpdateFuture.handle((__, throwable) -> null)
+                .thenCompose(__ -> persistentWorker.closeAsync());
     }
 
     private void handleSnapshotSegmentEntry(Entry entry) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotSegmentAbortedTxnProcessorImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotSegmentAbortedTxnProcessorImpl.java
@@ -74,7 +74,6 @@ public class SnapshotSegmentAbortedTxnProcessorImpl extends AbstractSnapshotAbor
 
     private static final Logger LOG = Logger.get(SnapshotSegmentAbortedTxnProcessorImpl.class);
     private final Logger log;
-    private final PersistentTopic topic;
 
     /**
      * Stored the unsealed aborted transaction IDs Whose size is always less than the snapshotSegmentCapacity.
@@ -120,6 +119,8 @@ public class SnapshotSegmentAbortedTxnProcessorImpl extends AbstractSnapshotAbor
      */
     private final LinkedMap<Position, TransactionBufferSnapshotIndex> indexes = new LinkedMap<>();
 
+    private final PersistentTopic topic;
+
     private volatile long lastSnapshotTimestamps;
 
     private volatile long lastTakedSnapshotSegmentTimestamp;
@@ -138,7 +139,8 @@ public class SnapshotSegmentAbortedTxnProcessorImpl extends AbstractSnapshotAbor
      * <p>    Clear all snapshot segment. </p>
      */
     private final PersistentWorker persistentWorker;
-    private CompletableFuture<Void> recoveryIndexUpdateFuture = CompletableFuture.completedFuture(null);
+    // A failed recovery can be retried, so close must retain updates started by every attempt.
+    private CompletableFuture<Void> recoveryIndexUpdatesFuture = CompletableFuture.completedFuture(null);
 
     private static final String SNAPSHOT_PREFIX = "multiple-";
 
@@ -232,7 +234,7 @@ public class SnapshotSegmentAbortedTxnProcessorImpl extends AbstractSnapshotAbor
     }
 
     @Override
-    protected Position doRecoverFromSnapshot(ScheduledExecutorService executor) throws Exception {
+    Position doRecoverFromSnapshot(ScheduledExecutorService executor) throws Exception {
         final var pulsar = topic.getBrokerService().getPulsar();
         final var indexes = pulsar.getTransactionBufferSnapshotServiceFactory()
                 .getTxnBufferSnapshotIndexService().getTableView(executor)
@@ -298,10 +300,11 @@ public class SnapshotSegmentAbortedTxnProcessorImpl extends AbstractSnapshotAbor
                 }
             }
         }
-        if (hasInvalidIndex) {
+        if (hasInvalidIndex && !isClosed()) {
             // Update the snapshot segment index if there exist invalid indexes.
-            recoveryIndexUpdateFuture = persistentWorker.appendTask(PersistentWorker.OperationType.UpdateIndex,
-                    () -> persistentWorker.updateSnapshotIndex(indexes.getSnapshot()));
+            recoveryIndexUpdatesFuture = CompletableFuture.allOf(recoveryIndexUpdatesFuture,
+                    persistentWorker.appendTask(PersistentWorker.OperationType.UpdateIndex,
+                            () -> persistentWorker.updateSnapshotIndex(indexes.getSnapshot())));
         }
     }
 
@@ -416,8 +419,8 @@ public class SnapshotSegmentAbortedTxnProcessorImpl extends AbstractSnapshotAbor
     }
 
     @Override
-    protected CompletableFuture<Void> closeResources() {
-        return recoveryIndexUpdateFuture.handle((__, throwable) -> null)
+    CompletableFuture<Void> closeResources() {
+        return recoveryIndexUpdatesFuture.handle((__, throwable) -> null)
                 .thenCompose(__ -> persistentWorker.closeAsync());
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
@@ -27,12 +27,13 @@ import io.netty.util.TimerTask;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAdder;
-import lombok.SneakyThrows;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedCursor;
@@ -149,11 +150,15 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
 
     private void recover() {
         recoverTime.setRecoverStartTime(System.currentTimeMillis());
-        this.topic.getBrokerService().getPulsar().getTransactionExecutorProvider().getExecutor(this)
-                .execute(new TopicTransactionBufferRecover(new TopicTransactionBufferRecoverCallBack() {
+        Executor transactionExecutor = this.topic.getBrokerService().getPulsar()
+                .getTransactionExecutorProvider().getExecutor(this);
+        transactionExecutor.execute(new TopicTransactionBufferRecover(new TopicTransactionBufferRecoverCallBack() {
                     @Override
                     public void recoverComplete() {
                         synchronized (TopicTransactionBuffer.this) {
+                            if (checkIfClosed()) {
+                                return;
+                            }
                             if (ongoingTxns.isEmpty()) {
                                 updateMaxReadPositionAfterRecovery();
                             }
@@ -175,6 +180,9 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
                     @Override
                     public void noNeedToRecover() {
                         synchronized (TopicTransactionBuffer.this) {
+                            if (checkIfClosed()) {
+                                return;
+                            }
                             updateMaxReadPositionAfterRecovery();
                             if (!changeToNoSnapshotState()) {
                                 log.error().log("Transaction buffer recover fail");
@@ -197,6 +205,9 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
                             TxnID txnID = new TxnID(msgMetadata.getTxnidMostBits(), msgMetadata.getTxnidLeastBits());
                             Position position = PositionFactory.create(entry.getLedgerId(), entry.getEntryId());
                             synchronized (TopicTransactionBuffer.this) {
+                                if (checkIfClosed()) {
+                                    return;
+                                }
                                 if (Markers.isTxnMarker(msgMetadata)) {
                                     if (Markers.isTxnAbortMarker(msgMetadata)) {
                                         snapshotAbortedTxnProcessor.putAbortedTxnAndPosition(txnID, position);
@@ -211,11 +222,6 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
 
                     @Override
                     public void recoverExceptionally(Throwable e) {
-
-                        log.warn()
-                                .exception(e)
-                                .log("Closing topic due to read transaction buffer snapshot while recovering the"
-                                        + " transaction buffer throw exception");
                         // when create reader or writer fail throw PulsarClientException,
                         // should close this topic and then reinit this topic
                         if (e instanceof PulsarClientException) {
@@ -228,9 +234,16 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
                             getTransactionBufferFuture().completeExceptionally(e);
                         }
                         recoverTime.setRecoverEndTime(System.currentTimeMillis());
+                        if (checkIfClosed() || topic.isClosingOrDeleting()) {
+                            return;
+                        }
+                        log.warn()
+                                .exception(e)
+                                .log("Closing topic due to read transaction buffer snapshot while recovering the"
+                                        + " transaction buffer throw exception");
                         topic.close(true);
                     }
-                }, this.topic, this, snapshotAbortedTxnProcessor));
+                }, this.topic, this, snapshotAbortedTxnProcessor, transactionExecutor));
     }
 
     @Override
@@ -314,6 +327,11 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
                 PendingAppendingTxnBufferTask pendingTask = null;
                 try {
                     synchronized (pendingAppendingTxnBufferTasks) {
+                        if (checkIfClosed()) {
+                            failPendingTasks.accept(
+                                    new BrokerServiceException.ServiceUnitNotReadyException("Topic is closed"));
+                            return;
+                        }
                         while ((pendingTask = pendingAppendingTxnBufferTasks.poll()) != null) {
                             final ByteBuf data = pendingTask.buffer;
                             final CompletableFuture<Position> pendingFuture =
@@ -697,17 +715,26 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
 
     @Override
     public CompletableFuture<Void> closeAsync() {
-        synchronized (pendingAppendingTxnBufferTasks) {
-            if (!checkIfClosed()) {
-                PendingAppendingTxnBufferTask pendingTask = null;
-                Throwable t = new BrokerServiceException.ServiceUnitNotReadyException("Topic is closed");
-                while ((pendingTask = pendingAppendingTxnBufferTasks.poll()) != null) {
-                    pendingTask.fail(t);
-                }
-            }
+        boolean closeStarted;
+        // Serialize closure with recovery entry handling, which uses the same monitor.
+        synchronized (this) {
+            closeStarted = !checkIfClosed();
             changeToCloseState();
         }
-        return this.snapshotAbortedTxnProcessor.closeAsync();
+        // Cancel queued recovery before completing futures whose callbacks may run inline.
+        CompletableFuture<Void> processorCloseFuture = this.snapshotAbortedTxnProcessor.closeAsync();
+        if (closeStarted) {
+            Throwable closeException =
+                    new BrokerServiceException.ServiceUnitNotReadyException("Topic is closed");
+            getTransactionBufferFuture().completeExceptionally(closeException);
+            synchronized (pendingAppendingTxnBufferTasks) {
+                PendingAppendingTxnBufferTask pendingTask = null;
+                while ((pendingTask = pendingAppendingTxnBufferTasks.poll()) != null) {
+                    pendingTask.fail(closeException);
+                }
+            }
+        }
+        return processorCloseFuture;
     }
 
     @Override
@@ -811,8 +838,6 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
 
         private final TopicTransactionBufferRecoverCallBack callBack;
 
-        private Position startReadCursorPosition = PositionFactory.EARLIEST;
-
         private final SpscArrayQueue<Entry> entryQueue;
 
         private final AtomicLong exceptionNumber = new AtomicLong();
@@ -823,17 +848,19 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
 
         private final AbortedTxnProcessor abortedTxnProcessor;
 
+        private final Executor replayExecutor;
+
         private TopicTransactionBufferRecover(TopicTransactionBufferRecoverCallBack callBack, PersistentTopic topic,
                                               TopicTransactionBuffer transactionBuffer,
-                                              AbortedTxnProcessor abortedTxnProcessor) {
+                                              AbortedTxnProcessor abortedTxnProcessor, Executor replayExecutor) {
             this.topic = topic;
             this.callBack = callBack;
             this.entryQueue = new SpscArrayQueue<>(2000);
             this.topicTransactionBuffer = transactionBuffer;
             this.abortedTxnProcessor = abortedTxnProcessor;
+            this.replayExecutor = replayExecutor;
         }
 
-        @SneakyThrows
         @Override
         public void run() {
             if (!this.topicTransactionBuffer.changeToInitializingState()) {
@@ -842,32 +869,56 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
                         .log("TransactionBuffer of topic can not change state to Initializing");
                 return;
             }
-            abortedTxnProcessor.recoverFromSnapshot().thenAccept(startReadCursorPosition -> {
-                //Transaction is not use for this topic, so just make maxReadPosition as LAC.
-                if (startReadCursorPosition == null) {
-                    callBack.noNeedToRecover();
-                    return;
-                } else {
-                    this.startReadCursorPosition = startReadCursorPosition;
-                }
-                ManagedCursor managedCursor;
-                try {
-                    managedCursor = topic.getManagedLedger()
-                            .newNonDurableCursor(this.startReadCursorPosition, SUBSCRIPTION_NAME);
-                } catch (ManagedLedgerException e) {
+            // Transaction-buffer replay must not extend the snapshot processor's close barrier.
+            abortedTxnProcessor.recoverFromSnapshot().thenAcceptAsync(this::replayTransactionBuffer, replayExecutor)
+                    .exceptionally(this::handleRecoveryFailure);
+        }
+
+        private Void handleRecoveryFailure(Throwable error) {
+            Throwable cause = FutureUtil.unwrapCompletionException(error);
+            if (!shouldStopRecovery()) {
+                topicTransactionBuffer.log.error()
+                        .exception(cause)
+                        .log("Transaction buffer failed to recover snapshot");
+            }
+            callBack.recoverExceptionally(cause);
+            return null;
+        }
+
+        private boolean shouldStopRecovery() {
+            return topicTransactionBuffer.checkIfClosed() || topic.isClosingOrDeleting();
+        }
+
+        private void replayTransactionBuffer(Position recoveredPosition) {
+            if (shouldStopRecovery()) {
+                return;
+            }
+            // Transaction is not used for this topic, so just make maxReadPosition as LAC.
+            if (recoveredPosition == null) {
+                callBack.noNeedToRecover();
+                return;
+            }
+            ManagedCursor managedCursor;
+            try {
+                managedCursor = topic.getManagedLedger()
+                        .newNonDurableCursor(recoveredPosition, SUBSCRIPTION_NAME);
+            } catch (ManagedLedgerException e) {
+                if (!shouldStopRecovery()) {
                     callBack.recoverExceptionally(e);
                     topicTransactionBuffer.log.error()
                             .exception(e)
                             .log("Transaction buffer recover fail when open cursor!");
-                    return;
                 }
-                Position lastConfirmedEntry =
-                        topic.getManagedLedger().getLastConfirmedEntry();
-                Position currentLoadPosition = this.startReadCursorPosition;
-                FillEntryQueueCallback fillEntryQueueCallback = new FillEntryQueueCallback(entryQueue,
-                        managedCursor, TopicTransactionBufferRecover.this);
+                return;
+            }
+            Position lastConfirmedEntry = topic.getManagedLedger().getLastConfirmedEntry();
+            Position currentLoadPosition = recoveredPosition;
+            FillEntryQueueCallback fillEntryQueueCallback = new FillEntryQueueCallback(entryQueue,
+                    managedCursor, TopicTransactionBufferRecover.this);
+            try {
                 if (lastConfirmedEntry.getEntryId() != -1) {
-                    while (lastConfirmedEntry.compareTo(currentLoadPosition) > 0
+                    while (!shouldStopRecovery()
+                            && lastConfirmedEntry.compareTo(currentLoadPosition) > 0
                             && fillEntryQueueCallback.fillQueue()) {
                         Entry entry = entryQueue.poll();
                         if (entry != null) {
@@ -882,21 +933,19 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
                             try {
                                 Thread.sleep(1);
                             } catch (InterruptedException e) {
-                                //no-op
+                                Thread.currentThread().interrupt();
+                                throw new CompletionException(e);
                             }
                         }
                     }
                 }
-
+            } finally {
+                fillEntryQueueCallback.stopAndReleasePendingEntries();
                 closeCursor(SUBSCRIPTION_NAME);
+            }
+            if (!shouldStopRecovery()) {
                 callBack.recoverComplete();
-            }).exceptionally(e -> {
-                callBack.recoverExceptionally(e.getCause());
-                topicTransactionBuffer.log.error()
-                        .exception(e)
-                        .log("Transaction buffer failed to recover snapshot");
-                return null;
-            });
+            }
         }
 
         private void closeCursor(String subscriptionName) {
@@ -953,6 +1002,8 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
 
         private volatile boolean isReadable = true;
 
+        private volatile boolean stopped;
+
         private static final int NUMBER_OF_PER_READ_ENTRY = 100;
 
         private FillEntryQueueCallback(SpscArrayQueue<Entry> entryQueue, ManagedCursor cursor,
@@ -962,6 +1013,9 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
             this.recover = recover;
         }
         boolean fillQueue() {
+            if (stopped) {
+                return false;
+            }
             if (entryQueue.size() + NUMBER_OF_PER_READ_ENTRY < entryQueue.capacity()
                     && outstandingReadsRequests.get() == 0) {
                 if (cursor.hasMoreEntries()) {
@@ -978,7 +1032,13 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
         }
 
         @Override
-        public void readEntriesComplete(List<Entry> entries, Object ctx) {
+        public synchronized void readEntriesComplete(List<Entry> entries, Object ctx) {
+            if (stopped) {
+                // An asynchronous read can complete after replay has stopped and no longer has a consumer.
+                entries.forEach(Entry::release);
+                outstandingReadsRequests.decrementAndGet();
+                return;
+            }
             entryQueue.fill(new MessagePassingQueue.Supplier<Entry>() {
                 private int i = 0;
                 @Override
@@ -992,8 +1052,21 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
             outstandingReadsRequests.decrementAndGet();
         }
 
+        private synchronized void stopAndReleasePendingEntries() {
+            stopped = true;
+            isReadable = false;
+            Entry entry;
+            while ((entry = entryQueue.poll()) != null) {
+                entry.release();
+            }
+        }
+
         @Override
-        public void readEntriesFailed(ManagedLedgerException exception, Object ctx) {
+        public synchronized void readEntriesFailed(ManagedLedgerException exception, Object ctx) {
+            if (stopped) {
+                outstandingReadsRequests.decrementAndGet();
+                return;
+            }
             if (recover.topic.getManagedLedger().getConfig().isAutoSkipNonRecoverableData()
                     && exception instanceof ManagedLedgerException.NonRecoverableLedgerException
                     || exception instanceof ManagedLedgerException.ManagedLedgerFencedException

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
@@ -557,11 +557,15 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
                             removeTxnAndUpdateMaxReadPosition(txnID);
                             snapshotAbortedTxnProcessor.trimExpiredAbortedTxns();
                             takeSnapshotByChangeTimes();
-                            handleLowWaterMark(txnID, lowWaterMark);
                         }
                         updateLastDispatchablePosition(null);
                         txnAbortedCounter.increment();
                         completableFuture.complete(null);
+                        // Complete first so the low-water-mark abort continuation releases its permit before
+                        // we scan for the next transaction. Completion must remain outside the buffer monitor.
+                        synchronized (TopicTransactionBuffer.this) {
+                            handleLowWaterMark(txnID, lowWaterMark);
+                        }
                     }
 
                     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
@@ -29,7 +29,8 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -107,7 +108,9 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
     private final AbortedTxnProcessor snapshotAbortedTxnProcessor;
 
     private final AbortedTxnProcessor.SnapshotType snapshotType;
+    private final ExecutorService transactionExecutor;
     private final MaxReadPositionCallBack maxReadPositionCallBack;
+    private Future<?> recoveryReplayTask;
     /** if the first snapshot is in progress, it will pending following publishing tasks. **/
     private final LinkedList<PendingAppendingTxnBufferTask> pendingAppendingTxnBufferTasks = new LinkedList<>();
 
@@ -144,14 +147,14 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
         this.maxReadPosition = topic.getManagedLedger().getLastConfirmedEntry();
         this.snapshotAbortedTxnProcessor = snapshotAbortedTxnProcessor;
         this.snapshotType = snapshotType;
+        this.transactionExecutor = topic.getBrokerService().getPulsar()
+                .getTransactionExecutorProvider().getExecutor(this);
         this.maxReadPositionCallBack = topic.getMaxReadPositionCallBack();
         this.recover();
     }
 
     private void recover() {
         recoverTime.setRecoverStartTime(System.currentTimeMillis());
-        Executor transactionExecutor = this.topic.getBrokerService().getPulsar()
-                .getTransactionExecutorProvider().getExecutor(this);
         transactionExecutor.execute(new TopicTransactionBufferRecover(new TopicTransactionBufferRecoverCallBack() {
                     @Override
                     public void recoverComplete() {
@@ -243,7 +246,14 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
                                         + " transaction buffer throw exception");
                         topic.close(true);
                     }
-                }, this.topic, this, snapshotAbortedTxnProcessor, transactionExecutor));
+                }, this.topic, this, snapshotAbortedTxnProcessor));
+    }
+
+    private synchronized void submitRecoveryReplay(Runnable replay) {
+        if (checkIfClosed()) {
+            return;
+        }
+        recoveryReplayTask = transactionExecutor.submit(replay);
     }
 
     @Override
@@ -716,12 +726,16 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
     @Override
     public CompletableFuture<Void> closeAsync() {
         boolean closeStarted;
-        // Serialize closure with recovery entry handling, which uses the same monitor.
+        // Serialize closure with recovery entry handling and replay submission, which use the same monitor.
         synchronized (this) {
             closeStarted = !checkIfClosed();
             changeToCloseState();
+            if (recoveryReplayTask != null) {
+                recoveryReplayTask.cancel(false);
+                recoveryReplayTask = null;
+            }
         }
-        // Cancel queued recovery before completing futures whose callbacks may run inline.
+        // Cancel snapshot recovery before completing futures whose callbacks may run inline.
         CompletableFuture<Void> processorCloseFuture = this.snapshotAbortedTxnProcessor.closeAsync();
         if (closeStarted) {
             Throwable closeException =
@@ -848,17 +862,14 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
 
         private final AbortedTxnProcessor abortedTxnProcessor;
 
-        private final Executor replayExecutor;
-
         private TopicTransactionBufferRecover(TopicTransactionBufferRecoverCallBack callBack, PersistentTopic topic,
                                               TopicTransactionBuffer transactionBuffer,
-                                              AbortedTxnProcessor abortedTxnProcessor, Executor replayExecutor) {
+                                              AbortedTxnProcessor abortedTxnProcessor) {
             this.topic = topic;
             this.callBack = callBack;
             this.entryQueue = new SpscArrayQueue<>(2000);
             this.topicTransactionBuffer = transactionBuffer;
             this.abortedTxnProcessor = abortedTxnProcessor;
-            this.replayExecutor = replayExecutor;
         }
 
         @Override
@@ -869,9 +880,19 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
                         .log("TransactionBuffer of topic can not change state to Initializing");
                 return;
             }
-            // Transaction-buffer replay must not extend the snapshot processor's close barrier.
-            abortedTxnProcessor.recoverFromSnapshot().thenAcceptAsync(this::replayTransactionBuffer, replayExecutor)
+            // Keep replay on the transaction executor while retaining a task handle that close can cancel.
+            abortedTxnProcessor.recoverFromSnapshot().thenAccept(this::submitReplay)
                     .exceptionally(this::handleRecoveryFailure);
+        }
+
+        private void submitReplay(Position recoveredPosition) {
+            topicTransactionBuffer.submitRecoveryReplay(() -> {
+                try {
+                    replayTransactionBuffer(recoveredPosition);
+                } catch (Throwable error) {
+                    handleRecoveryFailure(error);
+                }
+            });
         }
 
         private Void handleRecoveryFailure(Throwable error) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
@@ -94,6 +94,7 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
 
     private final int takeSnapshotIntervalTime;
 
+    // Complete outside the buffer monitor: inline continuations may acquire the topic monitor.
     private final CompletableFuture<Void> transactionBufferFuture = new CompletableFuture<>();
 
     /**
@@ -156,6 +157,7 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
                 .execute(new TopicTransactionBufferRecover(new TopicTransactionBufferRecoverCallBack() {
                     @Override
                     public void recoverComplete() {
+                        BrokerServiceException recoveryFailure = null;
                         synchronized (TopicTransactionBuffer.this) {
                             if (checkIfClosed()) {
                                 return;
@@ -165,16 +167,19 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
                             }
                             if (!changeToReadyState()) {
                                 log.error("Transaction buffer recover fail");
-                                getTransactionBufferFuture().completeExceptionally
-                                        (new BrokerServiceException.ServiceUnitNotReadyException(
-                                                "Transaction buffer recover failed to change the status to Ready,"
-                                                        + "current state is: " + getState()));
+                                recoveryFailure = new BrokerServiceException.ServiceUnitNotReadyException(
+                                        "Transaction buffer recover failed to change the status to Ready,"
+                                                + "current state is: " + getState());
                             } else {
                                 timer.newTimeout(TopicTransactionBuffer.this,
                                         takeSnapshotIntervalTime, TimeUnit.MILLISECONDS);
-                                getTransactionBufferFuture().complete(null);
                                 recoverTime.setRecoverEndTime(System.currentTimeMillis());
                             }
+                        }
+                        if (recoveryFailure != null) {
+                            getTransactionBufferFuture().completeExceptionally(recoveryFailure);
+                        } else {
+                            getTransactionBufferFuture().complete(null);
                         }
                     }
 
@@ -187,11 +192,11 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
                             updateMaxReadPositionAfterRecovery();
                             if (!changeToNoSnapshotState()) {
                                 log.error().log("Transaction buffer recover fail");
-                            } else {
-                                getTransactionBufferFuture().complete(null);
-                                recoverTime.setRecoverEndTime(System.currentTimeMillis());
+                                return;
                             }
+                            recoverTime.setRecoverEndTime(System.currentTimeMillis());
                         }
+                        getTransactionBufferFuture().complete(null);
                     }
                     @Override
                     public void handleTxnEntry(Entry entry) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
@@ -54,6 +53,7 @@ import org.apache.pulsar.broker.transaction.buffer.metadata.TransactionBufferSna
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
+import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.TransactionBufferStats;
 import org.apache.pulsar.common.policies.data.TransactionInBufferStats;
 import org.apache.pulsar.common.protocol.Commands;
@@ -108,7 +108,6 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
     private final AbortedTxnProcessor snapshotAbortedTxnProcessor;
 
     private final AbortedTxnProcessor.SnapshotType snapshotType;
-    private final ExecutorService transactionExecutor;
     private final MaxReadPositionCallBack maxReadPositionCallBack;
     private Future<?> recoveryReplayTask;
     /** if the first snapshot is in progress, it will pending following publishing tasks. **/
@@ -147,15 +146,14 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
         this.maxReadPosition = topic.getManagedLedger().getLastConfirmedEntry();
         this.snapshotAbortedTxnProcessor = snapshotAbortedTxnProcessor;
         this.snapshotType = snapshotType;
-        this.transactionExecutor = topic.getBrokerService().getPulsar()
-                .getTransactionExecutorProvider().getExecutor(this);
         this.maxReadPositionCallBack = topic.getMaxReadPositionCallBack();
         this.recover();
     }
 
     private void recover() {
         recoverTime.setRecoverStartTime(System.currentTimeMillis());
-        transactionExecutor.execute(new TopicTransactionBufferRecover(new TopicTransactionBufferRecoverCallBack() {
+        this.topic.getBrokerService().getPulsar().getTransactionExecutorProvider().getExecutor(this)
+                .execute(new TopicTransactionBufferRecover(new TopicTransactionBufferRecoverCallBack() {
                     @Override
                     public void recoverComplete() {
                         synchronized (TopicTransactionBuffer.this) {
@@ -253,7 +251,9 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
         if (checkIfClosed()) {
             return;
         }
-        recoveryReplayTask = transactionExecutor.submit(replay);
+        // Replay polls for ledger reads, so it must stay off the live transaction executor.
+        recoveryReplayTask = topic.getBrokerService().getPulsar().getTransactionSnapshotRecoverExecutorProvider()
+                .chooseThread(TopicName.get(topic.getName()).getNamespace()).submit(replay);
     }
 
     @Override
@@ -880,7 +880,6 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
                         .log("TransactionBuffer of topic can not change state to Initializing");
                 return;
             }
-            // Keep replay on the transaction executor while retaining a task handle that close can cancel.
             abortedTxnProcessor.recoverFromSnapshot().thenAccept(this::submitReplay)
                     .exceptionally(this::handleRecoveryFailure);
         }
@@ -907,7 +906,8 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
         }
 
         private boolean shouldStopRecovery() {
-            return topicTransactionBuffer.checkIfClosed() || topic.isClosingOrDeleting();
+            // Topic deletion can be rolled back; only buffer closure is irreversible.
+            return topicTransactionBuffer.checkIfClosed();
         }
 
         private void replayTransactionBuffer(Position recoveredPosition) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
@@ -1023,7 +1023,7 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
 
         private volatile boolean isReadable = true;
 
-        private volatile boolean stopped;
+        private boolean stopped;
 
         private static final int NUMBER_OF_PER_READ_ENTRY = 100;
 
@@ -1034,9 +1034,6 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
             this.recover = recover;
         }
         boolean fillQueue() {
-            if (stopped) {
-                return false;
-            }
             if (entryQueue.size() + NUMBER_OF_PER_READ_ENTRY < entryQueue.capacity()
                     && outstandingReadsRequests.get() == 0) {
                 if (cursor.hasMoreEntries()) {
@@ -1057,7 +1054,6 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
             if (stopped) {
                 // An asynchronous read can complete after replay has stopped and no longer has a consumer.
                 entries.forEach(Entry::release);
-                outstandingReadsRequests.decrementAndGet();
                 return;
             }
             entryQueue.fill(new MessagePassingQueue.Supplier<Entry>() {
@@ -1075,7 +1071,6 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
 
         private synchronized void stopAndReleasePendingEntries() {
             stopped = true;
-            isReadable = false;
             Entry entry;
             while ((entry = entryQueue.poll()) != null) {
                 entry.release();
@@ -1085,7 +1080,6 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
         @Override
         public synchronized void readEntriesFailed(ManagedLedgerException exception, Object ctx) {
             if (stopped) {
-                outstandingReadsRequests.decrementAndGet();
                 return;
             }
             if (recover.topic.getManagedLedger().getConfig().isAutoSkipNonRecoverableData()

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
@@ -205,11 +205,12 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
                         if (msgMetadata != null && msgMetadata.hasTxnidMostBits() && msgMetadata.hasTxnidLeastBits()) {
                             TxnID txnID = new TxnID(msgMetadata.getTxnidMostBits(), msgMetadata.getTxnidLeastBits());
                             Position position = PositionFactory.create(entry.getLedgerId(), entry.getEntryId());
+                            boolean isTxnMarker = Markers.isTxnMarker(msgMetadata);
                             synchronized (TopicTransactionBuffer.this) {
                                 if (checkIfClosed()) {
                                     return;
                                 }
-                                if (Markers.isTxnMarker(msgMetadata)) {
+                                if (isTxnMarker) {
                                     if (Markers.isTxnAbortMarker(msgMetadata)) {
                                         snapshotAbortedTxnProcessor.putAbortedTxnAndPosition(txnID, position);
                                     }
@@ -217,6 +218,9 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
                                 } else {
                                     handleTransactionMessage(txnID, position);
                                 }
+                            }
+                            if (isTxnMarker) {
+                                updateLastDispatchablePosition(null);
                             }
                         }
                     }
@@ -469,7 +473,7 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
         }
     }
 
-    // ThreadSafe
+    // Acquires the topic monitor: never call while holding the buffer monitor, since topic close takes both.
     private void updateLastDispatchablePosition(Position position) {
         topic.updateLastDispatchablePosition(position);
     }
@@ -499,6 +503,7 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
                             snapshotAbortedTxnProcessor.trimExpiredAbortedTxns();
                             takeSnapshotByChangeTimes();
                         }
+                        updateLastDispatchablePosition(null);
                         txnCommittedCounter.increment();
                         completableFuture.complete(null);
                     }
@@ -547,10 +552,11 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
                             removeTxnAndUpdateMaxReadPosition(txnID);
                             snapshotAbortedTxnProcessor.trimExpiredAbortedTxns();
                             takeSnapshotByChangeTimes();
-                            txnAbortedCounter.increment();
-                            completableFuture.complete(null);
                             handleLowWaterMark(txnID, lowWaterMark);
                         }
+                        updateLastDispatchablePosition(null);
+                        txnAbortedCounter.increment();
+                        completableFuture.complete(null);
                     }
 
                     @Override
@@ -646,8 +652,6 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
         } else {
             updateMaxReadPosition(topic.getManagedLedger().getLastConfirmedEntry(), false);
         }
-        // Update the last dispatchable position to null if there is a TXN finished.
-        updateLastDispatchablePosition(null);
     }
 
     /**

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
@@ -38,6 +38,7 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
+import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import io.netty.buffer.Unpooled;
 import io.netty.util.HashedWheelTimer;
 import io.netty.util.Timeout;
@@ -70,6 +71,7 @@ import lombok.Cleanup;
 import lombok.CustomLog;
 import lombok.Lombok;
 import org.apache.bookkeeper.common.util.Bytes;
+import org.apache.bookkeeper.common.util.OrderedScheduler;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
@@ -1620,7 +1622,7 @@ public class TransactionTest extends TransactionTestBase {
     public void testTBRecoverChangeStateError() throws InterruptedException, TimeoutException {
         final AtomicReference<PersistentTopic> persistentTopic = new AtomicReference<>();
         // Create Executor
-        ScheduledExecutorService executorServiceRecover = mock(ScheduledExecutorService.class);
+        ListeningScheduledExecutorService executorServiceRecover = mock(ListeningScheduledExecutorService.class);
         // Mock serviceConfiguration.
         ServiceConfiguration serviceConfiguration = mock(ServiceConfiguration.class);
         when(serviceConfiguration.isEnableReplicatedSubscriptions()).thenReturn(false);
@@ -1674,6 +1676,9 @@ public class TransactionTest extends TransactionTestBase {
         when(pulsar.getConfiguration()).thenReturn(serviceConfiguration);
         when(pulsar.getConfig()).thenReturn(serviceConfiguration);
         when(pulsar.getTransactionExecutorProvider()).thenReturn(executorProvider);
+        OrderedScheduler snapshotRecoverExecutorProvider = mock(OrderedScheduler.class);
+        when(snapshotRecoverExecutorProvider.chooseThread(any(Object.class))).thenReturn(executorServiceRecover);
+        when(pulsar.getTransactionSnapshotRecoverExecutorProvider()).thenReturn(snapshotRecoverExecutorProvider);
         when(pulsar.getTransactionBufferSnapshotServiceFactory()).thenReturn(transactionBufferSnapshotServiceFactory);
         TopicTransactionBufferProvider topicTransactionBufferProvider = new TopicTransactionBufferProvider();
         when(pulsar.getTransactionBufferProvider()).thenReturn(topicTransactionBufferProvider);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/impl/AbstractSnapshotAbortedTxnProcessorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/impl/AbstractSnapshotAbortedTxnProcessorTest.java
@@ -34,6 +34,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.pulsar.broker.service.BrokerServiceException;
@@ -47,7 +48,11 @@ public class AbstractSnapshotAbortedTxnProcessorTest {
     @Test(timeOut = 10_000)
     public void testCloseCancelsQueuedRecovery() throws Exception {
         try (RecoveryTestContext context = RecoveryTestContext.queued()) {
-            CompletableFuture<?> recoveryFuture = context.recoverFromSnapshot();
+            CompletableFuture<?> recoveryFuture = context.processor.recoverFromSnapshot();
+            CompletableFuture<Boolean> callbackHeldProcessorLock =
+                    trackCallbackLock(recoveryFuture, context.processor);
+            CompletableFuture<Boolean> closeCompletedBeforeRecovery = recoveryFuture.handle(
+                    (__, ___) -> context.processor.closeAsync().isDone());
             CompletableFuture<?> repeatedRecoveryFuture = context.processor.recoverFromSnapshot();
             context.awaitRecoveryQueued();
 
@@ -58,13 +63,17 @@ public class AbstractSnapshotAbortedTxnProcessorTest {
             context.verifyRecoveryFailedAfterClose(repeatedRecoveryFuture);
             assertFalse(context.processor.recoveryStarted());
             assertTrue(context.processor.resourcesClosed());
+            assertFalse(callbackHeldProcessorLock.get(1, TimeUnit.SECONDS),
+                    "Recovery callbacks must run without holding the processor lock");
+            assertTrue(closeCompletedBeforeRecovery.get(1, TimeUnit.SECONDS),
+                    "Close must finish before publishing a close-induced recovery failure");
         }
     }
 
     @Test(timeOut = 10_000)
     public void testCloseWaitsForRunningRecovery() throws Exception {
         try (RecoveryTestContext context = RecoveryTestContext.running()) {
-            CompletableFuture<?> recoveryFuture = context.recoverFromSnapshot();
+            CompletableFuture<?> recoveryFuture = context.processor.recoverFromSnapshot();
             context.awaitRecoveryStarted();
 
             Future<?> recoveryTask = context.submittedRecoveryTask();
@@ -83,11 +92,11 @@ public class AbstractSnapshotAbortedTxnProcessorTest {
     }
 
     @Test(timeOut = 10_000)
-    public void testCloseWaitsForSynchronousRecoveryCallback() throws Exception {
+    public void testCloseDoesNotWaitForRecoveryCallback() throws Exception {
         CountDownLatch callbackStarted = new CountDownLatch(1);
         CountDownLatch finishCallback = new CountDownLatch(1);
         try (RecoveryTestContext context = RecoveryTestContext.running()) {
-            CompletableFuture<?> recoveryFuture = context.recoverFromSnapshot();
+            CompletableFuture<?> recoveryFuture = context.processor.recoverFromSnapshot();
             CompletableFuture<Void> callbackFuture = recoveryFuture.thenRun(() -> {
                 callbackStarted.countDown();
                 try {
@@ -103,13 +112,11 @@ public class AbstractSnapshotAbortedTxnProcessorTest {
             assertTrue(callbackStarted.await(5, TimeUnit.SECONDS));
             CompletableFuture<Void> closeFuture = context.processor.closeAsync();
 
-            assertFalse(closeFuture.isDone(), "Closing must wait for the recovery callback to return");
-            assertFalse(context.processor.resourcesClosed());
+            closeFuture.get(5, TimeUnit.SECONDS);
+            assertTrue(context.processor.resourcesClosed());
 
             finishCallback.countDown();
             callbackFuture.get(5, TimeUnit.SECONDS);
-            closeFuture.get(5, TimeUnit.SECONDS);
-            assertTrue(context.processor.resourcesClosed());
         } finally {
             finishCallback.countDown();
         }
@@ -118,15 +125,21 @@ public class AbstractSnapshotAbortedTxnProcessorTest {
     @Test(timeOut = 10_000)
     public void testCloseAfterRecoveryCompleted() throws Exception {
         try (RecoveryTestContext context = RecoveryTestContext.running()) {
-            CompletableFuture<?> recoveryFuture = context.recoverFromSnapshot();
+            CompletableFuture<?> recoveryFuture = context.processor.recoverFromSnapshot();
+            CompletableFuture<Boolean> callbackHeldProcessorLock =
+                    trackCallbackLock(recoveryFuture, context.processor);
             context.awaitRecoveryStarted();
 
             context.finishRecovery();
             context.verifyRecoverySucceeded(recoveryFuture);
+            context.verifyRecoverySucceeded(context.processor.recoverFromSnapshot());
+            assertEquals(context.processor.recoveryAttempts(), 2);
+            assertFalse(callbackHeldProcessorLock.get(1, TimeUnit.SECONDS),
+                    "Recovery callbacks must run without holding the processor lock");
             context.processor.closeAsync().get(5, TimeUnit.SECONDS);
 
             assertTrue(context.processor.resourcesClosed());
-            context.verifyRecoveryFailedAfterClose(context.recoverFromSnapshot());
+            context.verifyRecoveryFailedAfterClose(context.processor.recoverFromSnapshot());
         }
     }
 
@@ -135,12 +148,12 @@ public class AbstractSnapshotAbortedTxnProcessorTest {
         try (RecoveryTestContext context = RecoveryTestContext.running()) {
             RuntimeException failure = new RuntimeException("recovery failed");
             context.processor.failNextRecovery(failure);
-            CompletableFuture<?> recoveryFuture = context.recoverFromSnapshot();
+            CompletableFuture<?> recoveryFuture = context.processor.recoverFromSnapshot();
             context.awaitRecoveryStarted();
 
             context.finishRecovery();
             context.verifyRecoveryFailed(recoveryFuture, failure);
-            context.verifyRecoverySucceeded(context.recoverFromSnapshot());
+            context.verifyRecoverySucceeded(context.processor.recoverFromSnapshot());
 
             context.processor.closeAsync().get(5, TimeUnit.SECONDS);
         }
@@ -160,13 +173,19 @@ public class AbstractSnapshotAbortedTxnProcessorTest {
         assertTrue(processor.resourcesClosed());
     }
 
+    private static CompletableFuture<Boolean> trackCallbackLock(CompletableFuture<?> recoveryFuture,
+                                                                 Object processor) {
+        CompletableFuture<Boolean> callbackHeldProcessorLock = new CompletableFuture<>();
+        recoveryFuture.whenComplete((__, ___) ->
+                callbackHeldProcessorLock.complete(Thread.holdsLock(processor)));
+        return callbackHeldProcessorLock;
+    }
+
     private static final class RecoveryTestContext implements AutoCloseable {
 
         private final TrackingScheduledExecutor recoveryExecutor = new TrackingScheduledExecutor();
         private final CountDownLatch releaseBlocker = new CountDownLatch(1);
         private final TestSnapshotProcessor processor;
-
-        private CompletableFuture<Boolean> recoveryCallbackHeldProcessorLock;
 
         static RecoveryTestContext queued() throws Exception {
             return new RecoveryTestContext(true);
@@ -193,14 +212,6 @@ public class AbstractSnapshotAbortedTxnProcessorTest {
             processor = new TestSnapshotProcessor(recoveryExecutor);
         }
 
-        CompletableFuture<?> recoverFromSnapshot() {
-            CompletableFuture<?> recoveryFuture = processor.recoverFromSnapshot();
-            recoveryCallbackHeldProcessorLock = new CompletableFuture<>();
-            recoveryFuture.whenComplete((__, ___) ->
-                    recoveryCallbackHeldProcessorLock.complete(Thread.holdsLock(processor)));
-            return recoveryFuture;
-        }
-
         void awaitRecoveryQueued() {
             assertEquals(recoveryExecutor.getQueue().size(), 1);
             assertFalse(submittedRecoveryTask().isCancelled());
@@ -225,23 +236,16 @@ public class AbstractSnapshotAbortedTxnProcessorTest {
                     () -> recoveryFuture.get(5, TimeUnit.SECONDS));
             assertTrue(exception.getCause() instanceof BrokerServiceException.ServiceUnitNotReadyException,
                     "Closing the processor must fail the recovery future");
-            verifyRecoveryCallbackDidNotHoldProcessorLock();
         }
 
         void verifyRecoverySucceeded(CompletableFuture<?> recoveryFuture) throws Exception {
             assertNull(recoveryFuture.get(5, TimeUnit.SECONDS));
-            verifyRecoveryCallbackDidNotHoldProcessorLock();
         }
 
         void verifyRecoveryFailed(CompletableFuture<?> recoveryFuture, Throwable expected) {
             ExecutionException exception = expectThrows(ExecutionException.class,
                     () -> recoveryFuture.get(5, TimeUnit.SECONDS));
             assertSame(exception.getCause(), expected);
-        }
-
-        private void verifyRecoveryCallbackDidNotHoldProcessorLock() throws Exception {
-            assertFalse(recoveryCallbackHeldProcessorLock.get(1, TimeUnit.SECONDS),
-                    "Recovery callbacks must run without holding the processor lock");
         }
 
         @Override
@@ -279,13 +283,15 @@ public class AbstractSnapshotAbortedTxnProcessorTest {
         private final CountDownLatch finishRecovery = new CountDownLatch(1);
         private final AtomicBoolean resourcesClosed = new AtomicBoolean();
         private final AtomicReference<RuntimeException> nextRecoveryFailure = new AtomicReference<>();
+        private final AtomicInteger recoveryAttempts = new AtomicInteger();
 
         private TestSnapshotProcessor(ScheduledExecutorService recoveryExecutor) {
             super(recoveryExecutor);
         }
 
         @Override
-        protected Position doRecoverFromSnapshot(ScheduledExecutorService executor) throws Exception {
+        Position doRecoverFromSnapshot(ScheduledExecutorService executor) throws Exception {
+            recoveryAttempts.incrementAndGet();
             recoveryStarted.countDown();
             assertTrue(finishRecovery.await(5, TimeUnit.SECONDS));
             RuntimeException failure = nextRecoveryFailure.getAndSet(null);
@@ -295,8 +301,12 @@ public class AbstractSnapshotAbortedTxnProcessorTest {
             return null;
         }
 
+        private int recoveryAttempts() {
+            return recoveryAttempts.get();
+        }
+
         @Override
-        protected CompletableFuture<Void> closeResources() {
+        CompletableFuture<Void> closeResources() {
             resourcesClosed.set(true);
             return CompletableFuture.completedFuture(null);
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/impl/AbstractSnapshotAbortedTxnProcessorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/impl/AbstractSnapshotAbortedTxnProcessorTest.java
@@ -83,6 +83,39 @@ public class AbstractSnapshotAbortedTxnProcessorTest {
     }
 
     @Test(timeOut = 10_000)
+    public void testCloseWaitsForSynchronousRecoveryCallback() throws Exception {
+        CountDownLatch callbackStarted = new CountDownLatch(1);
+        CountDownLatch finishCallback = new CountDownLatch(1);
+        try (RecoveryTestContext context = RecoveryTestContext.running()) {
+            CompletableFuture<?> recoveryFuture = context.recoverFromSnapshot();
+            CompletableFuture<Void> callbackFuture = recoveryFuture.thenRun(() -> {
+                callbackStarted.countDown();
+                try {
+                    assertTrue(finishCallback.await(5, TimeUnit.SECONDS));
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new AssertionError(e);
+                }
+            });
+            context.awaitRecoveryStarted();
+
+            context.finishRecovery();
+            assertTrue(callbackStarted.await(5, TimeUnit.SECONDS));
+            CompletableFuture<Void> closeFuture = context.processor.closeAsync();
+
+            assertFalse(closeFuture.isDone(), "Closing must wait for the recovery callback to return");
+            assertFalse(context.processor.resourcesClosed());
+
+            finishCallback.countDown();
+            callbackFuture.get(5, TimeUnit.SECONDS);
+            closeFuture.get(5, TimeUnit.SECONDS);
+            assertTrue(context.processor.resourcesClosed());
+        } finally {
+            finishCallback.countDown();
+        }
+    }
+
+    @Test(timeOut = 10_000)
     public void testCloseAfterRecoveryCompleted() throws Exception {
         try (RecoveryTestContext context = RecoveryTestContext.running()) {
             CompletableFuture<?> recoveryFuture = context.recoverFromSnapshot();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/impl/AbstractSnapshotAbortedTxnProcessorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/impl/AbstractSnapshotAbortedTxnProcessorTest.java
@@ -1,0 +1,321 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.transaction.buffer.impl;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.bookkeeper.mledger.Position;
+import org.apache.pulsar.broker.service.BrokerServiceException;
+import org.apache.pulsar.client.api.transaction.TxnID;
+import org.apache.pulsar.common.policies.data.TransactionBufferStats;
+import org.testng.annotations.Test;
+
+@Test(groups = "broker")
+public class AbstractSnapshotAbortedTxnProcessorTest {
+
+    @Test(timeOut = 10_000)
+    public void testCloseCancelsQueuedRecovery() throws Exception {
+        try (RecoveryTestContext context = RecoveryTestContext.queued()) {
+            CompletableFuture<?> recoveryFuture = context.recoverFromSnapshot();
+            CompletableFuture<?> repeatedRecoveryFuture = context.processor.recoverFromSnapshot();
+            context.awaitRecoveryQueued();
+
+            context.processor.closeAsync().get(5, TimeUnit.SECONDS);
+
+            assertTrue(context.submittedRecoveryTask().isCancelled());
+            context.verifyRecoveryFailedAfterClose(recoveryFuture);
+            context.verifyRecoveryFailedAfterClose(repeatedRecoveryFuture);
+            assertFalse(context.processor.recoveryStarted());
+            assertTrue(context.processor.resourcesClosed());
+        }
+    }
+
+    @Test(timeOut = 10_000)
+    public void testCloseWaitsForRunningRecovery() throws Exception {
+        try (RecoveryTestContext context = RecoveryTestContext.running()) {
+            CompletableFuture<?> recoveryFuture = context.recoverFromSnapshot();
+            context.awaitRecoveryStarted();
+
+            Future<?> recoveryTask = context.submittedRecoveryTask();
+            CompletableFuture<Void> closeFuture = context.processor.closeAsync();
+
+            assertFalse(recoveryTask.isCancelled());
+            assertFalse(recoveryFuture.isDone(), "Running recovery must not complete until its task stops");
+            assertFalse(closeFuture.isDone(), "Closing must wait for running recovery before closing resources");
+            assertFalse(context.processor.resourcesClosed());
+
+            context.finishRecovery();
+            context.verifyRecoveryFailedAfterClose(recoveryFuture);
+            closeFuture.get(5, TimeUnit.SECONDS);
+            assertTrue(context.processor.resourcesClosed());
+        }
+    }
+
+    @Test(timeOut = 10_000)
+    public void testCloseAfterRecoveryCompleted() throws Exception {
+        try (RecoveryTestContext context = RecoveryTestContext.running()) {
+            CompletableFuture<?> recoveryFuture = context.recoverFromSnapshot();
+            context.awaitRecoveryStarted();
+
+            context.finishRecovery();
+            context.verifyRecoverySucceeded(recoveryFuture);
+            context.processor.closeAsync().get(5, TimeUnit.SECONDS);
+
+            assertTrue(context.processor.resourcesClosed());
+            context.verifyRecoveryFailedAfterClose(context.recoverFromSnapshot());
+        }
+    }
+
+    @Test(timeOut = 10_000)
+    public void testRetryAfterRecoveryFailed() throws Exception {
+        try (RecoveryTestContext context = RecoveryTestContext.running()) {
+            RuntimeException failure = new RuntimeException("recovery failed");
+            context.processor.failNextRecovery(failure);
+            CompletableFuture<?> recoveryFuture = context.recoverFromSnapshot();
+            context.awaitRecoveryStarted();
+
+            context.finishRecovery();
+            context.verifyRecoveryFailed(recoveryFuture, failure);
+            context.verifyRecoverySucceeded(context.recoverFromSnapshot());
+
+            context.processor.closeAsync().get(5, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test(timeOut = 10_000)
+    public void testRecoverySubmissionRejected() throws Exception {
+        TrackingScheduledExecutor recoveryExecutor = new TrackingScheduledExecutor();
+        recoveryExecutor.shutdown();
+        TestSnapshotProcessor processor = new TestSnapshotProcessor(recoveryExecutor);
+
+        CompletableFuture<Position> recoveryFuture = processor.recoverFromSnapshot();
+
+        ExecutionException exception = expectThrows(ExecutionException.class, recoveryFuture::get);
+        assertTrue(exception.getCause() instanceof RejectedExecutionException);
+        processor.closeAsync().get(5, TimeUnit.SECONDS);
+        assertTrue(processor.resourcesClosed());
+    }
+
+    private static final class RecoveryTestContext implements AutoCloseable {
+
+        private final TrackingScheduledExecutor recoveryExecutor = new TrackingScheduledExecutor();
+        private final CountDownLatch releaseBlocker = new CountDownLatch(1);
+        private final TestSnapshotProcessor processor;
+
+        private CompletableFuture<Boolean> recoveryCallbackHeldProcessorLock;
+
+        static RecoveryTestContext queued() throws Exception {
+            return new RecoveryTestContext(true);
+        }
+
+        static RecoveryTestContext running() throws Exception {
+            return new RecoveryTestContext(false);
+        }
+
+        private RecoveryTestContext(boolean queueRecovery) throws Exception {
+            if (queueRecovery) {
+                CountDownLatch blockerStarted = new CountDownLatch(1);
+                recoveryExecutor.execute(() -> {
+                    blockerStarted.countDown();
+                    try {
+                        releaseBlocker.await();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                });
+                assertTrue(blockerStarted.await(5, TimeUnit.SECONDS));
+            }
+
+            processor = new TestSnapshotProcessor(recoveryExecutor);
+        }
+
+        CompletableFuture<?> recoverFromSnapshot() {
+            CompletableFuture<?> recoveryFuture = processor.recoverFromSnapshot();
+            recoveryCallbackHeldProcessorLock = new CompletableFuture<>();
+            recoveryFuture.whenComplete((__, ___) ->
+                    recoveryCallbackHeldProcessorLock.complete(Thread.holdsLock(processor)));
+            return recoveryFuture;
+        }
+
+        void awaitRecoveryQueued() {
+            assertEquals(recoveryExecutor.getQueue().size(), 1);
+            assertFalse(submittedRecoveryTask().isCancelled());
+        }
+
+        void awaitRecoveryStarted() throws InterruptedException {
+            assertTrue(processor.awaitRecoveryStarted());
+        }
+
+        Future<?> submittedRecoveryTask() {
+            Future<?> recoveryTask = recoveryExecutor.submittedTask();
+            assertNotNull(recoveryTask);
+            return recoveryTask;
+        }
+
+        void finishRecovery() {
+            processor.finishRecovery();
+        }
+
+        void verifyRecoveryFailedAfterClose(CompletableFuture<?> recoveryFuture) throws Exception {
+            ExecutionException exception = expectThrows(ExecutionException.class,
+                    () -> recoveryFuture.get(5, TimeUnit.SECONDS));
+            assertTrue(exception.getCause() instanceof BrokerServiceException.ServiceUnitNotReadyException,
+                    "Closing the processor must fail the recovery future");
+            verifyRecoveryCallbackDidNotHoldProcessorLock();
+        }
+
+        void verifyRecoverySucceeded(CompletableFuture<?> recoveryFuture) throws Exception {
+            assertNull(recoveryFuture.get(5, TimeUnit.SECONDS));
+            verifyRecoveryCallbackDidNotHoldProcessorLock();
+        }
+
+        void verifyRecoveryFailed(CompletableFuture<?> recoveryFuture, Throwable expected) {
+            ExecutionException exception = expectThrows(ExecutionException.class,
+                    () -> recoveryFuture.get(5, TimeUnit.SECONDS));
+            assertSame(exception.getCause(), expected);
+        }
+
+        private void verifyRecoveryCallbackDidNotHoldProcessorLock() throws Exception {
+            assertFalse(recoveryCallbackHeldProcessorLock.get(1, TimeUnit.SECONDS),
+                    "Recovery callbacks must run without holding the processor lock");
+        }
+
+        @Override
+        public void close() throws Exception {
+            releaseBlocker.countDown();
+            processor.finishRecovery();
+            recoveryExecutor.shutdownNow();
+            assertTrue(recoveryExecutor.awaitTermination(5, TimeUnit.SECONDS));
+        }
+    }
+
+    private static final class TrackingScheduledExecutor extends ScheduledThreadPoolExecutor {
+
+        private final AtomicReference<Future<?>> submittedTask = new AtomicReference<>();
+
+        private TrackingScheduledExecutor() {
+            super(1);
+        }
+
+        @Override
+        public Future<?> submit(Runnable task) {
+            Future<?> future = super.submit(task);
+            submittedTask.set(future);
+            return future;
+        }
+
+        private Future<?> submittedTask() {
+            return submittedTask.get();
+        }
+    }
+
+    private static final class TestSnapshotProcessor extends AbstractSnapshotAbortedTxnProcessor {
+
+        private final CountDownLatch recoveryStarted = new CountDownLatch(1);
+        private final CountDownLatch finishRecovery = new CountDownLatch(1);
+        private final AtomicBoolean resourcesClosed = new AtomicBoolean();
+        private final AtomicReference<RuntimeException> nextRecoveryFailure = new AtomicReference<>();
+
+        private TestSnapshotProcessor(ScheduledExecutorService recoveryExecutor) {
+            super(recoveryExecutor);
+        }
+
+        @Override
+        protected Position doRecoverFromSnapshot(ScheduledExecutorService executor) throws Exception {
+            recoveryStarted.countDown();
+            assertTrue(finishRecovery.await(5, TimeUnit.SECONDS));
+            RuntimeException failure = nextRecoveryFailure.getAndSet(null);
+            if (failure != null) {
+                throw failure;
+            }
+            return null;
+        }
+
+        @Override
+        protected CompletableFuture<Void> closeResources() {
+            resourcesClosed.set(true);
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public void putAbortedTxnAndPosition(TxnID txnID, Position position) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void trimExpiredAbortedTxns() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean checkAbortedTransaction(TxnID txnID) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public CompletableFuture<Void> clearAbortedTxnSnapshot() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public CompletableFuture<Void> takeAbortedTxnsSnapshot(Position maxReadPosition) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public TransactionBufferStats generateSnapshotStats(boolean segmentStats) {
+            throw new UnsupportedOperationException();
+        }
+
+        boolean awaitRecoveryStarted() throws InterruptedException {
+            return recoveryStarted.await(5, TimeUnit.SECONDS);
+        }
+
+        boolean recoveryStarted() {
+            return recoveryStarted.getCount() == 0;
+        }
+
+        void finishRecovery() {
+            finishRecovery.countDown();
+        }
+
+        void failNextRecovery(RuntimeException failure) {
+            nextRecoveryFailure.set(failure);
+        }
+
+        boolean resourcesClosed() {
+            return resourcesClosed.get();
+        }
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/impl/AbstractSnapshotAbortedTxnProcessorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/impl/AbstractSnapshotAbortedTxnProcessorTest.java
@@ -21,8 +21,6 @@ package org.apache.pulsar.broker.transaction.buffer.impl;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.expectThrows;
 import java.util.concurrent.CompletableFuture;
@@ -34,7 +32,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.pulsar.broker.service.BrokerServiceException;
@@ -98,6 +95,8 @@ public class AbstractSnapshotAbortedTxnProcessorTest {
         try (RecoveryTestContext context = RecoveryTestContext.running()) {
             CompletableFuture<?> recoveryFuture = context.processor.recoverFromSnapshot();
             CompletableFuture<Void> callbackFuture = recoveryFuture.thenRun(() -> {
+                assertFalse(Thread.holdsLock(context.processor),
+                        "Recovery callbacks must run without holding the processor lock");
                 callbackStarted.countDown();
                 try {
                     assertTrue(finishCallback.await(5, TimeUnit.SECONDS));
@@ -114,48 +113,12 @@ public class AbstractSnapshotAbortedTxnProcessorTest {
 
             closeFuture.get(5, TimeUnit.SECONDS);
             assertTrue(context.processor.resourcesClosed());
+            context.verifyRecoveryFailedAfterClose(context.processor.recoverFromSnapshot());
 
             finishCallback.countDown();
             callbackFuture.get(5, TimeUnit.SECONDS);
         } finally {
             finishCallback.countDown();
-        }
-    }
-
-    @Test(timeOut = 10_000)
-    public void testCloseAfterRecoveryCompleted() throws Exception {
-        try (RecoveryTestContext context = RecoveryTestContext.running()) {
-            CompletableFuture<?> recoveryFuture = context.processor.recoverFromSnapshot();
-            CompletableFuture<Boolean> callbackHeldProcessorLock =
-                    trackCallbackLock(recoveryFuture, context.processor);
-            context.awaitRecoveryStarted();
-
-            context.finishRecovery();
-            context.verifyRecoverySucceeded(recoveryFuture);
-            context.verifyRecoverySucceeded(context.processor.recoverFromSnapshot());
-            assertEquals(context.processor.recoveryAttempts(), 2);
-            assertFalse(callbackHeldProcessorLock.get(1, TimeUnit.SECONDS),
-                    "Recovery callbacks must run without holding the processor lock");
-            context.processor.closeAsync().get(5, TimeUnit.SECONDS);
-
-            assertTrue(context.processor.resourcesClosed());
-            context.verifyRecoveryFailedAfterClose(context.processor.recoverFromSnapshot());
-        }
-    }
-
-    @Test(timeOut = 10_000)
-    public void testRetryAfterRecoveryFailed() throws Exception {
-        try (RecoveryTestContext context = RecoveryTestContext.running()) {
-            RuntimeException failure = new RuntimeException("recovery failed");
-            context.processor.failNextRecovery(failure);
-            CompletableFuture<?> recoveryFuture = context.processor.recoverFromSnapshot();
-            context.awaitRecoveryStarted();
-
-            context.finishRecovery();
-            context.verifyRecoveryFailed(recoveryFuture, failure);
-            context.verifyRecoverySucceeded(context.processor.recoverFromSnapshot());
-
-            context.processor.closeAsync().get(5, TimeUnit.SECONDS);
         }
     }
 
@@ -238,16 +201,6 @@ public class AbstractSnapshotAbortedTxnProcessorTest {
                     "Closing the processor must fail the recovery future");
         }
 
-        void verifyRecoverySucceeded(CompletableFuture<?> recoveryFuture) throws Exception {
-            assertNull(recoveryFuture.get(5, TimeUnit.SECONDS));
-        }
-
-        void verifyRecoveryFailed(CompletableFuture<?> recoveryFuture, Throwable expected) {
-            ExecutionException exception = expectThrows(ExecutionException.class,
-                    () -> recoveryFuture.get(5, TimeUnit.SECONDS));
-            assertSame(exception.getCause(), expected);
-        }
-
         @Override
         public void close() throws Exception {
             releaseBlocker.countDown();
@@ -282,8 +235,6 @@ public class AbstractSnapshotAbortedTxnProcessorTest {
         private final CountDownLatch recoveryStarted = new CountDownLatch(1);
         private final CountDownLatch finishRecovery = new CountDownLatch(1);
         private final AtomicBoolean resourcesClosed = new AtomicBoolean();
-        private final AtomicReference<RuntimeException> nextRecoveryFailure = new AtomicReference<>();
-        private final AtomicInteger recoveryAttempts = new AtomicInteger();
 
         private TestSnapshotProcessor(ScheduledExecutorService recoveryExecutor) {
             super(recoveryExecutor);
@@ -291,18 +242,9 @@ public class AbstractSnapshotAbortedTxnProcessorTest {
 
         @Override
         Position doRecoverFromSnapshot(ScheduledExecutorService executor) throws Exception {
-            recoveryAttempts.incrementAndGet();
             recoveryStarted.countDown();
             assertTrue(finishRecovery.await(5, TimeUnit.SECONDS));
-            RuntimeException failure = nextRecoveryFailure.getAndSet(null);
-            if (failure != null) {
-                throw failure;
-            }
             return null;
-        }
-
-        private int recoveryAttempts() {
-            return recoveryAttempts.get();
         }
 
         @Override
@@ -351,10 +293,6 @@ public class AbstractSnapshotAbortedTxnProcessorTest {
 
         void finishRecovery() {
             finishRecovery.countDown();
-        }
-
-        void failNextRecovery(RuntimeException failure) {
-            nextRecoveryFailure.set(failure);
         }
 
         boolean resourcesClosed() {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotSegmentAbortedTxnProcessorCloseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotSegmentAbortedTxnProcessorCloseTest.java
@@ -64,6 +64,7 @@ import org.testng.annotations.Test;
 public class SnapshotSegmentAbortedTxnProcessorCloseTest {
 
     @Test(timeOut = 10_000)
+    @SuppressWarnings("unchecked")
     public void testCloseWaitsForRecoveryIndexUpdate() throws Exception {
         ListeningScheduledExecutorService recoveryExecutor =
                 MoreExecutors.listeningDecorator(Executors.newSingleThreadScheduledExecutor());
@@ -94,22 +95,16 @@ public class SnapshotSegmentAbortedTxnProcessorCloseTest {
             when(recoveryScheduler.chooseThread(any(Object.class))).thenReturn(recoveryExecutor);
             when(pulsar.getTransactionBufferSnapshotServiceFactory()).thenReturn(serviceFactory);
 
-            @SuppressWarnings("unchecked")
             SystemTopicTxnBufferSnapshotService<TransactionBufferSnapshotSegment> segmentService =
                     mock(SystemTopicTxnBufferSnapshotService.class);
-            @SuppressWarnings("unchecked")
             SystemTopicTxnBufferSnapshotService<TransactionBufferSnapshotIndexes> indexService =
                     mock(SystemTopicTxnBufferSnapshotService.class);
-            @SuppressWarnings("unchecked")
             ReferenceCountedWriter<TransactionBufferSnapshotSegment> segmentWriter =
                     mock(ReferenceCountedWriter.class);
-            @SuppressWarnings("unchecked")
             ReferenceCountedWriter<TransactionBufferSnapshotIndexes> indexWriter =
                     mock(ReferenceCountedWriter.class);
-            @SuppressWarnings("unchecked")
             SystemTopicClient.Writer<TransactionBufferSnapshotSegment> segmentSystemWriter =
                     mock(SystemTopicClient.Writer.class);
-            @SuppressWarnings("unchecked")
             SystemTopicClient.Writer<TransactionBufferSnapshotIndexes> indexSystemWriter =
                     mock(SystemTopicClient.Writer.class);
 
@@ -129,7 +124,6 @@ public class SnapshotSegmentAbortedTxnProcessorCloseTest {
                     new TransactionBufferSnapshotIndexesMetadata(3, 3, Collections.emptyList());
             TransactionBufferSnapshotIndexes indexes =
                     new TransactionBufferSnapshotIndexes(topicName, Collections.singletonList(invalidIndex), metadata);
-            @SuppressWarnings("unchecked")
             TableView<TransactionBufferSnapshotIndexes> tableView = mock(TableView.class);
             when(indexService.getTableView(recoveryExecutor)).thenReturn(tableView);
             when(tableView.readLatest(topicName)).thenReturn(indexes);
@@ -156,6 +150,8 @@ public class SnapshotSegmentAbortedTxnProcessorCloseTest {
             processor = new SnapshotSegmentAbortedTxnProcessorImpl(topic);
             processor.recoverFromSnapshot().get(5, TimeUnit.SECONDS);
             assertTrue(indexUpdateStarted.await(5, TimeUnit.SECONDS));
+            // A later recovery must not replace the in-flight update in the close barrier.
+            processor.recoverFromSnapshot().get(5, TimeUnit.SECONDS);
 
             CompletableFuture<Void> closeFuture = processor.closeAsync();
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotSegmentAbortedTxnProcessorCloseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotSegmentAbortedTxnProcessorCloseTest.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.transaction.buffer.impl;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import com.google.common.util.concurrent.ListeningScheduledExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import java.util.Collections;
+import java.util.TreeMap;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.apache.bookkeeper.common.util.OrderedScheduler;
+import org.apache.bookkeeper.mledger.AsyncCallbacks;
+import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
+import org.apache.bookkeeper.mledger.ManagedLedgerException;
+import org.apache.bookkeeper.mledger.ManagedLedgerFactory;
+import org.apache.bookkeeper.mledger.ReadOnlyManagedLedger;
+import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
+import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.service.BrokerService;
+import org.apache.pulsar.broker.service.SystemTopicTxnBufferSnapshotService;
+import org.apache.pulsar.broker.service.SystemTopicTxnBufferSnapshotService.ReferenceCountedWriter;
+import org.apache.pulsar.broker.service.TransactionBufferSnapshotServiceFactory;
+import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.broker.systopic.SystemTopicClient;
+import org.apache.pulsar.broker.transaction.buffer.metadata.v2.TransactionBufferSnapshotIndex;
+import org.apache.pulsar.broker.transaction.buffer.metadata.v2.TransactionBufferSnapshotIndexes;
+import org.apache.pulsar.broker.transaction.buffer.metadata.v2.TransactionBufferSnapshotIndexesMetadata;
+import org.apache.pulsar.broker.transaction.buffer.metadata.v2.TransactionBufferSnapshotSegment;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.impl.PulsarClientImpl;
+import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
+import org.testng.annotations.Test;
+
+@Test(groups = "broker")
+public class SnapshotSegmentAbortedTxnProcessorCloseTest {
+
+    @Test(timeOut = 10_000)
+    public void testCloseWaitsForRecoveryIndexUpdate() throws Exception {
+        ListeningScheduledExecutorService recoveryExecutor =
+                MoreExecutors.listeningDecorator(Executors.newSingleThreadScheduledExecutor());
+        CompletableFuture<MessageId> indexUpdateFuture = new CompletableFuture<>();
+        CountDownLatch indexUpdateStarted = new CountDownLatch(1);
+        SnapshotSegmentAbortedTxnProcessorImpl processor = null;
+        try {
+            String topicName = "persistent://public/default/test-close-during-index-update";
+            PersistentTopic topic = mock(PersistentTopic.class);
+            BrokerService brokerService = mock(BrokerService.class);
+            PulsarService pulsar = mock(PulsarService.class);
+            ServiceConfiguration configuration = mock(ServiceConfiguration.class);
+            PulsarClientImpl client = mock(PulsarClientImpl.class);
+            ClientConfigurationData clientConfiguration = new ClientConfigurationData();
+            clientConfiguration.setOperationTimeoutMs(5_000);
+            OrderedScheduler recoveryScheduler = mock(OrderedScheduler.class);
+            TransactionBufferSnapshotServiceFactory serviceFactory =
+                    mock(TransactionBufferSnapshotServiceFactory.class);
+
+            when(topic.getName()).thenReturn(topicName);
+            when(topic.getBrokerService()).thenReturn(brokerService);
+            when(brokerService.getPulsar()).thenReturn(pulsar);
+            when(pulsar.getConfiguration()).thenReturn(configuration);
+            when(pulsar.getClient()).thenReturn(client);
+            when(client.getConfiguration()).thenReturn(clientConfiguration);
+            when(configuration.getTransactionBufferSnapshotSegmentSize()).thenReturn(1024);
+            when(pulsar.getTransactionSnapshotRecoverExecutorProvider()).thenReturn(recoveryScheduler);
+            when(recoveryScheduler.chooseThread(any(Object.class))).thenReturn(recoveryExecutor);
+            when(pulsar.getTransactionBufferSnapshotServiceFactory()).thenReturn(serviceFactory);
+
+            @SuppressWarnings("unchecked")
+            SystemTopicTxnBufferSnapshotService<TransactionBufferSnapshotSegment> segmentService =
+                    mock(SystemTopicTxnBufferSnapshotService.class);
+            @SuppressWarnings("unchecked")
+            SystemTopicTxnBufferSnapshotService<TransactionBufferSnapshotIndexes> indexService =
+                    mock(SystemTopicTxnBufferSnapshotService.class);
+            @SuppressWarnings("unchecked")
+            ReferenceCountedWriter<TransactionBufferSnapshotSegment> segmentWriter =
+                    mock(ReferenceCountedWriter.class);
+            @SuppressWarnings("unchecked")
+            ReferenceCountedWriter<TransactionBufferSnapshotIndexes> indexWriter =
+                    mock(ReferenceCountedWriter.class);
+            @SuppressWarnings("unchecked")
+            SystemTopicClient.Writer<TransactionBufferSnapshotSegment> segmentSystemWriter =
+                    mock(SystemTopicClient.Writer.class);
+            @SuppressWarnings("unchecked")
+            SystemTopicClient.Writer<TransactionBufferSnapshotIndexes> indexSystemWriter =
+                    mock(SystemTopicClient.Writer.class);
+
+            when(serviceFactory.getTxnBufferSnapshotSegmentService()).thenReturn(segmentService);
+            when(serviceFactory.getTxnBufferSnapshotIndexService()).thenReturn(indexService);
+            when(segmentService.getReferenceWriter(any())).thenReturn(segmentWriter);
+            when(indexService.getReferenceWriter(any())).thenReturn(indexWriter);
+            when(segmentWriter.getFuture()).thenReturn(CompletableFuture.completedFuture(segmentSystemWriter));
+            when(indexWriter.getFuture()).thenReturn(CompletableFuture.completedFuture(indexSystemWriter));
+            when(indexSystemWriter.writeAsync(anyString(), any())).thenAnswer(invocation -> {
+                indexUpdateStarted.countDown();
+                return indexUpdateFuture;
+            });
+
+            TransactionBufferSnapshotIndex invalidIndex = new TransactionBufferSnapshotIndex(0, 1, 1, 2, 2);
+            TransactionBufferSnapshotIndexesMetadata metadata =
+                    new TransactionBufferSnapshotIndexesMetadata(3, 3, Collections.emptyList());
+            TransactionBufferSnapshotIndexes indexes =
+                    new TransactionBufferSnapshotIndexes(topicName, Collections.singletonList(invalidIndex), metadata);
+            @SuppressWarnings("unchecked")
+            TableView<TransactionBufferSnapshotIndexes> tableView = mock(TableView.class);
+            when(indexService.getTableView(recoveryExecutor)).thenReturn(tableView);
+            when(tableView.readLatest(topicName)).thenReturn(indexes);
+
+            ManagedLedgerImpl managedLedger = mock(ManagedLedgerImpl.class);
+            when(topic.getManagedLedger()).thenReturn(managedLedger);
+            when(managedLedger.getConfig()).thenReturn(new ManagedLedgerConfig());
+            when(managedLedger.getLedgersInfo()).thenReturn(new TreeMap<>());
+            ManagedLedgerFactory managedLedgerFactory = mock(ManagedLedgerFactory.class);
+            ReadOnlyManagedLedger readOnlyManagedLedger = mock(ReadOnlyManagedLedger.class);
+            when(brokerService.getManagedLedgerFactoryForTopic(any()))
+                    .thenReturn(CompletableFuture.completedFuture(managedLedgerFactory));
+            doAnswer(invocation -> {
+                AsyncCallbacks.OpenReadOnlyManagedLedgerCallback callback = invocation.getArgument(1);
+                callback.openReadOnlyManagedLedgerComplete(readOnlyManagedLedger, invocation.getArgument(3));
+                return null;
+            }).when(managedLedgerFactory).asyncOpenReadOnlyManagedLedger(anyString(), any(), any(), isNull());
+            doAnswer(invocation -> {
+                AsyncCallbacks.ReadEntryCallback callback = invocation.getArgument(1);
+                callback.readEntryFailed(new ManagedLedgerException("missing segment"), invocation.getArgument(2));
+                return null;
+            }).when(readOnlyManagedLedger).asyncReadEntry(any(), any(), isNull());
+
+            processor = new SnapshotSegmentAbortedTxnProcessorImpl(topic);
+            processor.recoverFromSnapshot().get(5, TimeUnit.SECONDS);
+            assertTrue(indexUpdateStarted.await(5, TimeUnit.SECONDS));
+
+            CompletableFuture<Void> closeFuture = processor.closeAsync();
+
+            assertFalse(closeFuture.isDone(), "Closing must wait for the recovery index update");
+            verify(indexWriter, never()).release();
+
+            indexUpdateFuture.complete(MessageId.earliest);
+            closeFuture.get(5, TimeUnit.SECONDS);
+            verify(indexWriter).release();
+        } finally {
+            indexUpdateFuture.complete(MessageId.earliest);
+            if (processor != null) {
+                processor.closeAsync().get(5, TimeUnit.SECONDS);
+            }
+            recoveryExecutor.shutdownNow();
+            assertTrue(recoveryExecutor.awaitTermination(5, TimeUnit.SECONDS));
+        }
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBufferCloseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBufferCloseTest.java
@@ -1,0 +1,201 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.transaction.buffer.impl;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertTrue;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import org.apache.bookkeeper.mledger.AsyncCallbacks;
+import org.apache.bookkeeper.mledger.Entry;
+import org.apache.bookkeeper.mledger.ManagedCursor;
+import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
+import org.apache.bookkeeper.mledger.Position;
+import org.apache.bookkeeper.mledger.PositionFactory;
+import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
+import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.service.BrokerService;
+import org.apache.pulsar.broker.service.BrokerServiceException;
+import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.broker.transaction.buffer.AbortedTxnProcessor;
+import org.apache.pulsar.client.util.ExecutorProvider;
+import org.testng.annotations.Test;
+
+@Test(groups = "broker")
+public class TopicTransactionBufferCloseTest {
+
+    @Test(timeOut = 10_000)
+    public void testCloseInducedRecoveryFailureDoesNotCloseTopicAgain() throws Exception {
+        ContinuationBlockingRecoveryFuture recoveryFuture = new ContinuationBlockingRecoveryFuture();
+        recoveryFuture.allowContinuationRegistration();
+        try (TestContext context = new TestContext(recoveryFuture, PositionFactory.EARLIEST)) {
+            recoveryFuture.awaitContinuationRegistrationStarted();
+            when(context.processor.closeAsync()).thenAnswer(__ -> {
+                recoveryFuture.completeExceptionally(
+                        new BrokerServiceException.ServiceUnitNotReadyException("processor closed"));
+                return CompletableFuture.completedFuture(null);
+            });
+
+            context.transactionBuffer.closeAsync().get(5, TimeUnit.SECONDS);
+            context.awaitExecutorIdle();
+
+            verify(context.topic, never()).close(true);
+            assertTrue(context.transactionBuffer.getTransactionBufferFuture().isCompletedExceptionally());
+        }
+    }
+
+    @Test(timeOut = 10_000)
+    public void testRecoveryContinuationDoesNotStartAfterClose() throws Exception {
+        ContinuationBlockingRecoveryFuture recoveryFuture = new ContinuationBlockingRecoveryFuture();
+        try (TestContext context = new TestContext(recoveryFuture, PositionFactory.EARLIEST)) {
+            recoveryFuture.awaitContinuationRegistrationStarted();
+            recoveryFuture.complete(PositionFactory.EARLIEST);
+
+            context.transactionBuffer.closeAsync().get(5, TimeUnit.SECONDS);
+            recoveryFuture.allowContinuationRegistration();
+            context.awaitExecutorIdle();
+
+            verify(context.managedLedger, never()).newNonDurableCursor(any(), anyString());
+            assertTrue(context.transactionBuffer.getTransactionBufferFuture().isCompletedExceptionally());
+        } finally {
+            recoveryFuture.allowContinuationRegistration();
+        }
+    }
+
+    @Test(timeOut = 10_000)
+    public void testLateRecoveryReadIsReleasedAfterClose() throws Exception {
+        Position startPosition = PositionFactory.create(1, 0);
+        Position lastPosition = PositionFactory.create(1, 3);
+        CompletableFuture<Position> recoveryFuture = CompletableFuture.completedFuture(startPosition);
+        CountDownLatch readStarted = new CountDownLatch(1);
+        AtomicReference<AsyncCallbacks.ReadEntriesCallback> readCallback = new AtomicReference<>();
+        try (TestContext context = new TestContext(recoveryFuture, lastPosition)) {
+            when(context.managedCursor.hasMoreEntries()).thenReturn(true);
+            doAnswer(invocation -> {
+                readCallback.set(invocation.getArgument(1));
+                readStarted.countDown();
+                return null;
+            }).when(context.managedCursor).asyncReadEntries(anyInt(), any(), anyLong(), any());
+
+            assertTrue(readStarted.await(5, TimeUnit.SECONDS));
+            context.transactionBuffer.closeAsync().get(5, TimeUnit.SECONDS);
+            context.awaitExecutorIdle();
+
+            Entry lateEntry = mock(Entry.class);
+            readCallback.get().readEntriesComplete(List.of(lateEntry), null);
+
+            verify(lateEntry).release();
+            verify(context.managedCursor).asyncReadEntries(anyInt(), any(), anyLong(), any());
+        }
+    }
+
+    private static final class TestContext implements AutoCloseable {
+        private final ExecutorService executor = Executors.newSingleThreadExecutor();
+        private final AbortedTxnProcessor processor = mock(AbortedTxnProcessor.class);
+        private final PersistentTopic topic = mock(PersistentTopic.class);
+        private final ManagedLedgerImpl managedLedger = mock(ManagedLedgerImpl.class);
+        private final ManagedCursor managedCursor = mock(ManagedCursor.class);
+        private final TopicTransactionBuffer transactionBuffer;
+
+        private TestContext(CompletableFuture<Position> recoveryFuture, Position lastConfirmedEntry) throws Exception {
+            BrokerService brokerService = mock(BrokerService.class);
+            PulsarService pulsar = mock(PulsarService.class);
+            ServiceConfiguration configuration = mock(ServiceConfiguration.class);
+            ExecutorProvider executorProvider = mock(ExecutorProvider.class);
+
+            when(topic.getName()).thenReturn("persistent://public/default/test-close-during-recovery");
+            when(topic.getBrokerService()).thenReturn(brokerService);
+            when(topic.getManagedLedger()).thenReturn(managedLedger);
+            when(brokerService.getPulsar()).thenReturn(pulsar);
+            when(pulsar.getConfiguration()).thenReturn(configuration);
+            when(pulsar.getTransactionExecutorProvider()).thenReturn(executorProvider);
+            when(executorProvider.getExecutor(any(Object.class))).thenReturn(executor);
+            when(managedLedger.getLastConfirmedEntry()).thenReturn(lastConfirmedEntry);
+            when(managedLedger.getConfig()).thenReturn(new ManagedLedgerConfig());
+            when(managedLedger.newNonDurableCursor(any(), anyString())).thenReturn(managedCursor);
+            when(processor.recoverFromSnapshot()).thenReturn(recoveryFuture);
+            when(processor.closeAsync()).thenReturn(CompletableFuture.completedFuture(null));
+
+            transactionBuffer = new TopicTransactionBuffer(topic, processor, AbortedTxnProcessor.SnapshotType.Single);
+        }
+
+        private void awaitExecutorIdle() throws Exception {
+            executor.submit(() -> { }).get(5, TimeUnit.SECONDS);
+        }
+
+        @Override
+        public void close() throws Exception {
+            transactionBuffer.closeAsync().get(5, TimeUnit.SECONDS);
+            executor.shutdownNow();
+            assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS));
+        }
+    }
+
+    /** Blocks both continuation APIs so tests can deterministically control the registration race. */
+    private static final class ContinuationBlockingRecoveryFuture extends CompletableFuture<Position> {
+        private final CountDownLatch registrationStarted = new CountDownLatch(1);
+        private final CountDownLatch allowRegistration = new CountDownLatch(1);
+
+        @Override
+        public CompletableFuture<Void> thenAccept(Consumer<? super Position> action) {
+            awaitRegistration();
+            return super.thenAccept(action);
+        }
+
+        @Override
+        public CompletableFuture<Void> thenAcceptAsync(Consumer<? super Position> action, Executor executor) {
+            awaitRegistration();
+            return super.thenAcceptAsync(action, executor);
+        }
+
+        private void awaitRegistration() {
+            registrationStarted.countDown();
+            try {
+                assertTrue(allowRegistration.await(5, TimeUnit.SECONDS));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new AssertionError(e);
+            }
+        }
+
+        private void awaitContinuationRegistrationStarted() throws Exception {
+            assertTrue(registrationStarted.await(5, TimeUnit.SECONDS));
+        }
+
+        private void allowContinuationRegistration() {
+            allowRegistration.countDown();
+        }
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBufferCloseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBufferCloseTest.java
@@ -27,13 +27,15 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -95,6 +97,38 @@ public class TopicTransactionBufferCloseTest {
     }
 
     @Test(timeOut = 10_000)
+    public void testCloseCancelsQueuedRecoveryReplay() throws Exception {
+        CompletableFuture<Position> recoveryFuture = new CompletableFuture<>();
+        CountDownLatch blockerStarted = new CountDownLatch(1);
+        CountDownLatch releaseBlocker = new CountDownLatch(1);
+        try (TestContext context = new TestContext(recoveryFuture, PositionFactory.EARLIEST)) {
+            try {
+                context.awaitExecutorIdle();
+                context.executor.clearSubmittedTask();
+                context.executor.execute(() -> {
+                    blockerStarted.countDown();
+                    try {
+                        releaseBlocker.await();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                });
+                assertTrue(blockerStarted.await(5, TimeUnit.SECONDS));
+
+                recoveryFuture.complete(PositionFactory.EARLIEST);
+                Future<?> replayTask = context.executor.submittedTask();
+                assertNotNull(replayTask);
+
+                context.transactionBuffer.closeAsync().get(5, TimeUnit.SECONDS);
+
+                assertTrue(replayTask.isCancelled());
+            } finally {
+                releaseBlocker.countDown();
+            }
+        }
+    }
+
+    @Test(timeOut = 10_000)
     public void testLateRecoveryReadIsReleasedAfterClose() throws Exception {
         Position startPosition = PositionFactory.create(1, 0);
         Position lastPosition = PositionFactory.create(1, 3);
@@ -122,7 +156,7 @@ public class TopicTransactionBufferCloseTest {
     }
 
     private static final class TestContext implements AutoCloseable {
-        private final ExecutorService executor = Executors.newSingleThreadExecutor();
+        private final TrackingExecutor executor = new TrackingExecutor();
         private final AbortedTxnProcessor processor = mock(AbortedTxnProcessor.class);
         private final PersistentTopic topic = mock(PersistentTopic.class);
         private final ManagedLedgerImpl managedLedger = mock(ManagedLedgerImpl.class);
@@ -160,6 +194,29 @@ public class TopicTransactionBufferCloseTest {
             transactionBuffer.closeAsync().get(5, TimeUnit.SECONDS);
             executor.shutdownNow();
             assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS));
+        }
+    }
+
+    private static final class TrackingExecutor extends ThreadPoolExecutor {
+        private final AtomicReference<Future<?>> submittedTask = new AtomicReference<>();
+
+        private TrackingExecutor() {
+            super(1, 1, 0L, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>());
+        }
+
+        @Override
+        public Future<?> submit(Runnable task) {
+            Future<?> future = super.submit(task);
+            submittedTask.set(future);
+            return future;
+        }
+
+        private Future<?> submittedTask() {
+            return submittedTask.get();
+        }
+
+        private void clearSubmittedTask() {
+            submittedTask.set(null);
         }
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBufferCloseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBufferCloseTest.java
@@ -40,7 +40,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Consumer;
 import org.apache.bookkeeper.common.util.OrderedScheduler;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
 import org.apache.bookkeeper.mledger.Entry;
@@ -82,19 +81,16 @@ public class TopicTransactionBufferCloseTest {
 
     @Test(timeOut = 10_000)
     public void testRecoveryContinuationDoesNotStartAfterClose() throws Exception {
-        ContinuationBlockingRecoveryFuture recoveryFuture = new ContinuationBlockingRecoveryFuture();
+        CompletableFuture<Position> recoveryFuture = new CompletableFuture<>();
         try (TestContext context = new TestContext(recoveryFuture, PositionFactory.EARLIEST)) {
-            recoveryFuture.awaitContinuationRegistrationStarted();
-            recoveryFuture.complete(PositionFactory.EARLIEST);
+            context.awaitExecutorsIdle();
 
             context.transactionBuffer.closeAsync().get(5, TimeUnit.SECONDS);
-            recoveryFuture.allowContinuationRegistration();
+            recoveryFuture.complete(PositionFactory.EARLIEST);
             context.awaitExecutorsIdle();
 
             verify(context.managedLedger, never()).newNonDurableCursor(any(), anyString());
             assertTrue(context.transactionBuffer.getTransactionBufferFuture().isCompletedExceptionally());
-        } finally {
-            recoveryFuture.allowContinuationRegistration();
         }
     }
 
@@ -215,33 +211,4 @@ public class TopicTransactionBufferCloseTest {
         }
     }
 
-    /** Blocks continuation registration so tests can deterministically control the registration race. */
-    private static final class ContinuationBlockingRecoveryFuture extends CompletableFuture<Position> {
-        private final CountDownLatch registrationStarted = new CountDownLatch(1);
-        private final CountDownLatch allowRegistration = new CountDownLatch(1);
-
-        @Override
-        public CompletableFuture<Void> thenAccept(Consumer<? super Position> action) {
-            awaitRegistration();
-            return super.thenAccept(action);
-        }
-
-        private void awaitRegistration() {
-            registrationStarted.countDown();
-            try {
-                assertTrue(allowRegistration.await(5, TimeUnit.SECONDS));
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                throw new AssertionError(e);
-            }
-        }
-
-        private void awaitContinuationRegistrationStarted() throws Exception {
-            assertTrue(registrationStarted.await(5, TimeUnit.SECONDS));
-        }
-
-        private void allowContinuationRegistration() {
-            allowRegistration.countDown();
-        }
-    }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBufferCloseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBufferCloseTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.transaction.buffer.impl;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -32,6 +33,8 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
+import io.netty.buffer.ByteBuf;
+import io.netty.util.HashedWheelTimer;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -54,11 +57,70 @@ import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.broker.service.BrokerServiceException;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.broker.transaction.buffer.AbortedTxnProcessor;
+import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.client.util.ExecutorProvider;
+import org.apache.pulsar.common.api.proto.MarkerType;
+import org.apache.pulsar.common.api.proto.MessageMetadata;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 @Test(groups = "broker")
 public class TopicTransactionBufferCloseTest {
+
+    @DataProvider
+    public Object[][] transactionCompletionModes() {
+        return new Object[][] { { true, false }, { true, true }, { false, false }, { false, true } };
+    }
+
+    @Test(dataProvider = "transactionCompletionModes", timeOut = 10_000)
+    public void testTxnCompletionUpdatesTopicOutsideBufferLock(boolean replay, boolean abort) throws Exception {
+        Position position = PositionFactory.create(1, 1);
+        CompletableFuture<Position> recoveryFuture = new CompletableFuture<>();
+        try (TestContext context = new TestContext(recoveryFuture, position)) {
+            // Fenced publish failures close the buffer while holding the topic monitor.
+            doAnswer(__ -> {
+                assertThat(Thread.holdsLock(context.transactionBuffer))
+                        .as("updating the topic must not acquire its monitor while holding the buffer monitor")
+                        .isFalse();
+                return null;
+            }).when(context.topic).updateLastDispatchablePosition(null);
+
+            TxnID txnID = new TxnID(1, 1);
+            if (replay) {
+                Entry marker = mock(Entry.class);
+                when(marker.getLedgerId()).thenReturn(position.getLedgerId());
+                when(marker.getEntryId()).thenReturn(position.getEntryId());
+                when(marker.getMessageMetadata()).thenReturn(new MessageMetadata()
+                        .setTxnidMostBits(txnID.getMostSigBits())
+                        .setTxnidLeastBits(txnID.getLeastSigBits())
+                        .setMarkerType((abort ? MarkerType.TXN_ABORT : MarkerType.TXN_COMMIT).getValue()));
+                when(context.managedCursor.hasMoreEntries()).thenReturn(true, false);
+                doAnswer(invocation -> {
+                    AsyncCallbacks.ReadEntriesCallback callback = invocation.getArgument(1);
+                    callback.readEntriesComplete(List.of(marker), null);
+                    return null;
+                }).when(context.managedCursor).asyncReadEntries(anyInt(), any(), anyLong(), any());
+
+                recoveryFuture.complete(PositionFactory.create(1, 0));
+                context.transactionBuffer.getTransactionBufferFuture().get(5, TimeUnit.SECONDS);
+                verify(marker).release();
+            } else {
+                recoveryFuture.complete(position);
+                context.transactionBuffer.getTransactionBufferFuture().get(5, TimeUnit.SECONDS);
+                doAnswer(invocation -> {
+                    AsyncCallbacks.AddEntryCallback callback = invocation.getArgument(1);
+                    callback.addComplete(position, invocation.getArgument(0), null);
+                    return null;
+                }).when(context.managedLedger).asyncAddEntry(any(ByteBuf.class), any(), any());
+
+                CompletableFuture<Void> completion = abort
+                        ? context.transactionBuffer.abortTxn(txnID, 0)
+                        : context.transactionBuffer.commitTxn(txnID, 0);
+                completion.get(5, TimeUnit.SECONDS);
+            }
+            verify(context.topic).updateLastDispatchablePosition(null);
+        }
+    }
 
     @Test(timeOut = 10_000)
     public void testCloseInducedRecoveryFailureDoesNotCloseTopicAgain() throws Exception {
@@ -183,6 +245,7 @@ public class TopicTransactionBufferCloseTest {
             when(topic.getManagedLedger()).thenReturn(managedLedger);
             when(brokerService.getPulsar()).thenReturn(pulsar);
             when(pulsar.getConfiguration()).thenReturn(configuration);
+            when(pulsar.getTransactionTimer()).thenReturn(mock(HashedWheelTimer.class));
             when(pulsar.getTransactionExecutorProvider()).thenReturn(executorProvider);
             when(executorProvider.getExecutor(any(Object.class))).thenReturn(transactionExecutor);
             when(pulsar.getTransactionSnapshotRecoverExecutorProvider()).thenReturn(recoveryScheduler);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBufferCloseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBufferCloseTest.java
@@ -25,20 +25,23 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
+import com.google.common.util.concurrent.ListeningScheduledExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import org.apache.bookkeeper.common.util.OrderedScheduler;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedCursor;
@@ -71,7 +74,7 @@ public class TopicTransactionBufferCloseTest {
             });
 
             context.transactionBuffer.closeAsync().get(5, TimeUnit.SECONDS);
-            context.awaitExecutorIdle();
+            context.awaitExecutorsIdle();
 
             verify(context.topic, never()).close(true);
             assertTrue(context.transactionBuffer.getTransactionBufferFuture().isCompletedExceptionally());
@@ -87,7 +90,7 @@ public class TopicTransactionBufferCloseTest {
 
             context.transactionBuffer.closeAsync().get(5, TimeUnit.SECONDS);
             recoveryFuture.allowContinuationRegistration();
-            context.awaitExecutorIdle();
+            context.awaitExecutorsIdle();
 
             verify(context.managedLedger, never()).newNonDurableCursor(any(), anyString());
             assertTrue(context.transactionBuffer.getTransactionBufferFuture().isCompletedExceptionally());
@@ -103,9 +106,14 @@ public class TopicTransactionBufferCloseTest {
         CountDownLatch releaseBlocker = new CountDownLatch(1);
         try (TestContext context = new TestContext(recoveryFuture, PositionFactory.EARLIEST)) {
             try {
-                context.awaitExecutorIdle();
-                context.executor.clearSubmittedTask();
-                context.executor.execute(() -> {
+                context.awaitExecutorsIdle();
+                AtomicReference<Future<?>> submittedTask = new AtomicReference<>();
+                doAnswer(invocation -> {
+                    Future<?> task = (Future<?>) invocation.callRealMethod();
+                    submittedTask.set(task);
+                    return task;
+                }).when(context.recoveryExecutor).submit(any(Runnable.class));
+                context.recoveryExecutor.execute(() -> {
                     blockerStarted.countDown();
                     try {
                         releaseBlocker.await();
@@ -116,7 +124,7 @@ public class TopicTransactionBufferCloseTest {
                 assertTrue(blockerStarted.await(5, TimeUnit.SECONDS));
 
                 recoveryFuture.complete(PositionFactory.EARLIEST);
-                Future<?> replayTask = context.executor.submittedTask();
+                Future<?> replayTask = submittedTask.get();
                 assertNotNull(replayTask);
 
                 context.transactionBuffer.closeAsync().get(5, TimeUnit.SECONDS);
@@ -132,7 +140,7 @@ public class TopicTransactionBufferCloseTest {
     public void testLateRecoveryReadIsReleasedAfterClose() throws Exception {
         Position startPosition = PositionFactory.create(1, 0);
         Position lastPosition = PositionFactory.create(1, 3);
-        CompletableFuture<Position> recoveryFuture = CompletableFuture.completedFuture(startPosition);
+        CompletableFuture<Position> recoveryFuture = new CompletableFuture<>();
         CountDownLatch readStarted = new CountDownLatch(1);
         AtomicReference<AsyncCallbacks.ReadEntriesCallback> readCallback = new AtomicReference<>();
         try (TestContext context = new TestContext(recoveryFuture, lastPosition)) {
@@ -143,9 +151,12 @@ public class TopicTransactionBufferCloseTest {
                 return null;
             }).when(context.managedCursor).asyncReadEntries(anyInt(), any(), anyLong(), any());
 
+            recoveryFuture.complete(startPosition);
             assertTrue(readStarted.await(5, TimeUnit.SECONDS));
+            // Live transaction work must still run while the recovery read is outstanding.
+            context.transactionExecutor.submit(() -> { }).get(5, TimeUnit.SECONDS);
             context.transactionBuffer.closeAsync().get(5, TimeUnit.SECONDS);
-            context.awaitExecutorIdle();
+            context.awaitExecutorsIdle();
 
             Entry lateEntry = mock(Entry.class);
             readCallback.get().readEntriesComplete(List.of(lateEntry), null);
@@ -156,7 +167,9 @@ public class TopicTransactionBufferCloseTest {
     }
 
     private static final class TestContext implements AutoCloseable {
-        private final TrackingExecutor executor = new TrackingExecutor();
+        private final ExecutorService transactionExecutor = Executors.newSingleThreadExecutor();
+        private final ListeningScheduledExecutorService recoveryExecutor =
+                spy(MoreExecutors.listeningDecorator(Executors.newSingleThreadScheduledExecutor()));
         private final AbortedTxnProcessor processor = mock(AbortedTxnProcessor.class);
         private final PersistentTopic topic = mock(PersistentTopic.class);
         private final ManagedLedgerImpl managedLedger = mock(ManagedLedgerImpl.class);
@@ -168,6 +181,7 @@ public class TopicTransactionBufferCloseTest {
             PulsarService pulsar = mock(PulsarService.class);
             ServiceConfiguration configuration = mock(ServiceConfiguration.class);
             ExecutorProvider executorProvider = mock(ExecutorProvider.class);
+            OrderedScheduler recoveryScheduler = mock(OrderedScheduler.class);
 
             when(topic.getName()).thenReturn("persistent://public/default/test-close-during-recovery");
             when(topic.getBrokerService()).thenReturn(brokerService);
@@ -175,7 +189,9 @@ public class TopicTransactionBufferCloseTest {
             when(brokerService.getPulsar()).thenReturn(pulsar);
             when(pulsar.getConfiguration()).thenReturn(configuration);
             when(pulsar.getTransactionExecutorProvider()).thenReturn(executorProvider);
-            when(executorProvider.getExecutor(any(Object.class))).thenReturn(executor);
+            when(executorProvider.getExecutor(any(Object.class))).thenReturn(transactionExecutor);
+            when(pulsar.getTransactionSnapshotRecoverExecutorProvider()).thenReturn(recoveryScheduler);
+            when(recoveryScheduler.chooseThread(any(Object.class))).thenReturn(recoveryExecutor);
             when(managedLedger.getLastConfirmedEntry()).thenReturn(lastConfirmedEntry);
             when(managedLedger.getConfig()).thenReturn(new ManagedLedgerConfig());
             when(managedLedger.newNonDurableCursor(any(), anyString())).thenReturn(managedCursor);
@@ -185,42 +201,22 @@ public class TopicTransactionBufferCloseTest {
             transactionBuffer = new TopicTransactionBuffer(topic, processor, AbortedTxnProcessor.SnapshotType.Single);
         }
 
-        private void awaitExecutorIdle() throws Exception {
-            executor.submit(() -> { }).get(5, TimeUnit.SECONDS);
+        private void awaitExecutorsIdle() throws Exception {
+            transactionExecutor.submit(() -> { }).get(5, TimeUnit.SECONDS);
+            recoveryExecutor.submit(() -> { }).get(5, TimeUnit.SECONDS);
         }
 
         @Override
         public void close() throws Exception {
             transactionBuffer.closeAsync().get(5, TimeUnit.SECONDS);
-            executor.shutdownNow();
-            assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS));
+            transactionExecutor.shutdownNow();
+            recoveryExecutor.shutdownNow();
+            assertTrue(transactionExecutor.awaitTermination(5, TimeUnit.SECONDS));
+            assertTrue(recoveryExecutor.awaitTermination(5, TimeUnit.SECONDS));
         }
     }
 
-    private static final class TrackingExecutor extends ThreadPoolExecutor {
-        private final AtomicReference<Future<?>> submittedTask = new AtomicReference<>();
-
-        private TrackingExecutor() {
-            super(1, 1, 0L, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>());
-        }
-
-        @Override
-        public Future<?> submit(Runnable task) {
-            Future<?> future = super.submit(task);
-            submittedTask.set(future);
-            return future;
-        }
-
-        private Future<?> submittedTask() {
-            return submittedTask.get();
-        }
-
-        private void clearSubmittedTask() {
-            submittedTask.set(null);
-        }
-    }
-
-    /** Blocks both continuation APIs so tests can deterministically control the registration race. */
+    /** Blocks continuation registration so tests can deterministically control the registration race. */
     private static final class ContinuationBlockingRecoveryFuture extends CompletableFuture<Position> {
         private final CountDownLatch registrationStarted = new CountDownLatch(1);
         private final CountDownLatch allowRegistration = new CountDownLatch(1);
@@ -229,12 +225,6 @@ public class TopicTransactionBufferCloseTest {
         public CompletableFuture<Void> thenAccept(Consumer<? super Position> action) {
             awaitRegistration();
             return super.thenAccept(action);
-        }
-
-        @Override
-        public CompletableFuture<Void> thenAcceptAsync(Consumer<? super Position> action, Executor executor) {
-            awaitRegistration();
-            return super.thenAcceptAsync(action, executor);
         }
 
         private void awaitRegistration() {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBufferCloseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBufferCloseTest.java
@@ -63,10 +63,9 @@ public class TopicTransactionBufferCloseTest {
 
     @Test(timeOut = 10_000)
     public void testCloseInducedRecoveryFailureDoesNotCloseTopicAgain() throws Exception {
-        ContinuationBlockingRecoveryFuture recoveryFuture = new ContinuationBlockingRecoveryFuture();
-        recoveryFuture.allowContinuationRegistration();
+        CompletableFuture<Position> recoveryFuture = new CompletableFuture<>();
         try (TestContext context = new TestContext(recoveryFuture, PositionFactory.EARLIEST)) {
-            recoveryFuture.awaitContinuationRegistrationStarted();
+            context.awaitExecutorsIdle();
             when(context.processor.closeAsync()).thenAnswer(__ -> {
                 recoveryFuture.completeExceptionally(
                         new BrokerServiceException.ServiceUnitNotReadyException("processor closed"));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBufferRecoveryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBufferRecoveryTest.java
@@ -18,8 +18,14 @@
  */
 package org.apache.pulsar.broker.transaction.buffer.impl;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
@@ -28,17 +34,22 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import lombok.Cleanup;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.PositionFactory;
 import org.apache.pulsar.broker.BrokerTestUtil;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.broker.service.schema.SchemaRegistryService;
 import org.apache.pulsar.broker.transaction.buffer.AbortedTxnProcessor;
 import org.apache.pulsar.broker.transaction.buffer.TransactionBufferProvider;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.ProducerConsumerBase;
 import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.protocol.schema.SchemaVersion;
 import org.awaitility.Awaitility;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -68,6 +79,50 @@ public class TopicTransactionBufferRecoveryTest extends ProducerConsumerBase {
     @DataProvider(name = "snapshotExists")
     public Object[][] snapshotExists() {
         return new Object[][] { { false }, { true } };
+    }
+
+    @Test(dataProvider = "snapshotExists", timeOut = 30_000)
+    public void testRecoveryCompletesAfterDeletionFails(boolean snapshotExists) throws Exception {
+        String topicName = BrokerTestUtil.newUniqueName("persistent://public/default/tb-recovery-delete-failure");
+        TopicName parsedTopicName = TopicName.get(topicName);
+        CompletableFuture<Position> recoveryFuture = new CompletableFuture<>();
+        CompletableFuture<SchemaVersion> schemaDeleteFuture = new CompletableFuture<>();
+        SchemaRegistryService schemaRegistryService = spy(pulsar.getSchemaRegistryService());
+        doReturn(schemaDeleteFuture).when(schemaRegistryService).deleteSchemaStorage(parsedTopicName.getSchemaName());
+        AbortedTxnProcessor processor = mock(AbortedTxnProcessor.class);
+        when(processor.recoverFromSnapshot()).thenReturn(recoveryFuture);
+        when(processor.closeAsync()).thenReturn(CompletableFuture.completedFuture(null));
+        TransactionBufferProvider originalProvider = pulsar.getTransactionBufferProvider();
+        pulsar.setTransactionBufferProvider(topic -> new TopicTransactionBuffer(
+                (PersistentTopic) topic, processor, AbortedTxnProcessor.SnapshotType.Single));
+        doReturn(schemaRegistryService).when(pulsar).getSchemaRegistryService();
+        try {
+            PersistentTopic topic = (PersistentTopic) pulsar.getBrokerService()
+                    .getTopic(topicName, true).get(5, TimeUnit.SECONDS).orElseThrow();
+            ExecutorService transactionExecutor =
+                    pulsar.getTransactionExecutorProvider().getExecutor(topic.getTransactionBuffer());
+            // Ensure the recovery continuation is registered before completing its future.
+            transactionExecutor.submit(() -> { }).get(5, TimeUnit.SECONDS);
+            CompletableFuture<Void> deleteFuture = topic.delete();
+            verify(schemaRegistryService, timeout(5_000)).deleteSchemaStorage(parsedTopicName.getSchemaName());
+            assertThat(topic.isClosingOrDeleting()).isTrue();
+
+            recoveryFuture.complete(snapshotExists ? PositionFactory.EARLIEST : null);
+            // Let replay run while deletion is pending, regardless of which executor dispatches it.
+            transactionExecutor.submit(() -> { }).get(5, TimeUnit.SECONDS);
+            pulsar.getTransactionSnapshotRecoverExecutorProvider().chooseThread(parsedTopicName.getNamespace())
+                    .submit(() -> { }).get(5, TimeUnit.SECONDS);
+
+            schemaDeleteFuture.completeExceptionally(new IllegalStateException("schema deletion failed"));
+            assertThatThrownBy(() -> deleteFuture.get(5, TimeUnit.SECONDS))
+                    .hasCauseInstanceOf(IllegalStateException.class);
+            assertThat(topic.isClosingOrDeleting()).isFalse();
+            topic.getTransactionBuffer().checkIfTBRecoverCompletely().get(5, TimeUnit.SECONDS);
+        } finally {
+            schemaDeleteFuture.completeExceptionally(new IllegalStateException("test finished"));
+            doCallRealMethod().when(pulsar).getSchemaRegistryService();
+            pulsar.setTransactionBufferProvider(originalProvider);
+        }
     }
 
     /**

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBufferRecoveryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBufferRecoveryTest.java
@@ -82,6 +82,39 @@ public class TopicTransactionBufferRecoveryTest extends ProducerConsumerBase {
     }
 
     @Test(dataProvider = "snapshotExists", timeOut = 30_000)
+    public void testRecoveryNotifiesLastPositionQueryOutsideBufferLock(boolean snapshotExists) throws Exception {
+        String topicName = BrokerTestUtil.newUniqueName("persistent://public/default/tb-recovery-last-position");
+        CompletableFuture<Position> recoveryFuture = new CompletableFuture<>();
+        AbortedTxnProcessor processor = mock(AbortedTxnProcessor.class);
+        when(processor.recoverFromSnapshot()).thenReturn(recoveryFuture);
+        when(processor.closeAsync()).thenReturn(CompletableFuture.completedFuture(null));
+        TransactionBufferProvider originalProvider = pulsar.getTransactionBufferProvider();
+        pulsar.setTransactionBufferProvider(topic -> new TopicTransactionBuffer(
+                (PersistentTopic) topic, processor, AbortedTxnProcessor.SnapshotType.Single));
+        try {
+            PersistentTopic topic = (PersistentTopic) pulsar.getBrokerService()
+                    .getTopic(topicName, true).get(5, TimeUnit.SECONDS).orElseThrow();
+            Position lastConfirmedEntry = topic.getManagedLedger().getLastConfirmedEntry();
+            assertThat(lastConfirmedEntry.getEntryId()).isEqualTo(-1);
+
+            // GetLastMessageId registers this continuation; an empty ledger's lookup can take the topic lock inline.
+            CompletableFuture<Position> lastPositionFuture = topic.checkIfTransactionBufferRecoverCompletely()
+                    .thenCompose(__ -> {
+                        assertThat(Thread.holdsLock(topic.getTransactionBuffer()))
+                                .as("recovery callbacks must run outside the buffer monitor")
+                                .isFalse();
+                        return topic.getLastDispatchablePosition();
+                    });
+
+            recoveryFuture.complete(snapshotExists ? PositionFactory.EARLIEST : null);
+            assertThat(lastPositionFuture.get(5, TimeUnit.SECONDS)).isEqualTo(lastConfirmedEntry);
+        } finally {
+            recoveryFuture.complete(null);
+            pulsar.setTransactionBufferProvider(originalProvider);
+        }
+    }
+
+    @Test(dataProvider = "snapshotExists", timeOut = 30_000)
     public void testRecoveryCompletesAfterDeletionFails(boolean snapshotExists) throws Exception {
         String topicName = BrokerTestUtil.newUniqueName("persistent://public/default/tb-recovery-delete-failure");
         TopicName parsedTopicName = TopicName.get(topicName);


### PR DESCRIPTION
### Motivation

Transaction snapshot recovery tasks can remain queued after a topic is closed.
The queued task retains the snapshot processor, topic, and managed ledger,
causing closed topics to accumulate when topic loading is repeatedly retried.

### Modifications

- Cancel queued snapshot recovery tasks when the transaction buffer closes.
- Wait for running recovery to stop before releasing snapshot resources.
- Prevent recovery from succeeding after close has started.
- Stop segmented recovery between I/O operations after close.
- Handle recovery task submission rejection asynchronously.
- Add tests for queued, running, completed, retried, and rejected recovery.

Topic close may now wait for an in-flight recovery I/O operation to finish before releasing snapshot resources.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment