### PR TITLE
[fix][broker] Do not log an error when the tenant does not exist

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/MultiRolesTokenAuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/MultiRolesTokenAuthorizationProvider.java
@@ -32,6 +32,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
@@ -126,6 +127,20 @@ public class MultiRolesTokenAuthorizationProvider extends PulsarAuthorizationPro
 
                     return pulsarResources.getTenantResources()
                             .getTenantAsync(tenantName)
+                            // Failing to read the tenant is a broker-side fault, so it is handled here, on the
+                            // stage that can actually fail. Keeping this handler off the stage below prevents the
+                            // expected "tenant does not exist" rejection from being reported as an error.
+                            .exceptionally(ex -> {
+                                Throwable cause = FutureUtil.unwrapCompletionException(ex);
+                                if (cause instanceof MetadataStoreException.NotFoundException) {
+                                    log.warn()
+                                            .attr("tenant", tenantName)
+                                            .log("Failed to get tenant info data for non existing tenant");
+                                    return Optional.empty();
+                                }
+                                log.error().attr("tenant", tenantName).exception(cause).log("Failed to get tenant");
+                                throw new RestException(cause);
+                            })
                             .thenCompose(op -> {
                                 if (op.isPresent()) {
                                     TenantInfo tenantInfo = op.get();
@@ -135,19 +150,11 @@ public class MultiRolesTokenAuthorizationProvider extends PulsarAuthorizationPro
 
                                     return CompletableFuture.completedFuture(roles.stream()
                                             .anyMatch(n -> tenantInfo.getAdminRoles().contains(n)));
-                                } else {
-                                    throw new RestException(Response.Status.NOT_FOUND, "Tenant does not exist");
                                 }
-                            }).exceptionally(ex -> {
-                                Throwable cause = ex.getCause();
-                                if (cause instanceof MetadataStoreException.NotFoundException) {
-                                    log.warn()
-                                            .attr("tenant", tenantName)
-                                            .log("Failed to get tenant info data for non existing tenant");
-                                    throw new RestException(Response.Status.NOT_FOUND, "Tenant does not exist");
-                                }
-                                log.error().attr("tenant", tenantName).exception(cause).log("Failed to get tenant");
-                                throw new RestException(cause);
+                                // A client naming a tenant that does not exist is a client error, not a broker
+                                // fault: reject it without logging. Any client can trigger this at will, and the
+                                // caller (e.g. ServerCnx) already logs the rejection at its own level.
+                                throw new RestException(Response.Status.NOT_FOUND, "Tenant does not exist");
                             });
                 });
     }

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
@@ -736,22 +737,28 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
                     }
                     return pulsarResources.getTenantResources()
                             .getTenantAsync(tenantName)
-                            .thenCompose(op -> {
-                                if (op.isPresent()) {
-                                    return isTenantAdmin(tenantName, role, op.get(), authData);
-                                } else {
-                                    throw new RestException(Response.Status.NOT_FOUND, "Tenant does not exist");
-                                }
-                            }).exceptionally(ex -> {
-                                Throwable cause = ex.getCause();
+                            // Failing to read the tenant is a broker-side fault, so it is handled here, on the
+                            // stage that can actually fail. Keeping this handler off the stage below prevents the
+                            // expected "tenant does not exist" rejection from being reported as an error.
+                            .exceptionally(ex -> {
+                                Throwable cause = FutureUtil.unwrapCompletionException(ex);
                                 if (cause instanceof NotFoundException) {
                                     log.warn()
                                             .attr("tenant", tenantName)
                                             .log("Failed to get tenant info data for non existing tenant");
-                                    throw new RestException(Response.Status.NOT_FOUND, "Tenant does not exist");
+                                    return Optional.empty();
                                 }
                                 log.error().attr("tenant", tenantName).exception(cause).log("Failed to get tenant");
                                 throw new RestException(cause);
+                            })
+                            .thenCompose(op -> {
+                                if (op.isPresent()) {
+                                    return isTenantAdmin(tenantName, role, op.get(), authData);
+                                }
+                                // A client naming a tenant that does not exist is a client error, not a broker
+                                // fault: reject it without logging. Any client can trigger this at will, and the
+                                // caller (e.g. ServerCnx) already logs the rejection at its own level.
+                                throw new RestException(Response.Status.NOT_FOUND, "Tenant does not exist");
                             });
                 });
     }

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authorization/LogCapture.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authorization/LogCapture.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.authorization;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.layout.PatternLayout;
+
+/**
+ * Captures the Log4j2 events emitted by a single logger, so that tests can assert on the level a
+ * given condition is reported at. slog resolves to its Log4j2 backend whenever log4j-core is on the
+ * classpath, so this captures slog output too.
+ */
+final class LogCapture extends AbstractAppender implements AutoCloseable {
+
+    private static final AtomicInteger ID = new AtomicInteger();
+
+    private final List<LogEvent> events = Collections.synchronizedList(new ArrayList<>());
+    private final String loggerName;
+    private final LoggerConfig loggerConfig;
+    private final LoggerContext context;
+
+    /**
+     * Starts capturing the events logged by {@code loggerOwner}'s logger. The capture is released on
+     * {@link #close()}.
+     */
+    static LogCapture attach(Class<?> loggerOwner) {
+        LoggerContext context = (LoggerContext) LogManager.getContext(false);
+        LoggerConfig loggerConfig = context.getConfiguration().getLoggerConfig(loggerOwner.getName());
+        LogCapture capture = new LogCapture(loggerOwner.getName(), loggerConfig, context);
+        capture.start();
+        // The resolved LoggerConfig is often an ancestor (usually root), so this appender may also see
+        // events from unrelated loggers. append() filters them out by name.
+        loggerConfig.addAppender(capture, Level.ALL, null);
+        context.updateLoggers();
+        return capture;
+    }
+
+    private LogCapture(String loggerName, LoggerConfig loggerConfig, LoggerContext context) {
+        super("LogCapture-" + ID.incrementAndGet(), null, PatternLayout.createDefaultLayout(), false, null);
+        this.loggerName = loggerName;
+        this.loggerConfig = loggerConfig;
+        this.context = context;
+    }
+
+    @Override
+    public void append(LogEvent event) {
+        if (loggerName.equals(event.getLoggerName())) {
+            events.add(event.toImmutable());
+        }
+    }
+
+    /** Returns the formatted messages captured at {@code level}, in the order they were logged. */
+    List<String> messagesAt(Level level) {
+        synchronized (events) {
+            return events.stream()
+                    .filter(event -> event.getLevel() == level)
+                    .map(event -> event.getMessage().getFormattedMessage())
+                    .collect(Collectors.toList());
+        }
+    }
+
+    @Override
+    public void close() {
+        stop();
+        loggerConfig.removeAppender(getName());
+        context.updateLoggers();
+    }
+}

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authorization/MultiRolesTokenAuthorizationProviderTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authorization/MultiRolesTokenAuthorizationProviderTest.java
@@ -19,11 +19,16 @@
 package org.apache.pulsar.broker.authorization;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.expectThrows;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -31,12 +36,15 @@ import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 import javax.crypto.SecretKey;
 import lombok.Cleanup;
+import org.apache.logging.log4j.Level;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSubscription;
 import org.apache.pulsar.broker.authentication.utils.AuthTokenUtils;
 import org.apache.pulsar.broker.resources.PulsarResources;
+import org.apache.pulsar.broker.resources.TenantResources;
+import org.apache.pulsar.common.util.RestException;
 import org.testng.annotations.Test;
 
 public class MultiRolesTokenAuthorizationProviderTest {
@@ -418,5 +426,51 @@ public class MultiRolesTokenAuthorizationProviderTest {
         assertTrue(ex.getCause() instanceof PulsarServerException);
         assertTrue(ex.getCause().getMessage().contains(
                 "The subscription name needs to be prefixed by the authentication role"));
+    }
+
+    /**
+     * A client asking about a tenant that does not exist is a client-side 404, not a broker fault, so
+     * it must not be reported at ERROR. Any client can trigger it at will simply by mistyping a tenant.
+     */
+    @Test
+    public void testMissingTenantIsNotLoggedAtError() throws Exception {
+        String tenant = "non-existent-tenant";
+        TenantResources tenantResources = mock(TenantResources.class);
+        when(tenantResources.getTenantAsync(tenant))
+                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+        PulsarResources pulsarResources = mock(PulsarResources.class);
+        when(pulsarResources.getTenantResources()).thenReturn(tenantResources);
+
+        SecretKey secretKey = AuthTokenUtils.createSecretKey(SignatureAlgorithm.HS256);
+        String token = Jwts.builder().claim("roles", new String[]{"user-a"}).signWith(secretKey).compact();
+
+        MultiRolesTokenAuthorizationProvider provider = new MultiRolesTokenAuthorizationProvider();
+        provider.initialize(new ServiceConfiguration(), pulsarResources);
+
+        AuthenticationDataSource ads = new AuthenticationDataSource() {
+            @Override
+            public boolean hasDataFromHttp() {
+                return true;
+            }
+
+            @Override
+            public String getHttpHeader(String name) {
+                if (name.equals("Authorization")) {
+                    return "Bearer " + token;
+                } else {
+                    throw new IllegalArgumentException("Wrong HTTP header");
+                }
+            }
+        };
+
+        try (LogCapture logs = LogCapture.attach(MultiRolesTokenAuthorizationProvider.class)) {
+            CompletableFuture<Boolean> future = provider.validateTenantAdminAccess(tenant, "user-a", ads);
+
+            ExecutionException ee = expectThrows(ExecutionException.class, future::get);
+            assertEquals(((RestException) ee.getCause()).getResponse().getStatus(),
+                    Response.Status.NOT_FOUND.getStatusCode());
+            assertEquals(logs.messagesAt(Level.ERROR), List.of(),
+                    "A tenant that does not exist must not be logged at ERROR");
+        }
     }
 }

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProviderTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProviderTest.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.authorization;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.expectThrows;
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import org.apache.logging.log4j.Level;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.resources.PulsarResources;
+import org.apache.pulsar.broker.resources.TenantResources;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.policies.data.TenantInfo;
+import org.apache.pulsar.common.policies.data.TopicOperation;
+import org.apache.pulsar.common.util.RestException;
+import org.apache.pulsar.metadata.api.MetadataStoreException;
+import org.testng.annotations.Test;
+
+public class PulsarAuthorizationProviderTest {
+
+    private static final String MISSING_TENANT = "non-existent-tenant";
+    private static final String ROLE = "some-role";
+
+    private static PulsarAuthorizationProvider providerReturning(
+            CompletableFuture<Optional<TenantInfo>> tenantLookup) throws Exception {
+        TenantResources tenantResources = mock(TenantResources.class);
+        when(tenantResources.getTenantAsync(MISSING_TENANT)).thenReturn(tenantLookup);
+        PulsarResources pulsarResources = mock(PulsarResources.class);
+        when(pulsarResources.getTenantResources()).thenReturn(tenantResources);
+
+        PulsarAuthorizationProvider provider = new PulsarAuthorizationProvider();
+        provider.initialize(new ServiceConfiguration(), pulsarResources);
+        return provider;
+    }
+
+    /** A tenant that was never created: {@code getTenantAsync} succeeds with an empty Optional. */
+    private static PulsarAuthorizationProvider providerWithMissingTenant() throws Exception {
+        return providerReturning(CompletableFuture.completedFuture(Optional.empty()));
+    }
+
+    private static void assertNotFound(ExecutionException ee) {
+        RestException restException = (RestException) ee.getCause();
+        assertEquals(restException.getResponse().getStatus(), Response.Status.NOT_FOUND.getStatusCode());
+    }
+
+    /**
+     * A client asking about a tenant that does not exist is a client-side 404, not a broker fault, so
+     * it must not be reported at ERROR. Any client can trigger it at will simply by mistyping a tenant.
+     */
+    @Test
+    public void testMissingTenantIsNotLoggedAtErrorByValidateTenantAdminAccess() throws Exception {
+        PulsarAuthorizationProvider provider = providerWithMissingTenant();
+
+        try (LogCapture logs = LogCapture.attach(PulsarAuthorizationProvider.class)) {
+            CompletableFuture<Boolean> future =
+                    provider.validateTenantAdminAccess(MISSING_TENANT, ROLE, null);
+
+            assertNotFound(expectThrows(ExecutionException.class, future::get));
+            assertEquals(logs.messagesAt(Level.ERROR), List.of(),
+                    "A tenant that does not exist must not be logged at ERROR");
+        }
+    }
+
+    /**
+     * The path an actual LOOKUP takes: ServerCnx -> AuthorizationService -> allowTopicOperationAsync.
+     * One ERROR line per lookup here is what floods a broker when a misconfigured client hammers a
+     * cluster that does not host its tenant.
+     */
+    @Test
+    public void testMissingTenantIsNotLoggedAtErrorByLookupAuthorization() throws Exception {
+        PulsarAuthorizationProvider provider = providerWithMissingTenant();
+        TopicName topicName = TopicName.get("persistent://" + MISSING_TENANT + "/ns/topic");
+
+        try (LogCapture logs = LogCapture.attach(PulsarAuthorizationProvider.class)) {
+            CompletableFuture<Boolean> future =
+                    provider.allowTopicOperationAsync(topicName, ROLE, TopicOperation.LOOKUP, null);
+
+            assertNotFound(expectThrows(ExecutionException.class, future::get));
+            assertEquals(logs.messagesAt(Level.ERROR), List.of(),
+                    "A tenant that does not exist must not be logged at ERROR");
+        }
+    }
+
+    /**
+     * Guards the fix from over-reaching: a genuine metadata store failure is a broker-side fault and
+     * must still be reported at ERROR.
+     */
+    @Test
+    public void testMetadataStoreFailureIsStillLoggedAtError() throws Exception {
+        PulsarAuthorizationProvider provider = providerReturning(CompletableFuture.failedFuture(
+                new MetadataStoreException("simulated metadata store failure")));
+
+        try (LogCapture logs = LogCapture.attach(PulsarAuthorizationProvider.class)) {
+            CompletableFuture<Boolean> future =
+                    provider.validateTenantAdminAccess(MISSING_TENANT, ROLE, null);
+
+            expectThrows(ExecutionException.class, future::get);
+            assertFalse(logs.messagesAt(Level.ERROR).isEmpty(),
+                    "A metadata store failure must still be logged at ERROR");
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

`PulsarAuthorizationProvider#validateTenantAdminAccess` throws `RestException(404, "Tenant does not exist")` from inside `thenCompose`, and the `exceptionally` handler chained onto that same stage catches it. That handler only special-cases `MetadataStoreException.NotFoundException`, so the self-thrown 404 falls through to `log.error("Failed to get tenant", cause)`.

Every request naming a tenant that does not exist therefore produces an ERROR line with a stack trace. A lookup is enough to trigger it, so a single misconfigured client pointed at a cluster that does not host its tenant can flood a healthy broker — roughly 1000 ERROR lines in 10 minutes from one client, on a broker with nothing wrong with it.

A tenant that does not exist is a client error, not a broker fault: any client can trigger it by mistyping a tenant name, and `ServerCnx` already reports the rejection at its own level.

`MultiRolesTokenAuthorizationProvider` overrides the method and carries an identical copy of the bug.

### Modifications

- Move the `exceptionally` handler onto `getTenantAsync()`, the stage that can actually fail, and perform the presence check after it. The "tenant does not exist" rejection then has no error handler downstream.
- Map `MetadataStoreException.NotFoundException` to an empty `Optional` so both "tenant is missing" paths converge on the same 404.
- Use `FutureUtil.unwrapCompletionException` instead of `ex.getCause()`. Attached directly to `getTenantAsync()`, the exception is no longer wrapped in a `CompletionException`.
- Apply the same change to `MultiRolesTokenAuthorizationProvider`.

Genuine metadata store failures are still logged at ERROR. Client-visible behaviour is unchanged: the previous code rethrew `new RestException(cause)`, which preserved the 404 response, so the status, message and `ErrorData` entity are identical.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- Added `PulsarAuthorizationProviderTest` with three tests: one on `validateTenantAdminAccess`, one on `allowTopicOperationAsync` with `TopicOperation.LOOKUP` (the path an actual lookup takes), and one asserting that a metadata store failure is still logged at ERROR, which guards the fix from over-reaching.
- Added an equivalent test to `MultiRolesTokenAuthorizationProviderTest`.
- Added `LogCapture`, a Log4j2 appender that captures a single logger's events so the tests can assert on the level a condition is reported at.
- With the production change reverted, the three "must not be logged at ERROR" tests fail and the metadata-store-failure test still passes.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
