### PR TITLE
[improve][build] Upgrade networking and infrastructure client libraries

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -432,7 +432,7 @@ The Apache Software License, Version 2.0
  * SnakeYaml -- org.yaml-snakeyaml-2.6.jar
  * RocksDB - org.rocksdb-rocksdbjni-9.9.3.jar
  * Google Error Prone Annotations - com.google.errorprone-error_prone_annotations-2.45.0.jar
- * Apache Thrift - org.apache.thrift-libthrift-0.23.0.jar
+ * Apache Thrift - org.apache.thrift-libthrift-0.24.0.jar
  * OkHttp3
      - com.squareup.okhttp3-logging-interceptor-5.3.2.jar
      - com.squareup.okhttp3-okhttp-jvm-5.3.2.jar
@@ -469,15 +469,15 @@ The Apache Software License, Version 2.0
     - org.apache.avro-avro-1.12.0.jar
     - org.apache.avro-avro-protobuf-1.12.0.jar
   * Apache Curator
-    - org.apache.curator-curator-client-5.7.1.jar
-    - org.apache.curator-curator-framework-5.7.1.jar
-    - org.apache.curator-curator-recipes-5.7.1.jar
+    - org.apache.curator-curator-client-5.9.0.jar
+    - org.apache.curator-curator-framework-5.9.0.jar
+    - org.apache.curator-curator-recipes-5.9.0.jar
   * Apache Yetus
     - org.apache.yetus-audience-annotations-0.12.0.jar
   * Kubernetes Client
-    - io.kubernetes-client-java-26.0.0.jar
-    - io.kubernetes-client-java-api-26.0.0.jar
-    - io.kubernetes-client-java-proto-26.0.0.jar
+    - io.kubernetes-client-java-27.0.0.jar
+    - io.kubernetes-client-java-api-27.0.0.jar
+    - io.kubernetes-client-java-proto-27.0.0.jar
   * Dropwizard
     - io.dropwizard.metrics-metrics-core-4.1.12.1.jar
     - io.dropwizard.metrics-metrics-graphite-4.1.12.1.jar
@@ -499,11 +499,11 @@ The Apache Software License, Version 2.0
     - org.jctools-jctools-core-4.0.6.jar
     - org.jctools-jctools-core-jdk11-4.0.6.jar
   * Vertx
-    - io.vertx-vertx-auth-common-4.5.28.jar
-    - io.vertx-vertx-bridge-common-4.5.28.jar
-    - io.vertx-vertx-core-4.5.28.jar
-    - io.vertx-vertx-web-4.5.28.jar
-    - io.vertx-vertx-web-common-4.5.28.jar
+    - io.vertx-vertx-auth-common-4.5.32.jar
+    - io.vertx-vertx-bridge-common-4.5.32.jar
+    - io.vertx-vertx-core-4.5.32.jar
+    - io.vertx-vertx-web-4.5.32.jar
+    - io.vertx-vertx-web-common-4.5.32.jar
   * Apache ZooKeeper
     - org.apache.zookeeper-zookeeper-jute-3.9.5.jar
   * Snappy Java
@@ -548,9 +548,9 @@ The Apache Software License, Version 2.0
 
 BSD 3-clause "New" or "Revised" License
  * Google auth library
-    - com.google.auth-google-auth-library-credentials-1.43.0.jar -- ../licenses/LICENSE-google-auth-library.txt
-    - com.google.auth-google-auth-library-oauth2-http-1.43.0.jar -- ../licenses/LICENSE-google-auth-library.txt
- * Google API Common -- com.google.api-api-common-2.53.0.jar
+    - com.google.auth-google-auth-library-credentials-1.48.0.jar -- ../licenses/LICENSE-google-auth-library.txt
+    - com.google.auth-google-auth-library-oauth2-http-1.48.0.jar -- ../licenses/LICENSE-google-auth-library.txt
+ * Google API Common -- com.google.api-api-common-2.64.0.jar
  * LevelDB -- (included in org.rocksdb.*.jar) -- ../licenses/LICENSE-LevelDB.txt
  * JSR305 -- com.google.code.findbugs-jsr305-3.0.2.jar -- ../licenses/LICENSE-JSR305.txt
  * JSR305 -- jsr305-3.0.2.jar -- ../licenses/LICENSE-JSR305.txt

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -64,7 +64,7 @@ avro = "1.12.0"
 gson = "2.13.2"
 snakeyaml = "2.6"
 # Vert.x
-vertx = "4.5.28"
+vertx = "4.5.32"
 # Networking / HTTP
 asynchttpclient = "3.0.10"
 conscrypt = "2.6.2"
@@ -109,7 +109,7 @@ javassist = "3.25.0-GA"
 rocksdb = "9.9.3"
 audience-annotations = "0.12.0"
 # Misc
-curator = "5.7.1"
+curator = "5.9.0"
 reflections = "0.10.2"
 # OpenAPI 3 annotations (io.swagger.core.v3, jakarta variant) used for REST API and config docs annotations
 swagger = "2.2.50"
@@ -169,11 +169,11 @@ skyscreamer = "1.5.0"
 # misc
 zstd-jni = "1.5.7-3"
 lz4java = "1.11.1"
-kubernetesclient = "26.0.0"
-aws-sdk = "1.12.788"
+kubernetesclient = "27.0.0"
+aws-sdk = "1.12.797"
 hadoop3 = "3.5.0"
-jclouds = "2.6.0"
-thrift = "0.23.0"
+jclouds = "2.7.0"
+thrift = "0.24.0"
 datasketches-memory = "4.1.0"
 datasketches-java = "7.0.1"
 # Shading


### PR DESCRIPTION
### Motivation

The networking and infrastructure client libraries are behind. These are grouped together because
they are all external service or transport clients with similar risk profiles.

### Modifications

`gradle/libs.versions.toml`:

| library | from | to |
|---|---|---|
| Vert.x | 4.5.28 | 4.5.32 |
| async-http-client | 3.0.10 | 3.0.13 |
| netty-reactive-streams | 2.0.6 | 2.0.19 |
| Curator | 5.7.1 | 5.9.0 |
| Thrift | 0.23.0 | 0.24.0 |
| jclouds | 2.6.0 | 2.7.0 |
| Kubernetes client | 26.0.0 | 27.0.0 |
| AWS SDK | 1.12.788 | 1.12.797 |

Plus the corresponding jar names in the server and shell distribution `LICENSE.bin.txt` files.

Notes on the individual bumps:

- **Vert.x stays on the 4.5.x line.** That is what BookKeeper's `vertx-http-server` builds against;
  4.5.32 is its latest patch release. Vert.x 5.x is not taken here.
- **Curator 5.9.0** targets ZooKeeper 3.9.x, matching the 3.9.5 already in the catalog.
- **Thrift** is a transitive dependency of `distributedlog-core`; 0.24.0 keeps a Java 8 baseline.
- **jclouds 2.7.0** is a compatibility and bug-fix release. The Jakarta migration already happened in
  2.6.0, and jclouds is fully isolated inside the `jclouds-shaded` module, so the blast radius is
  contained.
- **Kubernetes client 27.0.0** tracks the upstream API spec and is Java 11 bytecode. The disruptive
  changes in that client (the options-object API shape, dropping Java 8) landed back at 20.0.0, well
  behind the 26.0.0 already in use.

The Kubernetes client upgrade also lifts unpinned transitives that ship in the server distribution,
so their LICENSE entries are updated to match: `api-common` 2.53.0 → 2.64.0 and
`google-auth-library-credentials` / `-oauth2-http` 1.43.0 → 1.48.0. These were caught by
`checkBinaryLicense`.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

Verified locally with `./gradlew sanityCheck` and `./gradlew checkBinaryLicense`.

### Does this pull request potentially affect one of the following parts:

- [x] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
