### PR TITLE
[improve][build] Upgrade BouncyCastle to 1.85 and BouncyCastle FIPS to 2.1.x

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -625,9 +625,9 @@ Public Domain (CC0) -- ../licenses/LICENSE-CC0.txt
 
 Bouncy Castle License
  * Bouncy Castle -- ../licenses/LICENSE-bouncycastle.txt
-    - org.bouncycastle-bcpkix-jdk18on-1.84.jar
-    - org.bouncycastle-bcprov-jdk18on-1.84.jar
-    - org.bouncycastle-bcutil-jdk18on-1.84.jar
+    - org.bouncycastle-bcpkix-jdk18on-1.85.jar
+    - org.bouncycastle-bcprov-jdk18on-1.85.2.jar
+    - org.bouncycastle-bcutil-jdk18on-1.85.jar
 
 ------------------------
 

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -473,9 +473,9 @@ Public Domain (CC0) -- ../licenses/LICENSE-CC0.txt
 
 Bouncy Castle License
  * Bouncy Castle -- ../licenses/LICENSE-bouncycastle.txt
-    - bcpkix-jdk18on-1.84.jar
-    - bcprov-jdk18on-1.84.jar
-    - bcutil-jdk18on-1.84.jar
+    - bcpkix-jdk18on-1.85.jar
+    - bcprov-jdk18on-1.85.2.jar
+    - bcutil-jdk18on-1.85.jar
 
 ------------------------
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,10 +55,13 @@ commons-logging = "1.3.6"
 commons-beanutils = "1.11.0"
 commons-configuration2 = "2.15.1"
 # BouncyCastle
-bouncycastle = "1.84"
-bouncycastle-bcpkix-fips = "2.0.11"
-bouncycastle-bcutil-fips = "2.0.6"
-bouncycastle-bc-fips = "2.0.1"
+bouncycastle = "1.85"
+# bcprov is versioned separately: BouncyCastle shipped a provider-only patch release (1.85.2)
+# that was not published for bcpkix-jdk18on or bctls-jdk18on, which remain at 1.85
+bouncycastle-bcprov = "1.85.2"
+bouncycastle-bcpkix-fips = "2.1.12"
+bouncycastle-bcutil-fips = "2.1.7"
+bouncycastle-bc-fips = "2.1.3"
 # Serialization
 avro = "1.12.0"
 gson = "2.13.2"
@@ -458,7 +461,7 @@ athenz-cert-refresher = { module = "com.yahoo.athenz:athenz-cert-refresher", ver
 athenz-auth-core = { module = "com.yahoo.athenz:athenz-auth-core", version.ref = "athenz" }
 athenz-zpe-java-client = { module = "com.yahoo.athenz:athenz-zpe-java-client", version.ref = "athenz" }
 # Misc
-bcprov-jdk18on = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bouncycastle" }
+bcprov-jdk18on = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bouncycastle-bcprov" }
 bctls-jdk18on = { module = "org.bouncycastle:bctls-jdk18on", version.ref = "bouncycastle" }
 commons-logging = { module = "commons-logging:commons-logging", version.ref = "commons-logging" }
 commons-beanutils = { module = "commons-beanutils:commons-beanutils", version.ref = "commons-beanutils" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -59,6 +59,19 @@ bouncycastle = "1.85"
 # bcprov is versioned separately: BouncyCastle shipped a provider-only patch release (1.85.2)
 # that was not published for bcpkix-jdk18on or bctls-jdk18on, which remain at 1.85
 bouncycastle-bcprov = "1.85.2"
+# BouncyCastle FIPS. Test-only in this build (tests/pulsar-client-test-bcfips): the server distribution
+# excludes bc-fips and ships the non-FIPS provider, so a FIPS deployment assembles its own classpath.
+#
+# The FIPS 140-3 cryptographic boundary is the bc-fips jar *file name*, so exactly one version per line
+# is the validated module — the security policies name bc-fips-2.1.1.jar and bc-fips-2.0.0.jar:
+#   #4943  BC-FJA 2.1.1  active, "Interim Validation", sunset 2027-01-16  https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4943
+#   #4743  BC-FJA 2.0.0  active,                       sunset 2029-07-28  https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4743
+# BouncyCastle ships security fixes only in later releases of a line — labelled "Provider (patched)" on
+# its download page — and submits them for certification afterwards, so no certified jar is CVE-free:
+# 2.1.1 has 13 known CVEs and 2.0.0 has 11, two CVSS 9.3 in each (CVE-2026-8763, CVE-2026-58062).
+# The versions below are the vendor's minimum fixed versions for the 2.1.x line and have none. They are
+# no worse than the previous 2.0.1/2.0.11/2.0.6 pins on certification — those were not certified either.
+# bcpkix-fips and bcutil-fips are outside the certified boundary.
 bouncycastle-bcpkix-fips = "2.1.12"
 bouncycastle-bcutil-fips = "2.1.7"
 bouncycastle-bc-fips = "2.1.3"


### PR DESCRIPTION
### Motivation

BouncyCastle and BouncyCastle FIPS are both behind. This brings the non-FIPS provider stack to 1.85
and the FIPS stack to the 2.1.x line.

### Modifications

`gradle/libs.versions.toml`:

| library | from | to |
|---|---|---|
| bcpkix-jdk18on / bctls-jdk18on | 1.84 | 1.85 |
| bcprov-jdk18on | 1.84 | **1.85.2** |
| bc-fips | 2.0.1 | 2.1.3 |
| bcpkix-fips | 2.0.11 | 2.1.12 |
| bcutil-fips | 2.0.6 | 2.1.7 |

Plus the corresponding jar names in the server and shell distribution `LICENSE.bin.txt` files, and a
comment in the version catalog recording the FIPS certificate mapping described below, so the next
person bumping these does not have to re-derive it.

**A new `bouncycastle-bcprov` version reference is introduced.** BouncyCastle published a
provider-only patch release, 1.85.2, that was *not* released for `bcpkix-jdk18on` or
`bctls-jdk18on` — those remain at 1.85 on Maven Central. `bcprov-jdk18on` previously shared the
single `bouncycastle` reference, which can no longer express this, so it now has its own.

### FIPS: which jar is the validated module

Thanks @david-streamlio — you were right to push on this, and the original description overstated
things. Of your three outcomes, **(b) holds: only 2.1.1 is validated.** But the remedy does not
follow, and the reason is worth spelling out because it applies to the 2.0.x line just as much.

**The cryptographic boundary is the jar file, by name.** The
[security policy for certificate 4943][sp4943] (BC-FJA, Software Version 2.1.1, 2025-07-18) says so
in §2:

> The Module is of type software and the module has a Multi-Chip Stand Alone embodiment; the
> cryptographic boundary is the Java Archive (JAR) file, *bc-fips-2.1.1.jar*.

So there is no jar-version/module-version indirection to map — exactly one published jar per line is
the validated module, and it is named in the policy:

| CMVP certificate | Validated jar | Status | Sunset | Tested Java |
|---|---|---|---|---|
| [#4943][c4943] | `bc-fips-2.1.1.jar` | Active, caveat *"Interim Validation"* | 2027-01-16 | 8, 11, 17, 21 |
| [#4743][c4743] | `bc-fips-2.0.0.jar` | Active | 2029-07-28 | 8, 11, 17, 21 |

BouncyCastle's [download page][bcdl] shows the same shape from the vendor side, listing two provider
jars per line — `bc-fips-2.1.0.jar` under "Provider" and `bc-fips-2.1.3.jar` under
"**Provider (patched)**":

> The 2.1.0 release, BC-FJA 2.1.0 (Certificate [#4943](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4943)), is certified for use on Java 8, Java 11,
> Java 17, and Java 21. The 2.1.3 release is a patch release on 2.1.0/2.1.1/2.1.3, **going into
> submission**.

The [roadmap][bcrm] adds that 2.1.1 is a "Bug fix release for 2.1.0 (GC related issues)",
"Superseded by 2.1.2", and 2.1.2 is "Under submission". (BouncyCastle's pages still name 2.1.0 as
the certified jar; CMVP rolled [#4943](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4943) forward to 2.1.1 in its 2025-11-14 update.) So **2.1.3's status
is "pending submission" — not certified, not rejected.**

#### Why this PR keeps 2.1.3

Because BouncyCastle ships security fixes only in the patch releases and certifies them afterwards,
**no certified bc-fips jar is free of known CVEs — on either line**:

| bc-fips | Certified? | Known CVEs |
|---|---|---|
| **2.0.0** | ✅ [#4743](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4743) | **11** — incl. CVE-2026-8763, CVE-2026-58062 (both CVSS 9.3) |
| 2.0.1 — *the pin this PR replaces* | ❌ | 10 — incl. the same two 9.3s |
| 2.0.2 | ❌ | 0 |
| **2.1.1** | ✅ [#4943](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4943) | **13** — incl. the same two 9.3s |
| 2.1.2 | ❌ | 12 |
| **2.1.3** — this PR | ❌ pending submission | **0** |

The two criticals are certificate-validation bypasses: CVE-2026-8763 (Name Constraints bypass via a
trailing dot in `rfc822Name`/URI) and CVE-2026-58062 (stapled OCSP response accepted without binding
to the checked certificate). Pinning 2.1.1 to match the certificate would knowingly ship both.

The key point for this PR: **Pulsar's existing `bc-fips 2.0.1` pin is not a certified version
either** — certificate [#4743](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4743) names 2.0.0 only. So 2.1.3 is *no worse than the status quo from a
certification perspective*, and strictly better on CVEs, which is why the upgrade to the 2.1.x line
is the right move rather than a downgrade to a certified-but-vulnerable jar. The same reasoning
rules out the 2.0.x alternative: `2.0.2` would also be uncertified.

The other two bumps are the vendor's minimum fixed versions as well, and neither is inside the
certified boundary — the security policy states "This module is the only software component within
the Cryptographic Boundary" — so they carry no certification consequence:

- `bcpkix-fips 2.0.11 → 2.1.12` fixes CVE-2026-59639, CVE-2026-12802, CVE-2026-59642 (all 8.7),
  CVE-2026-59647, CVE-2026-15055
- `bcutil-fips 2.0.6 → 2.1.7` fixes CVE-2026-59645 (8.7)

#### The two secondary points

**Certificate horizon (your point 2)** — confirmed: [#4943](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4943) is an interim validation sunsetting
2027-01-16, ~2.5 years earlier than [#4743](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4743)'s 2029-07-28. What takes the sting out of it here is that
`bc-fips` is **test-only in this build**: it is declared once, as `testImplementation` in
`tests/pulsar-client-test-bcfips`; the server distribution explicitly excludes it and ships the
non-FIPS provider instead; it appears in no `LICENSE.bin.txt`, no published POM, and not in
`pulsar-bom`. Resolving `:distribution:pulsar-server-distribution` yields only
`bcprov-jdk18on:1.85.2`, `bcpkix-jdk18on:1.85` and `bcutil-jdk18on:1.85` — no `bc-fips` at any
version. A FIPS deployment assembles its own provider classpath today (as PIP-478 notes), so this
pin does not commit any operator to the shorter horizon; it determines what Pulsar's FIPS test module
exercises. That also means the *"swaps out the certified cryptographic module underneath anyone
running Pulsar in FIPS mode"* framing in the original description was wrong on both halves, and it
has been removed.

**Tested Java ceiling (your point 3)** — confirmed, and the security policy is more specific than the
certificate page. Beyond the tested environments (Table 2) it lists 78 *Vendor Affirmed* environments
(Table 3), and every one tops out at Java SE Runtime Environment v21; Java 25 is on neither list. The
policy's porting terms:

> The cryptographic module will remain compliant with the FIPS 140-3 validation when operating on any
> general purpose computer (GPC) provided that: 1) No source code has been modified. 2) The GPC uses
> the specified single-user platform, or another compatible single-user platform such as one of the
> Java SE Runtime Environments listed on any of the following: […]
>
> *For the avoidance of doubt, it is hereby stated that the CMVP makes no statement as to the correct
> operation of the module or the security strengths of the generated keys when so ported if the
> specific operational environment is not listed on the validation certificate.*

Whether vendor affirmation suffices is the operator's compliance programme's call. For this
repository it affects only which JDK `pulsar-client-test-bcfips` happens to run on in CI.

[c4943]: https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4943
[c4743]: https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4743
[sp4943]: https://csrc.nist.gov/CSRC/media/projects/cryptographic-module-validation-program/documents/security-policies/140sp4943.pdf
[bcdl]: https://www.bouncycastle.org/download/bouncy-castle-java-fips/
[bcrm]: https://www.bouncycastle.org/download/bouncy-castle-java-fips/roadmap/

### On 1.85 release notes

BouncyCastle publishes no formal release notes for 1.85 (see bcgit/bc-java#2355). Based on the
project's release announcement, 1.85 is feature-additive over 1.84: post-quantum signature
algorithms from recent NIST and Korean standardisation work, BLS12-381 signatures, BIP-340 Taproot
Schnorr signatures, and hybrid X.509 certificate support. No API removals are announced.

Class file versions were checked in the published jars: all artifacts keep Java 8 roots with
multi-release overlays, so the Java 17 baseline is unaffected.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests, in particular the `tests/pulsar-client-test-bcfips`
module, which exercises the FIPS provider end to end.

Verified locally with:

- `./gradlew sanityCheck` and `./gradlew checkBinaryLicense`
- `./gradlew :tests:pulsar-client-test-bcfips:test` — passes against bc-fips 2.1.3 / bcpkix-fips
  2.1.12 / bcutil-fips 2.1.7
- `./gradlew :distribution:pulsar-server-distribution:dependencies` and
  `:tests:pulsar-client-test-bcfips:dependencies` — confirm the resolved BouncyCastle sets quoted
  above

### Does this pull request potentially affect one of the following parts:

- [x] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [x] Anything that affects deployment

The non-FIPS BouncyCastle jars bundled in the server and shell distributions change version.
`bc-fips` is in no distribution, so the FIPS bump affects only the in-tree FIPS test module.
