### PR TITLE
[fix][sec] Upgrade Jackson to 2.18.10

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -249,17 +249,17 @@ The Apache Software License, Version 2.0
      - info.picocli-picocli-shell-jline3-4.7.7.jar
  * High Performance Primitive Collections for Java -- com.carrotsearch-hppc-0.9.1.jar
  * Jackson
-     - com.fasterxml.jackson.core-jackson-annotations-2.18.9.jar
-     - com.fasterxml.jackson.core-jackson-core-2.18.9.jar
-     - com.fasterxml.jackson.core-jackson-databind-2.18.9.jar
-     - com.fasterxml.jackson.dataformat-jackson-dataformat-yaml-2.18.9.jar
-     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-base-2.18.9.jar
-     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-json-provider-2.18.9.jar
-     - com.fasterxml.jackson.module-jackson-module-jaxb-annotations-2.18.9.jar
-     - com.fasterxml.jackson.module-jackson-module-jsonSchema-2.18.9.jar
-     - com.fasterxml.jackson.datatype-jackson-datatype-jdk8-2.18.9.jar
-     - com.fasterxml.jackson.datatype-jackson-datatype-jsr310-2.18.9.jar
-     - com.fasterxml.jackson.module-jackson-module-parameter-names-2.18.9.jar
+     - com.fasterxml.jackson.core-jackson-annotations-2.18.10.jar
+     - com.fasterxml.jackson.core-jackson-core-2.18.10.jar
+     - com.fasterxml.jackson.core-jackson-databind-2.18.10.jar
+     - com.fasterxml.jackson.dataformat-jackson-dataformat-yaml-2.18.10.jar
+     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-base-2.18.10.jar
+     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-json-provider-2.18.10.jar
+     - com.fasterxml.jackson.module-jackson-module-jaxb-annotations-2.18.10.jar
+     - com.fasterxml.jackson.module-jackson-module-jsonSchema-2.18.10.jar
+     - com.fasterxml.jackson.datatype-jackson-datatype-jdk8-2.18.10.jar
+     - com.fasterxml.jackson.datatype-jackson-datatype-jsr310-2.18.10.jar
+     - com.fasterxml.jackson.module-jackson-module-parameter-names-2.18.10.jar
  * Caffeine -- com.github.ben-manes.caffeine-caffeine-3.2.4.jar
  * Conscrypt -- org.conscrypt-conscrypt-openjdk-uber-2.6.2.jar
  * Fastutil -- it.unimi.dsi-fastutil-8.5.16.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -313,17 +313,17 @@ The Apache Software License, Version 2.0
      - picocli-4.7.7.jar
      - picocli-shell-jline3-4.7.7.jar
  * Jackson
-     - jackson-annotations-2.18.9.jar
-     - jackson-core-2.18.9.jar
-     - jackson-databind-2.18.9.jar
-     - jackson-dataformat-yaml-2.18.9.jar
-     - jackson-jaxrs-base-2.18.9.jar
-     - jackson-jaxrs-json-provider-2.18.9.jar
-     - jackson-module-jaxb-annotations-2.18.9.jar
-     - jackson-module-jsonSchema-2.18.9.jar
-     - jackson-datatype-jdk8-2.18.9.jar
-     - jackson-datatype-jsr310-2.18.9.jar
-     - jackson-module-parameter-names-2.18.9.jar
+     - jackson-annotations-2.18.10.jar
+     - jackson-core-2.18.10.jar
+     - jackson-databind-2.18.10.jar
+     - jackson-dataformat-yaml-2.18.10.jar
+     - jackson-jaxrs-base-2.18.10.jar
+     - jackson-jaxrs-json-provider-2.18.10.jar
+     - jackson-module-jaxb-annotations-2.18.10.jar
+     - jackson-module-jsonSchema-2.18.10.jar
+     - jackson-datatype-jdk8-2.18.10.jar
+     - jackson-datatype-jsr310-2.18.10.jar
+     - jackson-module-parameter-names-2.18.10.jar
  * Caffeine -- caffeine-3.2.4.jar
  * Conscrypt -- conscrypt-openjdk-uber-2.6.2.jar
  * Gson

--- a/pom.xml
+++ b/pom.xml
@@ -211,7 +211,7 @@ flexible messaging model and an intuitive client API.</description>
     <bouncycastle.bcpkix-fips.version>2.0.11</bouncycastle.bcpkix-fips.version>
     <bouncycastle.bcutil-fips.version>2.0.6</bouncycastle.bcutil-fips.version>
     <bouncycastle.bc-fips.version>2.0.1</bouncycastle.bc-fips.version>
-    <jackson.version>2.18.9</jackson.version>
+    <jackson.version>2.18.10</jackson.version>
     <fastutil.version>8.5.16</fastutil.version>
     <jctools.version>4.0.5</jctools.version>
     <reflections.version>0.10.2</reflections.version>


### PR DESCRIPTION
### Motivation

Jackson 2.18.10 (released 15-Aug-2026) is a security release. `branch-4.2` currently ships 2.18.9, so
it is exposed to the following issues fixed upstream:

**jackson-databind**
- `CVE-2026-68497` — `StreamReadConstraints` number-length constraint was not applied to
  `javax.xml.datatype.XMLGregorianCalendar` / `javax.xml.datatype.Duration`
- `CVE-2026-19032` — unrestricted URL schemes in `java.nio.file.Path` deserialization
- `GHSA-gx83-3vf8-gh7j` — `java.lang.Comparable` was missing from the set of "unsafe" polymorphic
  base types

**jackson-core**
- `CVE-2026-68498` — `maxNameLength` was not enforced incrementally in `ReaderBasedJsonParser`
- `GHSA-2c4j-63jj-9fqr` — `maxDocumentLength` bypass in the async parser's single-`feedInput()` case

2.18.10 also picks up hardening for number-length limits on `BigDecimal`/`BigInteger`/`Double`/`Float`
map keys (databind #6165) and non-ASCII digit rejection in `InetAddress` literal validation
(databind #6116).

This is the `branch-4.2` counterpart of #26338, which takes `master` to Jackson 2.21.6. Both are
patch upgrades within the Jackson line each branch already tracks; this one stays on 2.18.x.

### Modifications

- `pom.xml`: `jackson.version` 2.18.9 → 2.18.10.
- `distribution/server/src/assemble/LICENSE.bin.txt` and
  `distribution/shell/src/assemble/LICENSE.bin.txt`: bumped the 11 bundled Jackson jar names in each.

The root `pom.xml` imports `jackson-bom` and no module overrides a Jackson version, so the single
property governs every Jackson artifact. Unlike on `master`, `jackson-annotations` is bumped here too:
Jackson only dropped the patch component from that artifact in 2.20, so 2.18.x still publishes
`jackson-annotations-2.18.10`.

I reviewed the 2.18.10 behaviour changes against this branch's usage and none of them apply:

- The polymorphic-base hardening is inert because `ProtectedObjectMapper` already throws
  `UnsupportedOperationException` from every `activateDefaultTyping` / `enableDefaultTyping` overload.
- There is no `XMLGregorianCalendar` / `javax.xml.datatype` usage.
- The only jackson-dataformats-text change in 2.18.10 is in the TOML module, which Pulsar does not use.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a dependency upgrade without new test coverage; it is verified by the existing binary
license checks:

- Built both distributions and ran `src/check-binary-license.sh` against each tarball — both exit 0.
- Confirmed the bundled jars are actually the new version: all 11 Jackson jars in both the server and
  shell tarballs are `2.18.10`, and the artifact set is unchanged from 2.18.9.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [x] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

Upgrades the Jackson dependency from 2.18.9 to 2.18.10 (patch release within the same line).
