### PR TITLE
[improve][build] Set --enable-native-access=ALL-UNNAMED for test JVMs on Java 24+

### DIFF
--- a/build-logic/conventions/src/main/kotlin/pulsar.java-conventions.gradle.kts
+++ b/build-logic/conventions/src/main/kotlin/pulsar.java-conventions.gradle.kts
@@ -198,6 +198,9 @@ dependencies {
 // Allow overriding the JDK used for running tests via -PtestJavaVersion=17
 val testJavaVersion = providers.gradleProperty("testJavaVersion").map { it.toInt() }
 val javaToolchains = extensions.getByType<JavaToolchainService>()
+// Effective Java major version used to run tests: the -PtestJavaVersion override when set,
+// otherwise the JVM running Gradle.
+val testJavaMajorVersion = testJavaVersion.orNull ?: JavaVersion.current().majorVersion.toInt()
 
 tasks.withType<Test>().configureEach {
     testJavaVersion.orNull?.let { version ->
@@ -261,6 +264,13 @@ tasks.withType<Test>().configureEach {
         // loopback would otherwise fail to start.
         "-Djava.net.preferIPv4Stack=true",
     )
+    if (testJavaMajorVersion >= 24) {
+        // Netty loads its native libraries (epoll, io_uring, tcnative) through
+        // java.lang.System::loadLibrary, which is a restricted method as of Java 24. Without this
+        // every test JVM that touches a Netty native transport prints a multi-line warning to
+        // stderr, which is noise in test output and breaks assertions on empty stderr.
+        jvmArgs("--enable-native-access=ALL-UNNAMED")
+    }
 }
 
 // Expose test classes for cross-module test dependencies (Maven test-jar equivalent)


### PR DESCRIPTION
### Motivation

Netty loads its native libraries (epoll, io_uring, tcnative) through
`java.lang.System::loadLibrary`, which became a restricted method in Java 24. Any test JVM that
touches a Netty native transport therefore prints to stderr:

```
WARNING: A restricted method in java.lang.System has been called
WARNING: java.lang.System::loadLibrary has been called by io.netty.util.internal.NativeLibraryUtil
         in an unnamed module
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
WARNING: Restricted methods will be blocked in a future release unless native access is enabled
```

Pulsar already runs CI on JDK 25, so this is noise on every affected test JVM. It also
interferes with tests that assert a process wrote nothing to stderr, and, as the warning says,
restricted methods will eventually be **blocked** rather than warned about.

`bin/pulsar` already passes `--enable-native-access=ALL-UNNAMED` for the server, and #26365 adds
it to the CLI scripts. This PR does the same for the test JVMs.

### Modifications

In `build-logic/conventions/src/main/kotlin/pulsar.java-conventions.gradle.kts`:

```kotlin
// Effective Java major version used to run tests: the -PtestJavaVersion override when set,
// otherwise the JVM running Gradle.
val testJavaMajorVersion = testJavaVersion.orNull ?: JavaVersion.current().majorVersion.toInt()
```

and, inside `tasks.withType<Test>().configureEach`:

```kotlin
if (testJavaMajorVersion >= 24) {
    jvmArgs("--enable-native-access=ALL-UNNAMED")
}
```

The version gate matters because the option is not accepted by older JVMs, and tests can be run
on an older JDK via `-PtestJavaVersion`. The effective version therefore honours that toolchain
override when present and falls back to the JVM running Gradle, so the gate is correct in both
cases.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

Verified locally that the conditional actually takes effect, in both directions, by inspecting
the test worker command line with `--rerun-tasks -i`:

- with the threshold temporarily lowered to 21 on a Java 21 JVM, `--enable-native-access=ALL-UNNAMED`
  appears in the spawned test JVM arguments;
- with the threshold at 24 on the same Java 21 JVM, it does not appear.

Also ran `./gradlew :buildtools:compileJava` to confirm the convention plugin still compiles, and
a targeted test to confirm test execution is unaffected.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
