### PR TITLE
[improve][build] Upgrade async-http-client to 3.0.13 and netty-reactive-streams to 2.0.19

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -274,7 +274,7 @@ The Apache Software License, Version 2.0
     - com.google.guava-failureaccess-1.0.3.jar
     - com.google.guava-listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
  * J2ObjC Annotations -- com.google.j2objc-j2objc-annotations-3.1.jar
- * Netty Reactive Streams -- com.typesafe.netty-netty-reactive-streams-2.0.6.jar
+ * Netty Reactive Streams -- com.typesafe.netty-netty-reactive-streams-2.0.19.jar
  * Swagger
     - io.swagger.core.v3-swagger-annotations-jakarta-2.2.50.jar
  * slog -- io.github.merlimat.slog-slog-0.10.0.jar
@@ -390,7 +390,7 @@ The Apache Software License, Version 2.0
  * AirCompressor
     - io.airlift-aircompressor-2.0.3.jar
  * AsyncHttpClient
-    - org.asynchttpclient-async-http-client-3.0.10.jar
+    - org.asynchttpclient-async-http-client-3.0.13.jar
  * Jetty
     - org.eclipse.jetty-jetty-alpn-client-12.1.12.jar
     - org.eclipse.jetty-jetty-alpn-conscrypt-server-12.1.12.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -333,7 +333,7 @@ The Apache Software License, Version 2.0
     - failureaccess-1.0.3.jar
     - listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
  * J2ObjC Annotations -- j2objc-annotations-3.1.jar
- * Netty Reactive Streams -- netty-reactive-streams-2.0.6.jar
+ * Netty Reactive Streams -- netty-reactive-streams-2.0.19.jar
  * Swagger -- swagger-annotations-jakarta-2.2.50.jar
  * DataSketches
     - datasketches-java-7.0.1.jar
@@ -404,7 +404,7 @@ The Apache Software License, Version 2.0
   * AirCompressor
      - aircompressor-2.0.3.jar
  * AsyncHttpClient
-    - async-http-client-3.0.10.jar
+    - async-http-client-3.0.13.jar
  * Jetty
     - jetty-alpn-client-12.1.12.jar
     - jetty-client-12.1.12.jar

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -66,7 +66,7 @@ snakeyaml = "2.6"
 # Vert.x
 vertx = "4.5.28"
 # Networking / HTTP
-asynchttpclient = "3.0.10"
+asynchttpclient = "3.0.13"
 conscrypt = "2.6.2"
 okhttp3 = "5.3.2"
 okio = "3.17.0"
@@ -117,7 +117,7 @@ typetools = "0.5.0"
 jna = "5.18.1"
 java-semver = "0.9.0"
 oshi = "6.4.0"
-netty-reactive-streams = "2.0.6"
+netty-reactive-streams = "2.0.19"
 # 9.2.0+ is required for CronType.SPRING53 (Spring 5.3+ cron syntax)
 cron-utils = "9.2.1"
 failsafe = "3.3.2"


### PR DESCRIPTION
### Motivation

`async-http-client` and `netty-reactive-streams` are the HTTP stack behind the admin client.
They were originally part of #26358 (networking dependency updates) and are split out here,
because that PR reproducibly failed four integration and system test jobs and these two are the
most likely trigger.

### Modifications

`gradle/libs.versions.toml`:

| library | from | to |
|---|---|---|
| async-http-client | 3.0.10 | 3.0.13 |
| netty-reactive-streams | 2.0.6 | 2.0.19 |

Plus the corresponding jar names in the server and shell distribution `LICENSE.bin.txt` files.

### Why these are split out — what CI showed

On #26358 the following jobs failed, twice, identically (master and the twelve sibling
dependency PRs were green):

- CI - Integration - Cli
- CI - System - Function
- CI - System - Pulsar Connectors - Process
- CI - System - Pulsar Connectors - Thread

All four share one root cause. `pulsar-admin` / `pulsar-client` print a JDK restricted-method
warning to stderr, and the tests assert the CLI produces no stderr output:

```
WARNING: A restricted method in java.lang.System has been called
WARNING: java.lang.System::loadLibrary has been called by io.netty.util.internal.NativeLibraryUtil
         in an unnamed module (file:/pulsar/lib/io.netty-netty-common-4.2.17.Final.jar)
```

What was ruled out while diagnosing this:

- **Not the distribution contents.** Diffing the built `apache-pulsar-*-bin.tar.gz` jar list
  against the base commit shows only the intended version bumps. No new Netty jars appear, and
  `netty-transport-native-epoll` / `-io_uring` are present in both.
- **Not a Netty upgrade.** Netty stays at 4.2.17.Final.
- **Not AHC switching transports by default.** `ahc-default.properties` has
  `useNativeTransport=false` and `useOnlyEpollNativeTransport=false` in both 3.0.10 and 3.0.13.
- **Not flaky.** It reproduced on two independent runs, and the same jobs pass everywhere else.

So the trigger is a change in *when* a Netty native library is loaded, not in which Netty is
used. AHC 3.0.13 does add DNS/IP-cooldown behaviour (`failedIpCooldownEnabled`,
`loadBalance`) that 3.0.10 lacks, which is a plausible path to an availability probe such as
`IoUring.isAvailable()` loading the native library, but this PR does not claim that as proven —
it exists so CI can confirm or refute it in isolation.

Related: `bin/pulsar` passes `--enable-native-access=ALL-UNNAMED` while
`bin/pulsar-admin-common.sh` does not, which is why the warning is only visible from the CLI.
That gap is a pre-existing issue and is fixed separately in #26365.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests — specifically the CLI, Function and
Connectors integration/system suites named above, which are exactly what this PR is meant to
exercise.

Verified locally with `./gradlew sanityCheck` and `./gradlew checkBinaryLicense`.

### Does this pull request potentially affect one of the following parts:

- [x] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
