### PR TITLE
[fix][cli] Set --enable-native-access=ALL-UNNAMED for the CLI tools on Java 24+

### DIFF
--- a/bin/pulsar-admin-common.sh
+++ b/bin/pulsar-admin-common.sh
@@ -118,6 +118,14 @@ if [[ $JAVA_MAJOR_VERSION -ge 11 ]]; then
   # Required by Netty for optimized direct byte buffer access
   OPTS="$OPTS --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/jdk.internal.misc=ALL-UNNAMED"
 fi
+
+if [[ $JAVA_MAJOR_VERSION -ge 24 ]]; then
+  # Netty loads native libraries (epoll, io_uring, tcnative) via java.lang.System::loadLibrary,
+  # which is a restricted method from Java 24 onwards. Without this the JVM prints a warning to
+  # stderr on every invocation, and restricted methods will be blocked outright in a future
+  # release. bin/pulsar already sets this for the server side.
+  OPTS="$OPTS --enable-native-access=ALL-UNNAMED"
+fi
 # These two settings work together to ensure the Pulsar process exits immediately and predictably
 # if it runs out of either Java heap memory or its internal off-heap memory,
 # as these are unrecoverable errors that require a process restart to clear the faulty state and restore operation

--- a/bin/pulsar-perf
+++ b/bin/pulsar-perf
@@ -115,6 +115,14 @@ if [[ $JAVA_MAJOR_VERSION -ge 11 ]]; then
   # Required by Netty for optimized direct byte buffer access
   OPTS="$OPTS --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/jdk.internal.misc=ALL-UNNAMED"
 fi
+
+if [[ $JAVA_MAJOR_VERSION -ge 24 ]]; then
+  # Netty loads native libraries (epoll, io_uring, tcnative) via java.lang.System::loadLibrary,
+  # which is a restricted method from Java 24 onwards. Without this the JVM prints a warning to
+  # stderr on every invocation, and restricted methods will be blocked outright in a future
+  # release. bin/pulsar already sets this for the server side.
+  OPTS="$OPTS --enable-native-access=ALL-UNNAMED"
+fi
 # These two settings work together to ensure the Pulsar process exits immediately and predictably
 # if it runs out of either Java heap memory or its internal off-heap memory,
 # as these are unrecoverable errors that require a process restart to clear the faulty state and restore operation


### PR DESCRIPTION
### Motivation

`bin/pulsar` passes `--enable-native-access=ALL-UNNAMED`, but the client-side entry points do
not: `bin/pulsar-admin`, `bin/pulsar-client` and `bin/pulsar-shell` (all of which source
`bin/pulsar-admin-common.sh`), and `bin/pulsar-perf`.

Netty loads its native libraries (epoll, io_uring, tcnative) through
`java.lang.System::loadLibrary`, which became a restricted method in Java 24. Without the flag,
every CLI invocation that ends up loading a Netty native library prints to stderr:

```
WARNING: A restricted method in java.lang.System has been called
WARNING: java.lang.System::loadLibrary has been called by io.netty.util.internal.NativeLibraryUtil
         in an unnamed module (file:/pulsar/lib/io.netty-netty-common-4.2.17.Final.jar)
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
WARNING: Restricted methods will be blocked in a future release unless native access is enabled
```

Three reasons this is worth fixing:

1. It is noise on every affected CLI invocation, and it goes to stderr, so it pollutes scripted
   usage that captures CLI output.
2. It breaks integration and system tests that assert the CLI writes nothing to stderr
   (`ContainerExecResult.assertNoStderr()`). This surfaced on the networking dependency update
   #26358, where `CI - Integration - Cli`, `CI - System - Function` and both
   `CI - System - Pulsar Connectors` jobs failed on exactly this warning.
3. As the warning itself says, restricted methods will be **blocked** in a future release, so
   the CLI tools need this regardless.

### Modifications

Added to `bin/pulsar-admin-common.sh` (covering `pulsar-admin`, `pulsar-client` and
`pulsar-shell`) and to `bin/pulsar-perf`, which duplicates the same option-building logic:

```bash
if [[ $JAVA_MAJOR_VERSION -ge 24 ]]; then
  OPTS="$OPTS --enable-native-access=ALL-UNNAMED"
fi
```

The Java 24 gate is deliberate, and differs from `bin/pulsar`, which sets the flag
unconditionally:

- these CLI scripts still support older Java versions (they carry `-gt 8` and `-ge 11`
  conditionals), and the option is not accepted on Java 8 or 11, so an ungated flag would stop
  the CLI from starting there;
- the restricted-method warning was only introduced in Java 24, so gating there targets exactly
  the versions where the flag has an effect;
- `bin/pulsar` can set it unconditionally because the server requires a newer JVM.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests: the CLI, Function and Connectors
integration/system suites assert that CLI invocations produce no stderr output, which is the
assertion this warning was breaking.

Verified locally:

- `bash -n bin/pulsar-admin-common.sh` and `bash -n bin/pulsar-perf` — both parse cleanly
- `./gradlew quickCheck`
- Confirmed the JVM accepts `--enable-native-access=ALL-UNNAMED`

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [x] Anything that affects deployment

The JVM options used by the bundled CLI tools change on Java 24 and later.
