### PR TITLE
[fix][broker] Fix early completion and false timeouts in SplitManager and UnloadManager

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/manager/SplitManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/manager/SplitManager.java
@@ -20,10 +20,12 @@ package org.apache.pulsar.broker.loadbalance.extensions.manager;
 
 import static org.apache.pulsar.broker.loadbalance.extensions.models.SplitDecision.Label.Failure;
 import static org.apache.pulsar.broker.loadbalance.extensions.models.SplitDecision.Reason.Unknown;
+import com.google.common.annotations.VisibleForTesting;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import lombok.CustomLog;
 import org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitState;
 import org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateData;
@@ -47,16 +49,15 @@ public class SplitManager implements StateChangeListener {
     }
 
     private void complete(String serviceUnit, Throwable ex) {
-        inFlightSplitRequests.computeIfPresent(serviceUnit, (__, future) -> {
-            if (!future.isDone()) {
-                if (ex != null) {
-                    future.completeExceptionally(ex);
-                } else {
-                    future.complete(null);
-                }
-            }
-            return null;
-        });
+        CompletableFuture<Void> future = inFlightSplitRequests.remove(serviceUnit);
+        if (future == null || future.isDone()) {
+            return;
+        }
+        if (ex != null) {
+            future.completeExceptionally(ex);
+        } else {
+            future.complete(null);
+        }
     }
 
     public CompletableFuture<Void> waitAsync(CompletableFuture<Void> eventPubFuture,
@@ -64,22 +65,22 @@ public class SplitManager implements StateChangeListener {
                                              SplitDecision decision,
                                              long timeout,
                                              TimeUnit timeoutUnit) {
-        return eventPubFuture
-                .thenCompose(__ -> inFlightSplitRequests.computeIfAbsent(bundle, ignore -> {
-                    log.info().attr("bundle", bundle).attr("timeout", timeout)
-                            .attr("timeoutUnit", timeoutUnit)
-                            .log("Published the bundle split event for bundle: . "
-                                    + "Waiting the split event to complete. Timeout");
-                    CompletableFuture<Void> future = new CompletableFuture<>();
-                    future.orTimeout(timeout, timeoutUnit).whenComplete((v, ex) -> {
-                        if (ex != null) {
-                            inFlightSplitRequests.remove(bundle);
-                            log.warn().attr("bundle", bundle).exception(ex)
-                                    .log("Timed out while waiting for the bundle split event");
-                        }
-                    });
-                    return future;
-                }))
+        return eventPubFuture.thenCompose(__ -> {
+            CompletableFuture<Void> future = inFlightSplitRequests.computeIfAbsent(bundle, ignore -> {
+                log.info().attr("bundle", bundle).attr("timeout", timeout)
+                        .attr("timeoutUnit", timeoutUnit)
+                        .log("Published the bundle split event for bundle: . "
+                                + "Waiting the split event to complete. Timeout");
+                return new CompletableFuture<Void>().orTimeout(timeout, timeoutUnit);
+            });
+            // Return the dependent stage so callers cannot observe completion before timeout cleanup finishes.
+            return future.whenComplete((v, ex) -> {
+                if (ex instanceof TimeoutException && inFlightSplitRequests.remove(bundle, future)) {
+                    log.warn().attr("bundle", bundle).exception(ex)
+                            .log("Timed out while waiting for the bundle split event");
+                }
+            });
+        })
                 .whenComplete((__, ex) -> {
                     if (ex != null) {
                         log.error().attr("bundle", bundle).exception(ex)
@@ -109,12 +110,16 @@ public class SplitManager implements StateChangeListener {
 
     public void close() {
         inFlightSplitRequests.forEach((bundle, future) -> {
-            if (!future.isDone()) {
+            if (inFlightSplitRequests.remove(bundle, future) && !future.isDone()) {
                 String msg = String.format("Splitting bundle: %s, but the manager already closed.", bundle);
                 log.warn(msg);
                 future.completeExceptionally(new IllegalStateException(msg));
             }
         });
-        inFlightSplitRequests.clear();
+    }
+
+    @VisibleForTesting
+    int getInFlightSplitRequestCount() {
+        return inFlightSplitRequests.size();
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/manager/UnloadManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/manager/UnloadManager.java
@@ -30,6 +30,7 @@ import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import lombok.CustomLog;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitState;
@@ -117,16 +118,15 @@ public class UnloadManager implements StateChangeListener {
             LatencyMetric.ASSIGN.endMeasurement(serviceUnit);
         }
 
-        inFlightUnloadRequest.computeIfPresent(serviceUnit, (__, future) -> {
-            if (!future.isDone()) {
-                if (ex != null) {
-                    future.completeExceptionally(ex);
-                } else {
-                    future.complete(null);
-                }
-            }
-            return null;
-        });
+        CompletableFuture<Void> future = inFlightUnloadRequest.remove(serviceUnit);
+        if (future == null || future.isDone()) {
+            return;
+        }
+        if (ex != null) {
+            future.completeExceptionally(ex);
+        } else {
+            future.complete(null);
+        }
     }
 
     public CompletableFuture<Void> waitAsync(CompletableFuture<Void> eventPubFuture,
@@ -134,18 +134,19 @@ public class UnloadManager implements StateChangeListener {
                                              UnloadDecision decision,
                                              long timeout,
                                              TimeUnit timeoutUnit) {
-        return eventPubFuture.thenCompose(__ -> inFlightUnloadRequest.computeIfAbsent(bundle, ignore -> {
-            log.debug().attr("bundle", bundle).attr("timeout", timeout).attr("timeoutUnit", timeoutUnit)
-                    .log("Handle unload bundle: , timeout");
-            CompletableFuture<Void> future = new CompletableFuture<>();
-            future.orTimeout(timeout, timeoutUnit).whenComplete((v, ex) -> {
-                if (ex != null) {
-                    inFlightUnloadRequest.remove(bundle);
+        return eventPubFuture.thenCompose(__ -> {
+            CompletableFuture<Void> future = inFlightUnloadRequest.computeIfAbsent(bundle, ignore -> {
+                log.debug().attr("bundle", bundle).attr("timeout", timeout).attr("timeoutUnit", timeoutUnit)
+                        .log("Handle unload bundle: , timeout");
+                return new CompletableFuture<Void>().orTimeout(timeout, timeoutUnit);
+            });
+            // Return the dependent stage so callers cannot observe completion before timeout cleanup finishes.
+            return future.whenComplete((v, ex) -> {
+                if (ex instanceof TimeoutException && inFlightUnloadRequest.remove(bundle, future)) {
                     log.warn().attr("bundle", bundle).exception(ex).log("Failed to wait unload for serviceUnit");
                 }
             });
-            return future;
-        })).whenComplete((__, ex) -> {
+        }).whenComplete((__, ex) -> {
             if (ex != null) {
                 counter.update(Failure, Unknown);
                 log.warn().attr("bundle", bundle).exception(ex).log("Failed to unload bundle");
@@ -207,12 +208,16 @@ public class UnloadManager implements StateChangeListener {
 
     public void close() {
         inFlightUnloadRequest.forEach((bundle, future) -> {
-            if (!future.isDone()) {
+            if (inFlightUnloadRequest.remove(bundle, future) && !future.isDone()) {
                 String msg = String.format("Unloading bundle: %s, but the unload manager already closed.", bundle);
                 log.warn(msg);
                 future.completeExceptionally(new IllegalStateException(msg));
             }
         });
-        inFlightUnloadRequest.clear();
+    }
+
+    @VisibleForTesting
+    int getInFlightUnloadRequestCount() {
+        return inFlightUnloadRequest.size();
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/manager/SplitManagerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/manager/SplitManagerTest.java
@@ -22,15 +22,19 @@ import static org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUni
 import static org.apache.pulsar.broker.loadbalance.extensions.models.SplitDecision.Reason.Sessions;
 import static org.apache.pulsar.broker.loadbalance.extensions.models.SplitDecision.Reason.Unknown;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
-import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import lombok.CustomLog;
-import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitState;
 import org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateData;
 import org.apache.pulsar.broker.loadbalance.extensions.models.SplitCounter;
@@ -41,6 +45,8 @@ import org.testng.annotations.Test;
 @CustomLog
 @Test(groups = "broker")
 public class SplitManagerTest {
+
+    private static final int CONCURRENT_REQUEST_COUNT = 32;
 
     String bundle = "bundle-1";
 
@@ -69,16 +75,17 @@ public class SplitManagerTest {
     }
 
     @Test
-    public void testTimeout() throws IllegalAccessException {
+    public void testTimeout() {
         var counter = new SplitCounter();
         SplitManager manager = new SplitManager(counter);
         var decision = new SplitDecision();
         CompletableFuture<Void> future =
                 manager.waitAsync(CompletableFuture.completedFuture(null),
                         bundle, decision, 3, TimeUnit.SECONDS);
-        var inFlightUnloadRequests = getinFlightUnloadRequests(manager);
+        CompletableFuture<Integer> inFlightRequestCountOnCompletion =
+                captureInFlightRequestCountOnCompletion(future, manager);
 
-        assertEquals(inFlightUnloadRequests.size(), 1);
+        assertEquals(manager.getInFlightSplitRequestCount(), 1);
 
         try {
             future.get();
@@ -87,15 +94,22 @@ public class SplitManagerTest {
             assertTrue(ex.getCause() instanceof TimeoutException);
         }
 
-        assertEquals(inFlightUnloadRequests.size(), 0);
+        assertEquals(inFlightRequestCountOnCompletion.join(), 0);
+        assertEquals(manager.getInFlightSplitRequestCount(), 0);
         var counterExpected = new SplitCounter();
         counterExpected.update(SplitDecision.Label.Failure, Unknown);
         assertEquals(counter.toMetrics(null).toString(),
                 counterExpected.toMetrics(null).toString());
+
+        CompletableFuture<Void> nextFuture = manager.waitAsync(CompletableFuture.completedFuture(null),
+                bundle, decision, 5, TimeUnit.SECONDS);
+        assertFalse(nextFuture.isDone());
+        assertEquals(manager.getInFlightSplitRequestCount(), 1);
+        manager.close();
     }
 
     @Test
-    public void testSuccess() throws IllegalAccessException, ExecutionException, InterruptedException {
+    public void testSuccess() throws ExecutionException, InterruptedException {
         var counter = new SplitCounter();
         SplitManager manager = new SplitManager(counter);
         var counterExpected = new SplitCounter();
@@ -104,56 +118,57 @@ public class SplitManagerTest {
         CompletableFuture<Void> future =
                 manager.waitAsync(CompletableFuture.completedFuture(null),
                         bundle, decision, 5, TimeUnit.SECONDS);
-        var inFlightUnloadRequests = getinFlightUnloadRequests(manager);
-
-        assertEquals(inFlightUnloadRequests.size(), 1);
+        CompletableFuture<Integer> inFlightRequestCountOnCompletion =
+                captureInFlightRequestCountOnCompletion(future, manager);
+        assertEquals(manager.getInFlightSplitRequestCount(), 1);
 
         manager.handleEvent(bundle,
                 new ServiceUnitStateData(ServiceUnitState.Assigning, dstBroker, VERSION_ID_INIT), null);
-        assertEquals(inFlightUnloadRequests.size(), 1);
+        assertEquals(manager.getInFlightSplitRequestCount(), 1);
 
         manager.handleEvent(bundle,
                 new ServiceUnitStateData(ServiceUnitState.Splitting, dstBroker, VERSION_ID_INIT), null);
-        assertEquals(inFlightUnloadRequests.size(), 1);
+        assertEquals(manager.getInFlightSplitRequestCount(), 1);
 
         manager.handleEvent(bundle,
                 new ServiceUnitStateData(ServiceUnitState.Releasing, dstBroker, VERSION_ID_INIT), null);
-        assertEquals(inFlightUnloadRequests.size(), 1);
+        assertEquals(manager.getInFlightSplitRequestCount(), 1);
 
         manager.handleEvent(bundle,
                 new ServiceUnitStateData(ServiceUnitState.Free, dstBroker, VERSION_ID_INIT), null);
-        assertEquals(inFlightUnloadRequests.size(), 1);
+        assertEquals(manager.getInFlightSplitRequestCount(), 1);
 
         manager.handleEvent(bundle,
                 new ServiceUnitStateData(ServiceUnitState.Deleted, dstBroker, VERSION_ID_INIT), null);
-        assertEquals(inFlightUnloadRequests.size(), 1);
+        assertEquals(manager.getInFlightSplitRequestCount(), 1);
 
         manager.handleEvent(bundle,
                 new ServiceUnitStateData(ServiceUnitState.Owned, dstBroker, VERSION_ID_INIT), null);
-        assertEquals(inFlightUnloadRequests.size(), 1);
+        assertEquals(manager.getInFlightSplitRequestCount(), 1);
 
         // Success with Init state.
         manager.handleEvent(bundle,
                 new ServiceUnitStateData(ServiceUnitState.Init, dstBroker, VERSION_ID_INIT), null);
-        assertEquals(inFlightUnloadRequests.size(), 0);
+        assertEquals(manager.getInFlightSplitRequestCount(), 0);
         counterExpected.update(SplitDecision.Label.Success, Sessions);
         assertEquals(counter.toMetrics(null).toString(),
                 counterExpected.toMetrics(null).toString());
 
         future.get();
+        assertEquals(inFlightRequestCountOnCompletion.join(), 0);
     }
 
     @Test
-    public void testFailedStage() throws IllegalAccessException {
+    public void testFailedStage() {
         var counter = new SplitCounter();
         SplitManager manager = new SplitManager(counter);
         var decision = new SplitDecision();
         CompletableFuture<Void> future =
                 manager.waitAsync(CompletableFuture.completedFuture(null),
                         bundle, decision, 5, TimeUnit.SECONDS);
-        var inFlightUnloadRequests = getinFlightUnloadRequests(manager);
-
-        assertEquals(inFlightUnloadRequests.size(), 1);
+        CompletableFuture<Integer> inFlightRequestCountOnCompletion =
+                captureInFlightRequestCountOnCompletion(future, manager);
+        assertEquals(manager.getInFlightSplitRequestCount(), 1);
 
         manager.handleEvent(bundle,
                 new ServiceUnitStateData(ServiceUnitState.Owned, dstBroker, VERSION_ID_INIT),
@@ -167,7 +182,8 @@ public class SplitManagerTest {
             assertEquals(ex.getCause().getMessage(), "Failed stage.");
         }
 
-        assertEquals(inFlightUnloadRequests.size(), 0);
+        assertEquals(manager.getInFlightSplitRequestCount(), 0);
+        assertEquals(inFlightRequestCountOnCompletion.join(), 0);
         var counterExpected = new SplitCounter();
         counterExpected.update(SplitDecision.Label.Failure, Unknown);
         assertEquals(counter.toMetrics(null).toString(),
@@ -175,16 +191,17 @@ public class SplitManagerTest {
     }
 
     @Test
-    public void testClose() throws IllegalAccessException {
+    public void testClose() {
         SplitManager manager = new SplitManager(new SplitCounter());
         var decision = new SplitDecision();
         CompletableFuture<Void> future =
                 manager.waitAsync(CompletableFuture.completedFuture(null),
                         bundle, decision, 5, TimeUnit.SECONDS);
-        var inFlightUnloadRequests = getinFlightUnloadRequests(manager);
-        assertEquals(inFlightUnloadRequests.size(), 1);
+        CompletableFuture<Integer> inFlightRequestCountOnCompletion =
+                captureInFlightRequestCountOnCompletion(future, manager);
+        assertEquals(manager.getInFlightSplitRequestCount(), 1);
         manager.close();
-        assertEquals(inFlightUnloadRequests.size(), 0);
+        assertEquals(manager.getInFlightSplitRequestCount(), 0);
 
         try {
             future.get();
@@ -192,15 +209,126 @@ public class SplitManagerTest {
         } catch (Exception ex) {
             assertTrue(ex.getCause() instanceof IllegalStateException);
         }
+        assertEquals(inFlightRequestCountOnCompletion.join(), 0);
     }
 
-    @SuppressWarnings("unchecked")
-    private Map<String, CompletableFuture<Void>> getinFlightUnloadRequests(SplitManager manager)
-            throws IllegalAccessException {
-        var inFlightUnloadRequest =
-                (Map<String, CompletableFuture<Void>>) FieldUtils.readField(manager, "inFlightSplitRequests", true);
+    @Test(timeOut = 10_000)
+    public void testConcurrentWaitersShareOneInFlightRequest() {
+        SplitManager manager = new SplitManager(new SplitCounter());
+        var decision = new SplitDecision();
+        decision.succeed(Sessions);
+        ExecutorService executor = Executors.newFixedThreadPool(8);
+        try {
+            CountDownLatch start = new CountDownLatch(1);
+            List<CompletableFuture<CompletableFuture<Void>>> registrations = new ArrayList<>();
+            for (int i = 0; i < CONCURRENT_REQUEST_COUNT; i++) {
+                registrations.add(CompletableFuture.supplyAsync(() -> {
+                    await(start);
+                    return manager.waitAsync(CompletableFuture.completedFuture(null),
+                            bundle, decision, 30, TimeUnit.SECONDS);
+                }, executor));
+            }
 
-        return inFlightUnloadRequest;
+            start.countDown();
+            List<CompletableFuture<Void>> waiters = registrations.stream()
+                    .map(CompletableFuture::join)
+                    .toList();
+            assertEquals(manager.getInFlightSplitRequestCount(), 1);
+            List<CompletableFuture<Integer>> countsOnCompletion = waiters.stream()
+                    .map(future -> captureInFlightRequestCountOnCompletion(future, manager))
+                    .toList();
+
+            manager.handleEvent(bundle,
+                    new ServiceUnitStateData(ServiceUnitState.Init, dstBroker, VERSION_ID_INIT), null);
+
+            waiters.forEach(CompletableFuture::join);
+            countsOnCompletion.forEach(count -> assertEquals(count.join().intValue(), 0));
+            assertEquals(manager.getInFlightSplitRequestCount(), 0);
+
+            String timeoutBundle = "concurrent-timeout";
+            List<CompletableFuture<Void>> timeoutWaiters = new ArrayList<>();
+            for (int i = 0; i < CONCURRENT_REQUEST_COUNT; i++) {
+                timeoutWaiters.add(manager.waitAsync(CompletableFuture.completedFuture(null),
+                        timeoutBundle, decision, 1, TimeUnit.SECONDS));
+            }
+            assertEquals(manager.getInFlightSplitRequestCount(), 1);
+            List<CompletableFuture<Integer>> timeoutCountsOnCompletion = timeoutWaiters.stream()
+                    .map(future -> captureInFlightRequestCountOnCompletion(future, manager))
+                    .toList();
+            List<CompletableFuture<Throwable>> timeoutFailures = timeoutWaiters.stream()
+                    .map(future -> future.handle((__, ex) -> ex))
+                    .toList();
+
+            CompletableFuture.allOf(timeoutWaiters.stream()
+                    .map(SplitManagerTest::ignoreFailure)
+                    .toArray(CompletableFuture[]::new)).join();
+            timeoutCountsOnCompletion.forEach(count -> assertEquals(count.join().intValue(), 0));
+            timeoutFailures.forEach(failure ->
+                    assertTrue(FutureUtil.unwrapCompletionException(failure.join()) instanceof TimeoutException));
+            assertEquals(manager.getInFlightSplitRequestCount(), 0);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test(timeOut = 10_000)
+    public void testCloseRacingWithConcurrentCompletions() {
+        SplitManager manager = new SplitManager(new SplitCounter());
+        var decision = new SplitDecision();
+        decision.succeed(Sessions);
+        List<String> bundles = new ArrayList<>();
+        List<CompletableFuture<Void>> waiters = new ArrayList<>();
+        for (int i = 0; i < CONCURRENT_REQUEST_COUNT; i++) {
+            String requestBundle = "close-race-" + i;
+            bundles.add(requestBundle);
+            waiters.add(manager.waitAsync(CompletableFuture.completedFuture(null),
+                    requestBundle, decision, 30, TimeUnit.SECONDS));
+        }
+        assertEquals(manager.getInFlightSplitRequestCount(), CONCURRENT_REQUEST_COUNT);
+
+        ExecutorService executor = Executors.newFixedThreadPool(8);
+        try {
+            CountDownLatch start = new CountDownLatch(1);
+            List<CompletableFuture<Void>> terminalSignals = new ArrayList<>();
+            terminalSignals.add(CompletableFuture.runAsync(() -> {
+                await(start);
+                manager.close();
+            }, executor));
+            for (String requestBundle : bundles) {
+                terminalSignals.add(CompletableFuture.runAsync(() -> {
+                    await(start);
+                    manager.handleEvent(requestBundle,
+                            new ServiceUnitStateData(ServiceUnitState.Init, dstBroker, VERSION_ID_INIT), null);
+                }, executor));
+            }
+
+            start.countDown();
+            CompletableFuture.allOf(terminalSignals.toArray(CompletableFuture[]::new)).join();
+            CompletableFuture.allOf(waiters.stream()
+                    .map(SplitManagerTest::ignoreFailure)
+                    .toArray(CompletableFuture[]::new)).join();
+            assertEquals(manager.getInFlightSplitRequestCount(), 0);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private static CompletableFuture<Integer> captureInFlightRequestCountOnCompletion(
+            CompletableFuture<Void> future, SplitManager manager) {
+        return future.handle((__, ex) -> manager.getInFlightSplitRequestCount());
+    }
+
+    private static CompletableFuture<Void> ignoreFailure(CompletableFuture<Void> future) {
+        return future.handle((__, ex) -> null);
+    }
+
+    private static void await(CountDownLatch latch) {
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError(e);
+        }
     }
 
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/manager/UnloadManagerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/manager/UnloadManagerTest.java
@@ -24,15 +24,19 @@ import static org.apache.pulsar.broker.loadbalance.extensions.models.UnloadDecis
 import static org.apache.pulsar.broker.loadbalance.extensions.models.UnloadDecision.Reason.Admin;
 import static org.apache.pulsar.broker.loadbalance.extensions.models.UnloadDecision.Reason.Unknown;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
-import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import lombok.CustomLog;
-import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitState;
 import org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateData;
 import org.apache.pulsar.broker.loadbalance.extensions.models.Unload;
@@ -44,6 +48,8 @@ import org.testng.annotations.Test;
 @CustomLog
 @Test(groups = "broker")
 public class UnloadManagerTest {
+
+    private static final int CONCURRENT_REQUEST_COUNT = 32;
 
     @Test
     public void testEventPubFutureHasException() {
@@ -66,7 +72,7 @@ public class UnloadManagerTest {
     }
 
     @Test
-    public void testTimeout() throws IllegalAccessException {
+    public void testTimeout() {
         UnloadCounter counter = new UnloadCounter();
         UnloadManager manager = new UnloadManager(counter, "mockBrokerId");
         var unloadDecision =
@@ -74,9 +80,10 @@ public class UnloadManagerTest {
         CompletableFuture<Void> future =
                 manager.waitAsync(CompletableFuture.completedFuture(null),
                         "bundle-1", unloadDecision, 3, TimeUnit.SECONDS);
-        Map<String, CompletableFuture<Void>> inFlightUnloadRequestMap = getInFlightUnloadRequestMap(manager);
+        CompletableFuture<Integer> inFlightRequestCountOnCompletion =
+                captureInFlightRequestCountOnCompletion(future, manager);
 
-        assertEquals(inFlightUnloadRequestMap.size(), 1);
+        assertEquals(manager.getInFlightUnloadRequestCount(), 1);
 
         try {
             future.get();
@@ -85,12 +92,19 @@ public class UnloadManagerTest {
             assertTrue(ex.getCause() instanceof TimeoutException);
         }
 
-        assertEquals(inFlightUnloadRequestMap.size(), 0);
+        assertEquals(inFlightRequestCountOnCompletion.join(), 0);
+        assertEquals(manager.getInFlightUnloadRequestCount(), 0);
         assertEquals(counter.getBreakdownCounters().get(Failure).get(Unknown).get(), 1);
+
+        CompletableFuture<Void> nextFuture = manager.waitAsync(CompletableFuture.completedFuture(null),
+                "bundle-1", unloadDecision, 5, TimeUnit.SECONDS);
+        assertFalse(nextFuture.isDone());
+        assertEquals(manager.getInFlightUnloadRequestCount(), 1);
+        manager.close();
     }
 
     @Test
-    public void testSuccess() throws IllegalAccessException, ExecutionException, InterruptedException {
+    public void testSuccess() throws ExecutionException, InterruptedException {
         UnloadCounter counter = new UnloadCounter();
         UnloadManager manager = new UnloadManager(counter, "mockBrokerId");
         String dstBroker = "broker-2";
@@ -101,61 +115,60 @@ public class UnloadManagerTest {
         CompletableFuture<Void> future =
                 manager.waitAsync(CompletableFuture.completedFuture(null),
                         bundle, unloadDecision, 5, TimeUnit.SECONDS);
-        Map<String, CompletableFuture<Void>> inFlightUnloadRequestMap = getInFlightUnloadRequestMap(manager);
-
-        assertEquals(inFlightUnloadRequestMap.size(), 1);
+        CompletableFuture<Integer> inFlightRequestCountOnCompletion =
+                captureInFlightRequestCountOnCompletion(future, manager);
+        assertEquals(manager.getInFlightUnloadRequestCount(), 1);
 
         manager.handleEvent(bundle,
                 new ServiceUnitStateData(ServiceUnitState.Assigning, null, srcBroker, VERSION_ID_INIT), null);
-        assertEquals(inFlightUnloadRequestMap.size(), 1);
+        assertEquals(manager.getInFlightUnloadRequestCount(), 1);
 
         manager.handleEvent(bundle,
                 new ServiceUnitStateData(ServiceUnitState.Deleted, null, srcBroker, VERSION_ID_INIT), null);
-        assertEquals(inFlightUnloadRequestMap.size(), 1);
+        assertEquals(manager.getInFlightUnloadRequestCount(), 1);
 
         manager.handleEvent(bundle,
                 new ServiceUnitStateData(ServiceUnitState.Splitting, null, srcBroker, VERSION_ID_INIT), null);
-        assertEquals(inFlightUnloadRequestMap.size(), 1);
+        assertEquals(manager.getInFlightUnloadRequestCount(), 1);
 
         manager.handleEvent(bundle,
                 new ServiceUnitStateData(ServiceUnitState.Releasing, null, srcBroker, VERSION_ID_INIT), null);
-        assertEquals(inFlightUnloadRequestMap.size(), 1);
+        assertEquals(manager.getInFlightUnloadRequestCount(), 1);
 
         manager.handleEvent(bundle,
                 new ServiceUnitStateData(ServiceUnitState.Free, null, srcBroker, true, VERSION_ID_INIT), null);
-        assertEquals(inFlightUnloadRequestMap.size(), 1);
+        assertEquals(manager.getInFlightUnloadRequestCount(), 1);
 
         // Success with Init state.
         manager.handleEvent(bundle, null, null);
-        assertEquals(inFlightUnloadRequestMap.size(), 0);
+        assertEquals(manager.getInFlightUnloadRequestCount(), 0);
         future.get();
+        assertEquals(inFlightRequestCountOnCompletion.join(), 0);
         assertEquals(counter.getBreakdownCounters().get(Success).get(Admin).get(), 1);
 
         // Success with Owned state.
         future = manager.waitAsync(CompletableFuture.completedFuture(null),
                 bundle, unloadDecision, 5, TimeUnit.SECONDS);
-        inFlightUnloadRequestMap = getInFlightUnloadRequestMap(manager);
-        assertEquals(inFlightUnloadRequestMap.size(), 1);
+        assertEquals(manager.getInFlightUnloadRequestCount(), 1);
         manager.handleEvent(bundle,
                 new ServiceUnitStateData(ServiceUnitState.Owned, dstBroker, null, VERSION_ID_INIT), null);
-        assertEquals(inFlightUnloadRequestMap.size(), 1);
+        assertEquals(manager.getInFlightUnloadRequestCount(), 1);
         manager.handleEvent(bundle,
                 new ServiceUnitStateData(ServiceUnitState.Owned, dstBroker, srcBroker, VERSION_ID_INIT), null);
-        assertEquals(inFlightUnloadRequestMap.size(), 0);
+        assertEquals(manager.getInFlightUnloadRequestCount(), 0);
         future.get();
         assertEquals(counter.getBreakdownCounters().get(Success).get(Admin).get(), 2);
 
         // Success with Free state.
         future = manager.waitAsync(CompletableFuture.completedFuture(null),
                 bundle, unloadDecision, 5, TimeUnit.SECONDS);
-        inFlightUnloadRequestMap = getInFlightUnloadRequestMap(manager);
-        assertEquals(inFlightUnloadRequestMap.size(), 1);
+        assertEquals(manager.getInFlightUnloadRequestCount(), 1);
         manager.handleEvent(bundle,
                 new ServiceUnitStateData(ServiceUnitState.Free, dstBroker, srcBroker, true, VERSION_ID_INIT), null);
-        assertEquals(inFlightUnloadRequestMap.size(), 1);
+        assertEquals(manager.getInFlightUnloadRequestCount(), 1);
         manager.handleEvent(bundle,
                 new ServiceUnitStateData(ServiceUnitState.Free, dstBroker, srcBroker, false, VERSION_ID_INIT), null);
-        assertEquals(inFlightUnloadRequestMap.size(), 0);
+        assertEquals(manager.getInFlightUnloadRequestCount(), 0);
         future.get();
         assertEquals(counter.getBreakdownCounters().get(Success).get(Admin).get(), 3);
 
@@ -163,7 +176,7 @@ public class UnloadManagerTest {
     }
 
     @Test
-    public void testFailedStage() throws IllegalAccessException {
+    public void testFailedStage() {
         UnloadCounter counter = new UnloadCounter();
         UnloadManager manager = new UnloadManager(counter, "mockBrokerId");
         var unloadDecision =
@@ -171,9 +184,9 @@ public class UnloadManagerTest {
         CompletableFuture<Void> future =
                 manager.waitAsync(CompletableFuture.completedFuture(null),
                         "bundle-1", unloadDecision, 5, TimeUnit.SECONDS);
-        Map<String, CompletableFuture<Void>> inFlightUnloadRequestMap = getInFlightUnloadRequestMap(manager);
-
-        assertEquals(inFlightUnloadRequestMap.size(), 1);
+        CompletableFuture<Integer> inFlightRequestCountOnCompletion =
+                captureInFlightRequestCountOnCompletion(future, manager);
+        assertEquals(manager.getInFlightUnloadRequestCount(), 1);
 
         manager.handleEvent("bundle-1",
                 new ServiceUnitStateData(ServiceUnitState.Owned, null, "broker-1", VERSION_ID_INIT),
@@ -187,12 +200,13 @@ public class UnloadManagerTest {
             assertEquals(ex.getCause().getMessage(), "Failed stage.");
         }
 
-        assertEquals(inFlightUnloadRequestMap.size(), 0);
+        assertEquals(manager.getInFlightUnloadRequestCount(), 0);
+        assertEquals(inFlightRequestCountOnCompletion.join(), 0);
         assertEquals(counter.getBreakdownCounters().get(Failure).get(Unknown).get(), 1);
     }
 
     @Test
-    public void testClose() throws IllegalAccessException {
+    public void testClose() {
         UnloadCounter counter = new UnloadCounter();
         UnloadManager manager = new UnloadManager(counter, "mockBrokerId");
         var unloadDecision =
@@ -200,10 +214,11 @@ public class UnloadManagerTest {
         CompletableFuture<Void> future =
                 manager.waitAsync(CompletableFuture.completedFuture(null),
                         "bundle-1", unloadDecision, 5, TimeUnit.SECONDS);
-        Map<String, CompletableFuture<Void>> inFlightUnloadRequestMap = getInFlightUnloadRequestMap(manager);
-        assertEquals(inFlightUnloadRequestMap.size(), 1);
+        CompletableFuture<Integer> inFlightRequestCountOnCompletion =
+                captureInFlightRequestCountOnCompletion(future, manager);
+        assertEquals(manager.getInFlightUnloadRequestCount(), 1);
         manager.close();
-        assertEquals(inFlightUnloadRequestMap.size(), 0);
+        assertEquals(manager.getInFlightUnloadRequestCount(), 0);
 
         try {
             future.get();
@@ -211,16 +226,127 @@ public class UnloadManagerTest {
         } catch (Exception ex) {
             assertTrue(ex.getCause() instanceof IllegalStateException);
         }
+        assertEquals(inFlightRequestCountOnCompletion.join(), 0);
         assertEquals(counter.getBreakdownCounters().get(Failure).get(Unknown).get(), 1);
     }
 
-    @SuppressWarnings("unchecked")
-    private Map<String, CompletableFuture<Void>> getInFlightUnloadRequestMap(UnloadManager manager)
-            throws IllegalAccessException {
-        Map<String, CompletableFuture<Void>> inFlightUnloadRequest =
-                (Map<String, CompletableFuture<Void>>) FieldUtils.readField(manager, "inFlightUnloadRequest", true);
+    @Test(timeOut = 10_000)
+    public void testConcurrentWaitersShareOneInFlightRequest() {
+        UnloadManager manager = new UnloadManager(new UnloadCounter(), "mockBrokerId");
+        var decision = newUnloadDecision("bundle-1");
+        ExecutorService executor = Executors.newFixedThreadPool(8);
+        try {
+            CountDownLatch start = new CountDownLatch(1);
+            List<CompletableFuture<CompletableFuture<Void>>> registrations = new ArrayList<>();
+            for (int i = 0; i < CONCURRENT_REQUEST_COUNT; i++) {
+                registrations.add(CompletableFuture.supplyAsync(() -> {
+                    await(start);
+                    return manager.waitAsync(CompletableFuture.completedFuture(null),
+                            "bundle-1", decision, 30, TimeUnit.SECONDS);
+                }, executor));
+            }
 
-        return inFlightUnloadRequest;
+            start.countDown();
+            List<CompletableFuture<Void>> waiters = registrations.stream()
+                    .map(CompletableFuture::join)
+                    .toList();
+            assertEquals(manager.getInFlightUnloadRequestCount(), 1);
+            List<CompletableFuture<Integer>> countsOnCompletion = waiters.stream()
+                    .map(future -> captureInFlightRequestCountOnCompletion(future, manager))
+                    .toList();
+
+            manager.handleEvent("bundle-1", null, null);
+
+            waiters.forEach(CompletableFuture::join);
+            countsOnCompletion.forEach(count -> assertEquals(count.join().intValue(), 0));
+            assertEquals(manager.getInFlightUnloadRequestCount(), 0);
+
+            String timeoutBundle = "concurrent-timeout";
+            var timeoutDecision = newUnloadDecision(timeoutBundle);
+            List<CompletableFuture<Void>> timeoutWaiters = new ArrayList<>();
+            for (int i = 0; i < CONCURRENT_REQUEST_COUNT; i++) {
+                timeoutWaiters.add(manager.waitAsync(CompletableFuture.completedFuture(null),
+                        timeoutBundle, timeoutDecision, 1, TimeUnit.SECONDS));
+            }
+            assertEquals(manager.getInFlightUnloadRequestCount(), 1);
+            List<CompletableFuture<Integer>> timeoutCountsOnCompletion = timeoutWaiters.stream()
+                    .map(future -> captureInFlightRequestCountOnCompletion(future, manager))
+                    .toList();
+            List<CompletableFuture<Throwable>> timeoutFailures = timeoutWaiters.stream()
+                    .map(future -> future.handle((__, ex) -> ex))
+                    .toList();
+
+            CompletableFuture.allOf(timeoutWaiters.stream()
+                    .map(UnloadManagerTest::ignoreFailure)
+                    .toArray(CompletableFuture[]::new)).join();
+            timeoutCountsOnCompletion.forEach(count -> assertEquals(count.join().intValue(), 0));
+            timeoutFailures.forEach(failure ->
+                    assertTrue(FutureUtil.unwrapCompletionException(failure.join()) instanceof TimeoutException));
+            assertEquals(manager.getInFlightUnloadRequestCount(), 0);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test(timeOut = 10_000)
+    public void testCloseRacingWithConcurrentCompletions() {
+        UnloadManager manager = new UnloadManager(new UnloadCounter(), "mockBrokerId");
+        List<String> bundles = new ArrayList<>();
+        List<CompletableFuture<Void>> waiters = new ArrayList<>();
+        for (int i = 0; i < CONCURRENT_REQUEST_COUNT; i++) {
+            String bundle = "close-race-" + i;
+            bundles.add(bundle);
+            waiters.add(manager.waitAsync(CompletableFuture.completedFuture(null),
+                    bundle, newUnloadDecision(bundle), 30, TimeUnit.SECONDS));
+        }
+        assertEquals(manager.getInFlightUnloadRequestCount(), CONCURRENT_REQUEST_COUNT);
+
+        ExecutorService executor = Executors.newFixedThreadPool(8);
+        try {
+            CountDownLatch start = new CountDownLatch(1);
+            List<CompletableFuture<Void>> terminalSignals = new ArrayList<>();
+            terminalSignals.add(CompletableFuture.runAsync(() -> {
+                await(start);
+                manager.close();
+            }, executor));
+            for (String bundle : bundles) {
+                terminalSignals.add(CompletableFuture.runAsync(() -> {
+                    await(start);
+                    manager.handleEvent(bundle, null, null);
+                }, executor));
+            }
+
+            start.countDown();
+            CompletableFuture.allOf(terminalSignals.toArray(CompletableFuture[]::new)).join();
+            CompletableFuture.allOf(waiters.stream()
+                    .map(UnloadManagerTest::ignoreFailure)
+                    .toArray(CompletableFuture[]::new)).join();
+            assertEquals(manager.getInFlightUnloadRequestCount(), 0);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private static CompletableFuture<Integer> captureInFlightRequestCountOnCompletion(
+            CompletableFuture<Void> future, UnloadManager manager) {
+        return future.handle((__, ex) -> manager.getInFlightUnloadRequestCount());
+    }
+
+    private static UnloadDecision newUnloadDecision(String bundle) {
+        return new UnloadDecision(new Unload("broker-1", bundle), Success, Admin);
+    }
+
+    private static CompletableFuture<Void> ignoreFailure(CompletableFuture<Void> future) {
+        return future.handle((__, ex) -> null);
+    }
+
+    private static void await(CountDownLatch latch) {
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError(e);
+        }
     }
 
 }


### PR DESCRIPTION
### Motivation

`SplitManager` and `UnloadManager` keep one in-flight future per bundle so concurrent callers can wait for the same split or unload operation.

The event and close paths completed that future before removing it from the in-flight map. The timeout path attached cleanup with `whenComplete`, but discarded the dependent stage and returned the original future. As a result, callers could observe a completed wait while the old entry was still visible. An immediate retry for the same bundle could then reuse the completed future instead of waiting for the new operation. A stale timeout callback could also remove a replacement entry by key.

Because the state event has already been published, this race does not normally stop the underlying split or unload operation. It affects completion tracking: a retry for the same bundle can return the previous request's result before the new operation completes. In a narrower race, stale cleanup can remove the new request's tracking entry, causing the caller or scheduler to wait until the configured timeout (60 seconds by default) and report a failure even if the underlying operation succeeds.

### Modifications

- Remove the matching in-flight entry before completing its future for state events and manager shutdown.
- Return a dependent timeout stage that completes only after cleanup has run.
- Guard timeout cleanup with `remove(bundle, future)` so a stale callback cannot remove a newer request.
- Replace reflection-based test inspection with package-private, test-visible request-count accessors.
- Add deterministic completion-boundary, immediate-retry, concurrent-waiter, and close-versus-completion tests for both managers.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added and extended unit tests and was verified locally with:

- `./gradlew :pulsar-broker:test --tests org.apache.pulsar.broker.loadbalance.extensions.manager.SplitManagerTest --tests org.apache.pulsar.broker.loadbalance.extensions.manager.UnloadManagerTest`
- `./gradlew :pulsar-broker:checkstyleMain :pulsar-broker:checkstyleTest`
- `./gradlew quickCheck`
- `git diff --check`

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
