### PR TITLE
[improve][monitor] Upgrade Dropwizard Metrics to 4.2.39 and HdrHistogram to 2.2.2

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -479,9 +479,9 @@ The Apache Software License, Version 2.0
     - io.kubernetes-client-java-api-26.0.0.jar
     - io.kubernetes-client-java-proto-26.0.0.jar
   * Dropwizard
-    - io.dropwizard.metrics-metrics-core-4.1.12.1.jar
-    - io.dropwizard.metrics-metrics-graphite-4.1.12.1.jar
-    - io.dropwizard.metrics-metrics-jvm-4.1.12.1.jar
+    - io.dropwizard.metrics-metrics-core-4.2.39.jar
+    - io.dropwizard.metrics-metrics-graphite-4.2.39.jar
+    - io.dropwizard.metrics-metrics-jvm-4.2.39.jar
   * Failsafe
     - dev.failsafe-failsafe-3.3.2.jar
   * Prometheus
@@ -561,7 +561,7 @@ BSD 3-clause "New" or "Revised" License
    - org.ow2.asm-asm-tree-9.10.1.jar -- ../licenses/LICENSE-ASM.txt
 
 BSD 2-Clause License
- * HdrHistogram -- org.hdrhistogram-HdrHistogram-2.1.9.jar -- ../licenses/LICENSE-HdrHistogram.txt
+ * HdrHistogram -- org.hdrhistogram-HdrHistogram-2.2.2.jar -- ../licenses/LICENSE-HdrHistogram.txt
 
 MIT License
  * Java SemVer -- com.github.zafarkhaja-java-semver-0.9.0.jar -- ../licenses/LICENSE-SemVer.txt

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -92,8 +92,8 @@ re2j = "1.8"
 # Metrics / Observability
 prometheus = "0.16.0"
 prometheus-jmx = "0.16.1"
-dropwizardmetrics = "4.1.12.1"
-hdrHistogram = "2.1.9"
+dropwizardmetrics = "4.2.39"
+hdrHistogram = "2.2.2"
 perfmark = "0.27.0"
 # Auth
 jsonwebtoken = "0.13.0"


### PR DESCRIPTION
### Motivation

Dropwizard Metrics is two minor lines behind (4.1.12.1, released in 2020) and HdrHistogram is behind
as well. Neither has any relationship to the Prometheus simpleclient, so they can be updated
independently of any Prometheus client_java migration.

### Modifications

`gradle/libs.versions.toml`:

| library | from | to |
|---|---|---|
| dropwizard metrics | 4.1.12.1 | 4.2.39 |
| HdrHistogram | 2.1.9 | 2.2.2 |

Plus the corresponding jar names in the server distribution `LICENSE.bin.txt`.

Dropwizard Metrics 4.2.0 was an additive release — support for Jersey 3.x, Jetty 10/11, the
`jakarta.servlet` namespace and Caffeine 3.x — with no documented API removals. Pulsar uses
`metrics-core`, `metrics-graphite` and `metrics-jvm`.

### Note on the Prometheus client

`prometheus` (simpleclient) 0.16.0 and `prometheus-jmx` 0.16.1 are deliberately **not** touched here.
simpleclient 0.16.0 is the final release of that line, and moving off it is a code migration rather
than a version bump:

- 64 Java files across 12 modules import `io.prometheus.client`;
- `org.apache.bookkeeper.stats:prometheus-metrics-provider:4.18.0` has hard compile dependencies on
  `simpleclient`, `simpleclient_hotspot` and `simpleclient_servlet`, and ships in the server
  distribution;
- `PrometheusMetricsGeneratorUtils` scrapes `CollectorRegistry.defaultRegistry`, the shared registry
  that BookKeeper and ZooKeeper publish into.

`prometheus-jmx` 1.6.0 is specifically coupled to that migration: it depends on
`prometheus-metrics-core` 1.7.0 rather than simpleclient, and in 1.x `io.prometheus.jmx.JmxCollector`
becomes a collector on the new registry. `RuntimeUtils.registerDefaultCollectors()` registers it into
`FunctionCollectorRegistry`, which extends the simpleclient `CollectorRegistry`, so that bump
requires migrating the `pulsar-functions` instance metrics stack first.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

Verified locally with `./gradlew sanityCheck` and `./gradlew checkBinaryLicense`.

### Does this pull request potentially affect one of the following parts:

- [x] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
