### PR TITLE
[improve][build] Upgrade misc tooling, annotation and utility libraries

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -276,7 +276,7 @@ The Apache Software License, Version 2.0
  * J2ObjC Annotations -- com.google.j2objc-j2objc-annotations-3.1.jar
  * Netty Reactive Streams -- com.typesafe.netty-netty-reactive-streams-2.0.6.jar
  * Swagger
-    - io.swagger.core.v3-swagger-annotations-jakarta-2.2.50.jar
+    - io.swagger.core.v3-swagger-annotations-jakarta-2.2.53.jar
  * slog -- io.github.merlimat.slog-slog-0.10.0.jar
  * DataSketches
     - org.apache.datasketches-datasketches-java-7.0.1.jar
@@ -354,8 +354,8 @@ The Apache Software License, Version 2.0
     - org.apache.logging.log4j-log4j-web-2.26.1.jar
     - org.apache.logging.log4j-log4j-layout-template-json-2.26.1.jar
  * Java Native Access JNA
-    - net.java.dev.jna-jna-jpms-5.18.1.jar
-    - net.java.dev.jna-jna-platform-jpms-5.18.1.jar
+    - net.java.dev.jna-jna-jpms-5.19.1.jar
+    - net.java.dev.jna-jna-platform-jpms-5.19.1.jar
  * BookKeeper
     - org.apache.bookkeeper-bookkeeper-common-4.18.0.jar
     - org.apache.bookkeeper-bookkeeper-common-allocator-4.18.0.jar
@@ -431,14 +431,14 @@ The Apache Software License, Version 2.0
     - org.eclipse.jetty.websocket-jetty-websocket-jetty-server-12.1.12.jar
  * SnakeYaml -- org.yaml-snakeyaml-2.6.jar
  * RocksDB - org.rocksdb-rocksdbjni-9.9.3.jar
- * Google Error Prone Annotations - com.google.errorprone-error_prone_annotations-2.45.0.jar
+ * Google Error Prone Annotations - com.google.errorprone-error_prone_annotations-2.50.0.jar
  * Apache Thrift - org.apache.thrift-libthrift-0.23.0.jar
  * OkHttp3
      - com.squareup.okhttp3-logging-interceptor-5.3.2.jar
      - com.squareup.okhttp3-okhttp-jvm-5.3.2.jar
  * Okio
      - com.squareup.okio-okio-jvm-3.17.0.jar
- * Javassist -- org.javassist-javassist-3.25.0-GA.jar
+ * Javassist -- org.javassist-javassist-3.32.0-GA.jar
  * Kotlin Standard Lib
      - org.jetbrains.kotlin-kotlin-stdlib-2.2.21.jar
  * JetBrains Annotations
@@ -460,11 +460,11 @@ The Apache Software License, Version 2.0
     - io.opencensus-opencensus-api-0.31.1.jar
     - io.opencensus-opencensus-contrib-http-util-0.31.1.jar
   * Jodah
-    - net.jodah-typetools-0.5.0.jar
+    - net.jodah-typetools-0.6.3.jar
   * Byte Buddy
     - net.bytebuddy-byte-buddy-1.17.7.jar
   * zt-zip
-    - org.zeroturnaround-zt-zip-1.17.jar
+    - org.zeroturnaround-zt-zip-1.18.2.jar
   * Apache Avro
     - org.apache.avro-avro-1.12.0.jar
     - org.apache.avro-avro-protobuf-1.12.0.jar
@@ -514,7 +514,7 @@ The Apache Software License, Version 2.0
     - com.google.auto.value-auto-value-annotations-1.11.0.jar
     - com.google.re2j-re2j-1.8.jar
   * IPAddress
-    - com.github.seancfoley-ipaddress-5.5.0.jar
+    - com.github.seancfoley-ipaddress-5.6.2.jar
   * RxJava
     - io.reactivex.rxjava3-rxjava-3.0.1.jar
   * RoaringBitmap
@@ -544,7 +544,7 @@ The Apache Software License, Version 2.0
   * Spotify completable-futures
     - com.spotify-completable-futures-0.3.6.jar
   * JSpecify
-    - org.jspecify-jspecify-1.0.0.jar
+    - org.jspecify-jspecify-1.0.1.jar
 
 BSD 3-clause "New" or "Revised" License
  * Google auth library
@@ -554,7 +554,7 @@ BSD 3-clause "New" or "Revised" License
  * LevelDB -- (included in org.rocksdb.*.jar) -- ../licenses/LICENSE-LevelDB.txt
  * JSR305 -- com.google.code.findbugs-jsr305-3.0.2.jar -- ../licenses/LICENSE-JSR305.txt
  * JSR305 -- jsr305-3.0.2.jar -- ../licenses/LICENSE-JSR305.txt
- * JLine3 -- org.jline-jline-4.2.1.jar -- ../licenses/LICENSE-JLine.txt
+ * JLine3 -- org.jline-jline-4.3.1.jar -- ../licenses/LICENSE-JLine.txt
  * OW2 ASM
    - org.ow2.asm-asm-9.10.1.jar -- ../licenses/LICENSE-ASM.txt
    - org.ow2.asm-asm-commons-9.10.1.jar -- ../licenses/LICENSE-ASM.txt
@@ -564,17 +564,18 @@ BSD 2-Clause License
  * HdrHistogram -- org.hdrhistogram-HdrHistogram-2.1.9.jar -- ../licenses/LICENSE-HdrHistogram.txt
 
 MIT License
- * Java SemVer -- com.github.zafarkhaja-java-semver-0.9.0.jar -- ../licenses/LICENSE-SemVer.txt
+ * Java SemVer -- com.github.zafarkhaja-java-semver-0.10.2.jar -- ../licenses/LICENSE-SemVer.txt
  * SLF4J -- ../licenses/LICENSE-SLF4J.txt
     - org.slf4j-slf4j-api-2.0.18.jar
     - org.slf4j-jcl-over-slf4j-2.0.18.jar
  * The Checker Framework
     - org.checkerframework-checker-qual-3.33.0.jar
  * oshi
-    - com.github.oshi-oshi-core-java11-6.4.0.jar
+    - com.github.oshi-oshi-core-java11-6.12.0.jar
+    - com.github.oshi-oshi-common-6.12.0.jar
  * Auth0, Inc.
-    - com.auth0-java-jwt-4.5.2.jar
-    - com.auth0-jwks-rsa-0.23.1.jar
+    - com.auth0-java-jwt-4.6.0.jar
+    - com.auth0-jwks-rsa-0.24.1.jar
 Protocol Buffers License
  * Protocol Buffers
    - com.google.protobuf-protobuf-java-4.35.0.jar -- ../licenses/LICENSE-protobuf.txt

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -334,7 +334,7 @@ The Apache Software License, Version 2.0
     - listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
  * J2ObjC Annotations -- j2objc-annotations-3.1.jar
  * Netty Reactive Streams -- netty-reactive-streams-2.0.6.jar
- * Swagger -- swagger-annotations-jakarta-2.2.50.jar
+ * Swagger -- swagger-annotations-jakarta-2.2.53.jar
  * DataSketches
     - datasketches-java-7.0.1.jar
     - datasketches-memory-4.1.0.jar
@@ -419,8 +419,8 @@ The Apache Software License, Version 2.0
     - jetty-websocket-jetty-client-12.1.12.jar
     - jetty-websocket-jetty-common-12.1.12.jar
  * SnakeYaml -- snakeyaml-2.6.jar
- * Google Error Prone Annotations - error_prone_annotations-2.45.0.jar
- * Javassist -- javassist-3.25.0-GA.jar
+ * Google Error Prone Annotations - error_prone_annotations-2.50.0.jar
+ * Javassist -- javassist-3.32.0-GA.jar
   * Apache Avro
     - avro-1.12.0.jar
     - avro-protobuf-1.12.0.jar
@@ -428,11 +428,11 @@ The Apache Software License, Version 2.0
  * Spotify completable-futures -- completable-futures-0.3.6.jar
  * RoaringBitmap -- RoaringBitmap-1.6.9.jar
  * Fastutil -- it.unimi.dsi:fastutil (only the classes used by Pulsar, bundled within pulsar-client-fastutil-minimized)
- * JSpecify -- jspecify-1.0.0.jar
+ * JSpecify -- jspecify-1.0.1.jar
  * JetBrains Annotations -- annotations-26.1.0.jar
 
 BSD 3-clause "New" or "Revised" License
- * JLine3 -- jline-4.2.1.jar -- ../licenses/LICENSE-JLine.txt
+ * JLine3 -- jline-4.3.1.jar -- ../licenses/LICENSE-JLine.txt
 
 MIT License
  * SLF4J -- ../licenses/LICENSE-SLF4J.txt

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,7 +35,7 @@ grpc = "1.79.0"
 slf4j = "2.0.18"
 slog = "0.10.0"
 log4j2 = "2.26.1"
-lombok = "1.18.42"
+lombok = "1.18.46"
 # OpenTelemetry
 opentelemetry = "1.65.0"
 opentelemetry-alpha = "1.65.0-alpha"
@@ -97,36 +97,41 @@ hdrHistogram = "2.1.9"
 perfmark = "0.27.0"
 # Auth
 jsonwebtoken = "0.13.0"
-athenz = "1.12.42"
+athenz = "1.12.45"
 jose4j = "0.9.6"
 nimbus-jose-jwt = "9.37.4"
-auth0-java-jwt = "4.5.2"
-auth0-jwks-rsa = "0.23.1"
+auth0-java-jwt = "4.6.0"
+auth0-jwks-rsa = "0.24.1"
 # CLI
 picocli = "4.7.7"
-jline3 = "4.2.1"
-javassist = "3.25.0-GA"
+jline3 = "4.3.1"
+javassist = "3.32.0-GA"
 rocksdb = "9.9.3"
 audience-annotations = "0.12.0"
 # Misc
 curator = "5.7.1"
 reflections = "0.10.2"
 # OpenAPI 3 annotations (io.swagger.core.v3, jakarta variant) used for REST API and config docs annotations
-swagger = "2.2.50"
-typetools = "0.5.0"
-jna = "5.18.1"
-java-semver = "0.9.0"
-oshi = "6.4.0"
+swagger = "2.2.53"
+typetools = "0.6.3"
+jna = "5.19.1"
+java-semver = "0.10.2"
+# oshi is capped at 6.x: at 7.0.0 the oshi-core-java11 artifact became a pom-only
+# relocation stub pointing at com.github.oshi:oshi-core, which is a coordinate change
+oshi = "6.12.0"
 netty-reactive-streams = "2.0.6"
 # 9.2.0+ is required for CronType.SPRING53 (Spring 5.3+ cron syntax)
 cron-utils = "9.2.1"
 failsafe = "3.3.2"
 disruptor = "3.4.3"
-ant = "1.10.12"
+ant = "1.10.17"
+# guice is held at 5.1.0 to match what TestNG 7.x declares; Guice 7 switches from
+# javax.inject to jakarta.inject. jclouds is the only consumer that needs Guice 7 and
+# jclouds-shaded forces it locally.
 guice = "5.1.0"
 snappy = "1.1.10.8"
-ipaddress = "5.5.0"
-zt-zip = "1.17"
+ipaddress = "5.6.2"
+zt-zip = "1.18.2"
 # Jakarta
 jakarta-ws-rs = "3.1.0"
 jakarta-annotation = "2.1.1"
@@ -146,8 +151,8 @@ oxia-testcontainers = "0.7.4"
 # Build plugins
 lightproto = "0.7.3"
 graalvm-buildtools = "1.1.9"
-errorprone = "2.45.0"
-spotbugs = "4.9.6"
+errorprone = "2.50.0"
+spotbugs = "4.10.3"
 checkerframework = "3.33.0"
 jsr305 = "3.0.2"
 # Test
@@ -373,7 +378,7 @@ vertx-core = { module = "io.vertx:vertx-core", version.ref = "vertx" }
 vertx-web = { module = "io.vertx:vertx-web", version.ref = "vertx" }
 avro = { module = "org.apache.avro:avro", version.ref = "avro" }
 avro-protobuf = { module = "org.apache.avro:avro-protobuf", version.ref = "avro" }
-joda-time = "joda-time:joda-time:2.10.10"
+joda-time = "joda-time:joda-time:2.14.3"
 java-semver = { module = "com.github.zafarkhaja:java-semver", version.ref = "java-semver" }
 oshi-core = { module = "com.github.oshi:oshi-core-java11", version.ref = "oshi" }
 jna = { module = "net.java.dev.jna:jna", version.ref = "jna" }
@@ -382,7 +387,7 @@ dropwizardmetrics-core = { module = "io.dropwizard.metrics:metrics-core", versio
 dropwizardmetrics-graphite = { module = "io.dropwizard.metrics:metrics-graphite", version.ref = "dropwizardmetrics" }
 dropwizardmetrics-jvm = { module = "io.dropwizard.metrics:metrics-jvm", version.ref = "dropwizardmetrics" }
 snappy-java = { module = "org.xerial.snappy:snappy-java", version.ref = "snappy" }
-jspecify = "org.jspecify:jspecify:1.0.0"
+jspecify = "org.jspecify:jspecify:1.0.1"
 reflections = { module = "org.reflections:reflections", version.ref = "reflections" }
 # Auth / Security
 jjwt-api = { module = "io.jsonwebtoken:jjwt-api", version.ref = "jsonwebtoken" }


### PR DESCRIPTION
### Motivation

The remaining small tooling, annotation and utility libraries in the version catalog are behind.
Grouped into one PR because each is individually low risk.

### Modifications

`gradle/libs.versions.toml`:

| library | from | to |
|---|---|---|
| lombok | 1.18.42 | 1.18.46 |
| swagger (library and Gradle plugin) | 2.2.50 | 2.2.53 |
| error_prone_annotations | 2.45.0 | 2.50.0 |
| spotbugs-annotations | 4.9.6 | 4.10.3 |
| jspecify | 1.0.0 | 1.0.1 |
| joda-time | 2.10.10 | 2.14.3 |
| ant | 1.10.12 | 1.10.17 |
| javassist | 3.25.0-GA | 3.32.0-GA |
| jline3 | 4.2.1 | 4.3.1 |
| jna | 5.18.1 | 5.19.1 |
| java-semver | 0.9.0 | 0.10.2 |
| typetools | 0.5.0 | 0.6.3 |
| zt-zip | 1.17 | 1.18.2 |
| ipaddress | 5.5.0 | 5.6.2 |
| oshi | 6.4.0 | **6.12.0** (not 7.0.0) |
| athenz | 1.12.42 | 1.12.45 |
| auth0 java-jwt | 4.5.2 | 4.6.0 |
| auth0 jwks-rsa | 0.23.1 | 0.24.1 |

Plus the corresponding jar names in the server and shell distribution `LICENSE.bin.txt` files.

`error_prone_annotations` and `spotbugs-annotations` are annotation-only artifacts; neither Error
Prone nor SpotBugs is applied as a build plugin, so those two carry no analysis behaviour change.

**java-semver 0.10.2 is a drop-in.** Inspecting the published jar confirms it retains the whole
deprecated 0.9.x API that Pulsar uses — `Version.valueOf(String)`, `Version.BUILD_AWARE_ORDER` and
`greaterThan` — so `BrokerVersionFilter` and `PersistentTopicsBase` need no source change. One
behaviour note for reviewers: `equals()` became build-metadata-aware in 0.10.x, and
`BrokerVersionFilter` compares versions with `equals`.

**oshi stops at 6.12.0 rather than 7.0.0.** At 7.0.0 the `oshi-core-java11` artifact became a
pom-only relocation stub redirecting to `com.github.oshi:oshi-core` — its own POM says "Deprecated:
use oshi-core instead". That is a coordinate change rather than a version bump and does not belong in
a bulk update. 6.12.0 splits out a new `oshi-common` artifact, which is added to the server LICENSE.

**guice is deliberately left at 5.1.0.** TestNG 7.12.0 declares `com.google.inject:guice` 5.1.0, and
Guice 7 switches from `javax.inject` to `jakarta.inject`. Since the version catalog drives the
`pulsar-dependencies` enforced platform, raising it would push TestNG onto a Guice it was not built
against across every test run. jclouds is the only consumer that actually needs Guice 7, and
`jclouds-shaded` already forces it locally, so there is nothing to gain. A comment recording this is
added to the catalog.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

Verified locally with `./gradlew sanityCheck` and `./gradlew checkBinaryLicense`.

### Does this pull request potentially affect one of the following parts:

- [x] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
