### PR TITLE
[improve][build] Upgrade Gson to 2.14.0 and json-smart to 2.6.0

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -267,7 +267,7 @@ The Apache Software License, Version 2.0
  * Proto Google Common Protos -- com.google.api.grpc-proto-google-common-protos-2.63.2.jar
  * Bitbucket -- org.bitbucket.b_c-jose4j-0.9.6.jar
  * Gson
-    - com.google.code.gson-gson-2.13.2.jar
+    - com.google.code.gson-gson-2.14.0.jar
     - io.gsonfire-gson-fire-1.9.0.jar
  * Guava
     - com.google.guava-guava-33.6.0-jre.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -327,7 +327,7 @@ The Apache Software License, Version 2.0
  * Caffeine -- caffeine-3.2.4.jar
  * Conscrypt -- conscrypt-openjdk-uber-2.6.2.jar
  * Gson
-    - gson-2.13.2.jar
+    - gson-2.14.0.jar
  * Guava
     - guava-33.6.0-jre.jar
     - failureaccess-1.0.3.jar

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -61,7 +61,7 @@ bouncycastle-bcutil-fips = "2.0.6"
 bouncycastle-bc-fips = "2.0.1"
 # Serialization
 avro = "1.12.0"
-gson = "2.13.2"
+gson = "2.14.0"
 snakeyaml = "2.6"
 # Vert.x
 vertx = "4.5.28"
@@ -450,7 +450,7 @@ hadoop-hdfs-client = { module = "org.apache.hadoop:hadoop-hdfs-client", version.
 hadoop-minicluster = { module = "org.apache.hadoop:hadoop-minicluster", version.ref = "hadoop3" }
 failsafe = { module = "dev.failsafe:failsafe", version.ref = "failsafe" }
 docker-java-core = "com.github.docker-java:docker-java-core:3.4.1"
-json-smart = "net.minidev:json-smart:2.5.2"
+json-smart = "net.minidev:json-smart:2.6.0"
 jfairy = "io.codearte.jfairy:jfairy:0.5.9"
 # Auth
 athenz-zts-java-client = { module = "com.yahoo.athenz:athenz-zts-java-client", version.ref = "athenz" }


### PR DESCRIPTION
### Motivation

Gson and json-smart are behind. Gson 2.14.0 in particular contains behaviour changes that are worth
landing on their own, separately from other dependency updates, so they are easy to bisect and
revert.

### Modifications

`gradle/libs.versions.toml`:

| library | from | to |
|---|---|---|
| gson | 2.13.2 | 2.14.0 |
| json-smart | 2.5.2 | 2.6.0 |

Plus the corresponding jar names in the server and shell distribution `LICENSE.bin.txt` files.

### Gson 2.14.0 behaviour changes — please review with these in mind

Gson parses externally supplied JSON in several places in Pulsar (function and connector
configuration, admin CLI input, the Kubernetes runtime), so these are the changes that matter:

1. **Duplicate member names in a JSON object are now rejected.** Input such as
   `{"foo": 1, "foo": 2}` previously parsed with last-key-wins and now throws.
2. **Strings parsed as integers must consist of ASCII characters.**
3. **`java.time` types now have built-in adapters.** Gson no longer reflects into the private fields
   of `Instant`, `Duration` and friends. This removes the need for `--add-opens` for those classes,
   and can change the serialized form of any such field that previously went through reflection.
4. The internal nested types in `GsonTypes` (`ParameterizedTypeImpl`, `GenericArrayTypeImpl`,
   `WildcardTypeImpl`) are no longer `Serializable`, and the unreleased `com.google.gson.graph`
   package was removed.

Neither library changes its Java 8 baseline.

### Jackson is not part of this change

Jackson stays on the 2.21 LTS line (2.21.6 / annotations 2.21). 2.22 was tried in #26101 and reverted
in #26166.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests. Verified locally:

- `./gradlew sanityCheck` and `./gradlew checkBinaryLicense`
- `pulsar-functions-utils` full test suite (154 tests) — green
- `pulsar-client-admin-original` full test suite (64 tests) — green

Both of those modules are heavy Gson users.

### Does this pull request potentially affect one of the following parts:

- [x] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

Not a schema change in the Pulsar sense, but note the JSON parsing behaviour changes listed above.
