### PR TITLE
[fix][cli] Restore the 64M default client memory limit in pulsar-perf

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -61,6 +61,8 @@ import org.apache.pulsar.tls.TlsPurpose;
 public class ClientConfigurationData implements Serializable, Cloneable {
     private static final long serialVersionUID = 1L;
 
+    public static final long DEFAULT_MEMORY_LIMIT_BYTES = 64 * 1024 * 1024;
+
     @Schema(
             name = "serviceUrl",
             requiredMode = Schema.RequiredMode.REQUIRED,
@@ -433,7 +435,7 @@ public class ClientConfigurationData implements Serializable, Cloneable {
             description = "Limit of client memory usage (in byte). The 64M default can guarantee a high producer "
                     + "throughput."
     )
-    private long memoryLimitBytes = 64 * 1024 * 1024;
+    private long memoryLimitBytes = DEFAULT_MEMORY_LIMIT_BYTES;
 
     @Schema(
             name = "proxyServiceUrl",

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceBaseArguments.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceBaseArguments.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.testclient;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.pulsar.client.impl.conf.ClientConfigurationData.DEFAULT_MEMORY_LIMIT_BYTES;
 import org.apache.pulsar.cli.converters.picocli.ByteUnitToLongConverter;
 import org.apache.pulsar.client.api.ProxyProtocol;
 import picocli.CommandLine.Option;
@@ -98,8 +99,9 @@ public abstract class PerformanceBaseArguments extends CmdBase{
     public String deprecatedAuthPluginClassName;
 
     @Option(names = { "-ml", "--memory-limit", }, description = "Configure the Pulsar client memory limit "
-            + "(eg: 32M, 64M)", converter = ByteUnitToLongConverter.class)
-    public long memoryLimit;
+            + "(eg: 32M, 64M). Use 0 to disable the limit. Default: 64M",
+            converter = ByteUnitToLongConverter.class)
+    public long memoryLimit = DEFAULT_MEMORY_LIMIT_BYTES;
     public PerformanceBaseArguments(String cmdName) {
         super(cmdName);
     }

--- a/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerformanceBaseArgumentsTest.java
+++ b/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerformanceBaseArgumentsTest.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.testclient;
 
 import static org.apache.pulsar.client.api.ProxyProtocol.SNI;
+import static org.apache.pulsar.client.impl.conf.ClientConfigurationData.DEFAULT_MEMORY_LIMIT_BYTES;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 import java.io.File;
@@ -245,6 +246,38 @@ public class PerformanceBaseArgumentsTest {
             }
             baseArgument.getCommander().setDefaultValueProvider(PulsarPerfTestPropertiesProvider.create(prop));
             baseArgument.parse(new String[]{});
+
+            // Act
+            baseArgument.parseCLI();
+
+            // Assert
+            assertEquals(baseArgument.memoryLimit, DEFAULT_MEMORY_LIMIT_BYTES);
+        }
+    }
+
+    @Test
+    public void testMemoryLimitCanBeDisabled() throws Exception {
+        for (String cmd : List.of(
+                "pulsar-perf read",
+                "pulsar-perf produce",
+                "pulsar-perf consume",
+                "pulsar-perf transaction"
+        )) {
+            // Arrange
+            final PerformanceBaseArguments baseArgument = new PerformanceBaseArguments("") {
+                @Override
+                public void run() throws Exception {
+
+                }
+
+            };
+            String confFile = "./src/test/resources/perf_client1.conf";
+            Properties prop = new Properties(System.getProperties());
+            try (FileInputStream fis = new FileInputStream(confFile)) {
+                prop.load(fis);
+            }
+            baseArgument.getCommander().setDefaultValueProvider(PulsarPerfTestPropertiesProvider.create(prop));
+            baseArgument.parse(new String[]{"-ml", "0"});
 
             // Act
             baseArgument.parseCLI();


### PR DESCRIPTION
Fixes #26340

### Motivation

`pulsar-perf` can exhaust direct memory and die with `OutOfDirectMemoryError` whenever the
producer outruns the brokers:

```
failed to allocate 4194304 byte(s) of direct memory (used: 4131389440, max: 4131389440)
```

The same run against a 3.0.x client completes normally, which makes this look like a client
regression. It is, but not in the allocator. It is a lost default.

Before #20663, `PerfClientUtils.createClientBuilderFromArguments` never called
`ClientBuilder#memoryLimit`, so `pulsar-perf` inherited the client default of 64M from
`ClientConfigurationData#memoryLimitBytes`.

That PR added the `--memory-limit` option and applied it unconditionally:

```java
ClientBuilder clientBuilder = PulsarClient.builder()
        .memoryLimit(arguments.memoryLimit, SizeUnit.BYTES)
```

but the backing field has no initializer:

```java
@Option(names = { "-ml", "--memory-limit", }, ...)
public long memoryLimit;
```

so when the option is not supplied, `pulsar-perf` passes `0`. And `0` is not "no override", it is
"no limit":

```java
public boolean isMemoryLimited() {
    return memoryLimit > 0;
}
```

So `pulsar-perf` went from bounded to unbounded client memory without anyone choosing that.

With the limit disabled there is no backpressure on the producer. When the brokers cannot keep up
with the offered rate, outbound buffers accumulate until direct memory is exhausted and the client
dies, rather than throttling and reporting the achievable rate, which is what a benchmarking tool
should do. Passing `--memory-limit 64M` restores the old behaviour and the same run completes.

This also affects `PerformanceConsumer`, `PerformanceReader`, `PerformanceTransaction` and
`LoadSimulationClient`, which share `PerformanceBaseArguments`, and on master it reaches both the
existing builder and the v5 `PulsarClientBuilder` call site.

### Modifications

- Extract the existing literal into `ClientConfigurationData.DEFAULT_MEMORY_LIMIT_BYTES` and use it
  for `memoryLimitBytes`. This is a pure refactor of a value that is already 64M; it just gives the
  default a name so the CLI can reference it. It follows the existing convention in the sibling
  `ProducerConfigurationData`, which already exposes `DEFAULT_BATCHING_MAX_MESSAGES` and friends
  that `PerformanceProducer` imports.
- Initialise `PerformanceBaseArguments#memoryLimit` to that constant, so an unset `--memory-limit`
  reproduces the pre-#20663 behaviour instead of silently disabling the limit. Referencing the
  constant rather than repeating `64 * 1024 * 1024` means the CLI default cannot drift from the
  client default.
- Update the option description to state the default and to document that `0` disables the limit.

`--memory-limit 0` still disables the limit explicitly, so the capability added by #20663 is
retained. Only the unset behaviour changes.

### Verifying this change

This change is already covered by existing tests, such as
`PerformanceBaseArgumentsTest#testMemoryLimitCliArgument`, which continues to verify that explicit
values (`-ml 1`, `-ml 1K`, `--memory-limit 1G`) are parsed correctly.

`PerformanceBaseArgumentsTest#testMemoryLimitCliArgumentDefault` asserted the previous `0` default
and is updated to assert the restored 64M default.

Added `PerformanceBaseArgumentsTest#testMemoryLimitCanBeDisabled` to pin the escape hatch, so a
future change cannot quietly remove the ability to run unbounded via `-ml 0`.

```
./gradlew :pulsar-testclient:test --tests '*PerformanceBaseArgumentsTest*'
BUILD SUCCESSFUL
8 tests, 0 failures, 0 skipped
```

The end-to-end behaviour was verified against a 3-node cluster: `pulsar-perf produce -r 100000
-time 300 -s 1024` fails with `OutOfDirectMemoryError` on 4.0.9 and 4.0.13, and completes once the
64M limit is in effect.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [x] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

The default of the `pulsar-perf` `--memory-limit` option changes from `0` (unlimited) to `64M`.
This restores the behaviour that `pulsar-perf` had before #20663 rather than introducing a new
one, and it aligns the tool with the documented client default. Existing runs that relied on
unbounded client memory need `--memory-limit 0` to keep it.

`ClientConfigurationData#memoryLimitBytes` itself is unchanged at 64M; only the literal moves to a
named constant.
