### PR TITLE
[improve][build] Upgrade Gradle plugins and move to the io.github.ben-manes.versions plugin id

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -474,9 +474,9 @@ nar = "io.github.merlimat.nar:0.1.3"
 protobuf = "com.google.protobuf:0.10.0"
 shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }
 rat = "org.nosphere.apache.rat:0.8.1"
-spotless = "com.diffplug.spotless:8.4.0"
+spotless = "com.diffplug.spotless:8.10.0"
 swagger = { id = "io.swagger.core.v3.swagger-gradle-plugin", version.ref = "swagger" }
-version-catalog-update = "nl.littlerobots.version-catalog-update:1.1.0"
-versions = "com.github.ben-manes.versions:0.53.0"
-crlf = "com.github.vlsi.crlf:3.0.1"
+version-catalog-update = "nl.littlerobots.version-catalog-update:1.1.1"
+versions = "io.github.ben-manes.versions:0.61.0"
+crlf = "com.github.vlsi.crlf:4.0.0"
 idea-ext = "org.jetbrains.gradle.plugin.idea-ext:1.4.1"


### PR DESCRIPTION
### Motivation

Several Gradle build plugins are behind. Separately, the `com.github.ben-manes.versions` plugin id
is now deprecated in favour of `io.github.ben-manes.versions`, to match current Gradle Plugin Portal
policy; the old id still receives releases but logs a deprecation warning on every build that applies
it.

### Modifications

`gradle/libs.versions.toml`:

| plugin | from | to |
|---|---|---|
| spotless | 8.4.0 | 8.10.0 |
| version-catalog-update | 1.1.0 | 1.1.1 |
| crlf (vlsi) | 3.0.1 | 4.0.0 |
| versions (ben-manes) | `com.github.ben-manes.versions:0.53.0` | `io.github.ben-manes.versions:0.61.0` |

The versions plugin is applied through `alias(libs.plugins.versions)` in the root build script, so
changing the coordinate in the catalog is sufficient — no build script edit is needed.

The remaining build plugins are already on their latest releases and are left unchanged:
`shadow` 9.6.1, `graalvm-buildtools` 1.1.9, `rat` 0.8.1, `nar` 0.1.3, `idea-ext` 1.4.1 and
`protobuf` 0.10.0. The `swagger` Gradle plugin tracks the shared `swagger` version reference and is
handled in the misc-libraries PR.

The vlsi crlf 4.x line requires Gradle 8.3+, Kotlin 1.9 and Java 8. Pulsar builds with Gradle 9.7, so
the floor is met.

### lightproto is deliberately excluded

`lightproto` 0.8.0 is available but is **not** included here, because it is not a build-only change.
Regenerating the protocol sources against 0.8.0 and diffing them against 0.7.3 shows that the
generated serialization code path is rewritten:

- writes move from `Unsafe`-style direct memory access (`memoryAddress()`, `BYTE_ARRAY_BASE_OFFSET`)
  to an array/scratch-buffer path, adding a per-message `_scratch` byte[] field;
- field presence tracking moves from sentinel values to `_bitField0` masks;
- a new class is generated into the `io.netty.buffer` package to reach `AbstractByteBuf`'s protected
  `_getByte` accessor and its `readerIndex` field directly, deliberately skipping Netty's per-byte
  bounds checks. Its own javadoc notes that it "creates a split package with netty-buffer under the
  JPMS module path" and that on truncated input a read may advance up to 9 bytes past the intended
  message limit.

That touches Pulsar's hottest serialization path and warrants its own PR with benchmarking, so it is
left for a follow-up.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

Verified locally with `./gradlew quickCheck`, `./gradlew sanityCheck` and
`./gradlew checkBinaryLicense` (the last one builds both distributions, which exercises the crlf
plugin).

### Does this pull request potentially affect one of the following parts:

- [x] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
