### PR TITLE
[improve][build] Upgrade Jakarta and servlet APIs within the Jakarta EE 10 level

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -582,7 +582,7 @@ Protocol Buffers License
 
 CDDL-1.1 -- ../licenses/LICENSE-CDDL-1.1.txt
  * Java Servlet API
-    - javax.servlet-javax.servlet-api-3.1.0.jar
+    - javax.servlet-javax.servlet-api-4.0.1.jar
     - jakarta.servlet-jakarta.servlet-api-6.0.0.jar
  * HK2 - Dependency Injection Kernel
     - org.glassfish.hk2-hk2-api-3.0.6.jar
@@ -604,9 +604,9 @@ CDDL-1.1 -- ../licenses/LICENSE-CDDL-1.1.txt
 
 Eclipse Distribution License 1.0 -- ../licenses/LICENSE-EDL-1.0.txt
  * Jakarta Activation
-    - jakarta.activation-jakarta.activation-api-2.1.3.jar
-    - org.eclipse.angus-angus-activation-2.0.2.jar
- * Jakarta XML Binding -- jakarta.xml.bind-jakarta.xml.bind-api-4.0.2.jar
+    - jakarta.activation-jakarta.activation-api-2.1.4.jar
+    - org.eclipse.angus-angus-activation-2.0.3.jar
+ * Jakarta XML Binding -- jakarta.xml.bind-jakarta.xml.bind-api-4.0.5.jar
 
 Eclipse Public License - v2.0 -- ../licenses/LICENSE-EPL-2.0.txt
  * Jakarta Annotations API -- jakarta.annotation-jakarta.annotation-api-2.1.1.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -456,10 +456,10 @@ CDDL-1.1 -- ../licenses/LICENSE-CDDL-1.1.txt
 
 Eclipse Distribution License 1.0 -- ../licenses/LICENSE-EDL-1.0.txt
  * Jakarta Activation
-    - jakarta.activation-api-2.1.3.jar
-    - angus-activation-2.0.2.jar
+    - jakarta.activation-api-2.1.4.jar
+    - angus-activation-2.0.3.jar
     - validation-api-1.1.0.Final.jar
- * Jakarta XML Binding -- jakarta.xml.bind-api-4.0.2.jar
+ * Jakarta XML Binding -- jakarta.xml.bind-api-4.0.5.jar
 
 Eclipse Public License - v2.0 -- ../licenses/LICENSE-EPL-2.0.txt
  * Jakarta Annotations API -- jakarta.annotation-api-2.1.1.jar

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -130,15 +130,17 @@ zt-zip = "1.17"
 # Jakarta
 jakarta-ws-rs = "3.1.0"
 jakarta-annotation = "2.1.1"
-jakarta-activation = "2.1.3"
+jakarta-activation = "2.1.4"
 # Jakarta Activation 2.x reference implementation (the com.sun.activation:jakarta.activation impl was not
 # republished past 2.0.x; Eclipse Angus is the EE10 impl of jakarta.activation-api 2.1.x)
-angus-activation = "2.0.2"
-jakarta-xml-bind = "4.0.2"
+angus-activation = "2.0.3"
+jakarta-xml-bind = "4.0.5"
 jakarta-validation = "3.0.2"
-# javax-servlet (Servlet 3.1, ee8) is retained alongside jakarta-servlet (Servlet 6.0, ee10)
-# so that the AdditionalServlet plugin SPI keeps supporting legacy javax.servlet handlers (PIP-472)
-javax-servlet = "3.1.0"
+# javax-servlet (Servlet 4.0, ee8) is retained alongside jakarta-servlet (Servlet 6.0, ee10)
+# so that the AdditionalServlet plugin SPI keeps supporting legacy javax.servlet handlers (PIP-472).
+# Each is kept at the Servlet level its Jetty 12.1 environment implements: Jetty ee8 ships
+# jetty-servlet-api 4.0.x and Jetty ee10 pins jakarta.servlet-api 6.0.0.
+javax-servlet = "4.0.1"
 jakarta-servlet = "6.0.0"
 # Oxia / etcd
 oxia = "0.9.4"


### PR DESCRIPTION
### Motivation

Several Jakarta API artifacts have newer patch releases within the Jakarta EE 10 level Pulsar
targets. Separately, `javax.servlet-api` was pinned at Servlet 3.1 while the Jetty ee8 environment
that consumes it actually implements Servlet 4.0.

### Modifications

`gradle/libs.versions.toml`:

| library | from | to |
|---|---|---|
| jakarta.activation-api | 2.1.3 | 2.1.4 |
| angus-activation | 2.0.2 | 2.0.3 |
| jakarta.xml.bind-api | 4.0.2 | 4.0.5 |
| javax.servlet-api | 3.1.0 | 4.0.1 |

Plus the corresponding jar names in the server and shell distribution `LICENSE.bin.txt` files, and an
updated comment in the catalog explaining the servlet level pairing.

Each API is kept at the level its Jetty 12.1 environment actually implements. Checking the Jetty
12.1.12 POMs directly:

- `org.eclipse.jetty.ee10:jetty-ee10` declares `ee10.jakarta.xml.bind.api.version = 4.0.5` — exactly
  what this PR moves to;
- `org.eclipse.jetty.ee8:jetty-ee8` declares `ee8.jetty.servlet.api.version = 4.0.9`
  (`org.eclipse.jetty.toolchain:jetty-servlet-api`), i.e. the ee8 environment implements Servlet 4.0,
  not the Servlet 3.1 previously pinned.

### Please note: `javax.servlet-api` widens a public plugin surface

`javax.servlet-api` is what the PIP-472 `AdditionalServlet` plugin SPI compiles against. Raising it
from 3.1 to 4.0 widens that public plugin API surface. Plugins already compiled against Servlet 3.1
continue to work, since Servlet 4.0 is backward compatible; what changes is that new plugins may
start relying on Servlet 4.0 API. Flagging it explicitly because it is effectively a one-way door.

### Deliberately not upgraded

These would move Pulsar past Jakarta EE 10 and out of step with the Jetty ee10 environment, so they
are left alone:

| available | why not |
|---|---|
| jakarta.ws.rs-api 4.0.0 | Jakarta REST 4.0 is EE 11, and would require Jersey 4.x |
| jakarta.annotation-api 3.0.0 | EE 11 |
| jakarta.servlet-api 6.1.0 | `jetty-ee10` 12.1.12 declares 6.0.0; Servlet 6.1 belongs to the ee11 environment |
| jakarta.validation-api 3.1.1 | Bean Validation 3.1 is EE 11 |

Note that `jakarta.validation-api` is not declared directly by any Pulsar module, but the version
catalog drives the `pulsar-dependencies` enforced platform, so a bump there would still pin Bean
Validation 3.1 globally for the swagger and Jersey transitives.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

Verified locally with `./gradlew sanityCheck` and `./gradlew checkBinaryLicense`.

### Does this pull request potentially affect one of the following parts:

- [x] Dependencies (add or upgrade a dependency)
- [x] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

The public API impact is the `AdditionalServlet` plugin SPI moving from Servlet 3.1 to Servlet 4.0,
described above.
