### PR TITLE
[improve][test] Upgrade test libraries

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -462,7 +462,7 @@ The Apache Software License, Version 2.0
   * Jodah
     - net.jodah-typetools-0.5.0.jar
   * Byte Buddy
-    - net.bytebuddy-byte-buddy-1.17.7.jar
+    - net.bytebuddy-byte-buddy-1.18.12.jar
   * zt-zip
     - org.zeroturnaround-zt-zip-1.17.jar
   * Apache Avro

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -153,19 +153,19 @@ jsr305 = "3.0.2"
 # Test
 testng = "7.12.0"
 mockito = "5.23.0"
-awaitility = "4.2.0"
+awaitility = "4.3.0"
 assertj = "3.27.7"
-hamcrest = "2.2"
+hamcrest = "3.0"
 system-lambda = "1.2.1"
-objenesis = "3.3"
-byte-buddy = "1.17.7"
+objenesis = "3.6"
+byte-buddy = "1.18.12"
 testcontainers = "1.21.4"
-wiremock = "2.35.1"
-kerby = "2.1.1"
-json = "20231013"
-consolecaptor = "1.0.3"
-restassured = "5.4.0"
-skyscreamer = "1.5.0"
+wiremock = "3.13.2"
+kerby = "2.1.2"
+json = "20260814"
+consolecaptor = "1.0.4"
+restassured = "5.5.7"
+skyscreamer = "1.5.3"
 # misc
 zstd-jni = "1.5.7-3"
 lz4java = "1.11.1"
@@ -422,8 +422,11 @@ assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj" }
 hamcrest = { module = "org.hamcrest:hamcrest", version.ref = "hamcrest" }
 system-lambda = { module = "com.github.stefanbirkner:system-lambda", version.ref = "system-lambda" }
 byte-buddy = { module = "net.bytebuddy:byte-buddy", version.ref = "byte-buddy" }
+# byte-buddy-agent is declared so the enforced platform pins it to the same version as
+# byte-buddy; Mockito depends on both and they must not diverge
+byte-buddy-agent = { module = "net.bytebuddy:byte-buddy-agent", version.ref = "byte-buddy" }
 objenesis = { module = "org.objenesis:objenesis", version.ref = "objenesis" }
-wiremock = { module = "com.github.tomakehurst:wiremock-jre8-standalone", version.ref = "wiremock" }
+wiremock = { module = "org.wiremock:wiremock-standalone", version.ref = "wiremock" }
 consolecaptor = { module = "io.github.hakky54:consolecaptor", version.ref = "consolecaptor" }
 restassured = { module = "io.rest-assured:rest-assured", version.ref = "restassured" }
 jsonassert = { module = "org.skyscreamer:jsonassert", version.ref = "skyscreamer" }
@@ -449,7 +452,7 @@ hadoop-common = { module = "org.apache.hadoop:hadoop-common", version.ref = "had
 hadoop-hdfs-client = { module = "org.apache.hadoop:hadoop-hdfs-client", version.ref = "hadoop3" }
 hadoop-minicluster = { module = "org.apache.hadoop:hadoop-minicluster", version.ref = "hadoop3" }
 failsafe = { module = "dev.failsafe:failsafe", version.ref = "failsafe" }
-docker-java-core = "com.github.docker-java:docker-java-core:3.4.1"
+docker-java-core = "com.github.docker-java:docker-java-core:3.7.1"
 json-smart = "net.minidev:json-smart:2.5.2"
 jfairy = "io.codearte.jfairy:jfairy:0.5.9"
 # Auth


### PR DESCRIPTION
### Motivation

The test-scope libraries in the version catalog have drifted behind. WireMock in particular is stuck
at 2.35.1 because the artifact it used was discontinued, and org.json 20231013 predates the fix for
CVE-2026-59171.

### Modifications

`gradle/libs.versions.toml`:

| library | from | to |
|---|---|---|
| awaitility | 4.2.0 | 4.3.0 |
| hamcrest | 2.2 | 3.0 |
| objenesis | 3.3 | 3.6 |
| byte-buddy | 1.17.7 | 1.18.12 |
| kerby | 2.1.1 | 2.1.2 |
| consolecaptor | 1.0.3 | 1.0.4 |
| jsonassert (skyscreamer) | 1.5.0 | 1.5.3 |
| rest-assured | 5.4.0 | 5.5.7 |
| org.json | 20231013 | 20260814 |
| docker-java-core | 3.4.1 | 3.7.1 |
| WireMock | 2.35.1 | 3.13.2 |

**WireMock changes coordinates.** `com.github.tomakehurst:wiremock-jre8-standalone` was discontinued
after 3.0.1; the 3.x line is published as `org.wiremock:wiremock-standalone`. The catalog entry
changes module, not just version. No test sources change: the Java packages are unchanged
(`com.github.tomakehurst.wiremock.*`), and the deprecated `ResponseTransformer` that
`AsyncHttpConnectorTest` implements is still present in 3.13.2 alongside its `ResponseTransformerV2`
replacement.

**`byte-buddy-agent` is added to the catalog.** Mockito 5.23.0 declares both `byte-buddy` and
`byte-buddy-agent` at 1.17.7, and Pulsar uses `MockedStatic` / `MockedConstruction`, which need the
inline mock maker. The catalog previously pinned only `byte-buddy`, so raising it alone would have
left the enforced platform pinning `byte-buddy` at 1.18.12 while `byte-buddy-agent` stayed at
Mockito's 1.17.7. Declaring both keeps them in lockstep — verified via
`./gradlew :pulsar-proxy:dependencies --configuration testRuntimeClasspath`, which now shows both
resolving to 1.18.12.

**rest-assured stays on the 5.x line.** 6.0.0 raises the baseline to Java 17 (fine on its own) but
also requires Groovy 5. Groovy is an unpinned transitive of rest-assured, so that would move Groovy
4→5 across four test modules at once; 5.5.7 is the newest 5.x release.

**Left unchanged, already current:**

- **Testcontainers stays at 1.21.4** — that is already the newest 1.x release; the next release is
  2.0.0, a new major line.
- testng 7.12.0, mockito 5.23.0, assertj 3.27.7 (4.0.0-M1 is a milestone).

**hamcrest 3.0** — the only documented breaking change is the Java 8 bytecode baseline. The three
classes Pulsar imports (`CoreMatchers`, `MatcherAssert`, `Matchers`) were confirmed present in the
3.0 jar.

**org.json 20260814** includes the fix for CVE-2026-59171 (unbounded BigInteger/BigDecimal parsing).
It is a test-scope dependency in `pulsar-functions-utils`.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests. Verified locally:

- `./gradlew sanityCheck` — all main and test sources compile
- `./gradlew checkBinaryLicense`
- WireMock 3.13.2: `AsyncHttpConnectorTest` (9 tests) and
  `AuthenticationProviderOpenIDIntegrationTest` (21 tests) — both green
- Mockito inline mock maker on byte-buddy 1.18.12 / objenesis 3.6: `ProxyExtensionUtilsTest`,
  `PulsarByteBufAllocator*Test` and `AuthenticationAthenzTest` (16 tests total) — all green
- org.json / jsonassert / WireMock: `pulsar-functions-utils` full test suite (154 tests) — green

### Does this pull request potentially affect one of the following parts:

- [x] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
