### PR TITLE
[fix][sec][branch-4.2] Upgrade BouncyCastle to 1.85 and BouncyCastle FIPS to 2.0.2 to address CVEs

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -632,9 +632,9 @@ Public Domain (CC0) -- ../licenses/LICENSE-CC0.txt
 
 Bouncy Castle License
  * Bouncy Castle -- ../licenses/LICENSE-bouncycastle.txt
-    - org.bouncycastle-bcpkix-jdk18on-1.84.jar
-    - org.bouncycastle-bcprov-jdk18on-1.84.jar
-    - org.bouncycastle-bcutil-jdk18on-1.84.jar
+    - org.bouncycastle-bcpkix-jdk18on-1.85.jar
+    - org.bouncycastle-bcprov-jdk18on-1.85.2.jar
+    - org.bouncycastle-bcutil-jdk18on-1.85.jar
 
 ------------------------
 

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -469,9 +469,9 @@ Public Domain (CC0) -- ../licenses/LICENSE-CC0.txt
 
 Bouncy Castle License
  * Bouncy Castle -- ../licenses/LICENSE-bouncycastle.txt
-    - bcpkix-jdk18on-1.84.jar
-    - bcprov-jdk18on-1.84.jar
-    - bcutil-jdk18on-1.84.jar
+    - bcpkix-jdk18on-1.85.jar
+    - bcprov-jdk18on-1.85.2.jar
+    - bcutil-jdk18on-1.85.jar
 
 ------------------------
 

--- a/pom.xml
+++ b/pom.xml
@@ -204,13 +204,13 @@ flexible messaging model and an intuitive client API.</description>
     <commons.collections4.version>4.5.0</commons.collections4.version>
     <log4j2.version>2.26.1</log4j2.version>
     <!-- bouncycastle dependencies aren't necessarily aligned -->
-    <bouncycastle.version>1.84</bouncycastle.version>
-    <bouncycastle.bcprov-jdk18on.version>${bouncycastle.version}</bouncycastle.bcprov-jdk18on.version>
+    <bouncycastle.version>1.85</bouncycastle.version>
+    <bouncycastle.bcprov-jdk18on.version>1.85.2</bouncycastle.bcprov-jdk18on.version>
     <bouncycastle.bcpkix-jdk18on.version>${bouncycastle.version}</bouncycastle.bcpkix-jdk18on.version>
     <bouncycastle.bcutil-jdk18on.version>${bouncycastle.version}</bouncycastle.bcutil-jdk18on.version>
-    <bouncycastle.bcpkix-fips.version>2.0.11</bouncycastle.bcpkix-fips.version>
-    <bouncycastle.bcutil-fips.version>2.0.6</bouncycastle.bcutil-fips.version>
-    <bouncycastle.bc-fips.version>2.0.1</bouncycastle.bc-fips.version>
+    <bouncycastle.bcpkix-fips.version>2.0.12</bouncycastle.bcpkix-fips.version>
+    <bouncycastle.bcutil-fips.version>2.0.7</bouncycastle.bcutil-fips.version>
+    <bouncycastle.bc-fips.version>2.0.2</bouncycastle.bc-fips.version>
     <jackson.version>2.18.10</jackson.version>
     <fastutil.version>8.5.16</fastutil.version>
     <jctools.version>4.0.5</jctools.version>


### PR DESCRIPTION
### Motivation

BouncyCastle published a large coordinated security release on **2026-08-03**. **1.85** is the fixed
version for the non-FIPS line, and `branch-4.2` pins **1.84**, so the server and shell distributions
are exposed to it.

The two most severe issues affecting the artifacts actually shipped here are both certificate
validation bypasses, CVSS 9.3:

| CVE | CVSS | Issue |
|---|---|---|
| [CVE-2026-8763](https://nvd.nist.gov/vuln/detail/CVE-2026-8763) | 9.3 | Name Constraints bypass via a trailing dot in `rfc822Name` and URI |
| [CVE-2026-58062](https://nvd.nist.gov/vuln/detail/CVE-2026-58062) | 9.3 | Stapled OCSP response accepted without binding to the checked certificate |

Also fixed by the same bump, among others: [CVE-2026-59639](https://nvd.nist.gov/vuln/detail/CVE-2026-59639)
(CMS `verifySignatures` returns true for `SignedData` with zero signers, 8.7),
[CVE-2026-59645](https://nvd.nist.gov/vuln/detail/CVE-2026-59645) (OER parser recurses without a depth
limit, 8.7), [CVE-2026-12802](https://nvd.nist.gov/vuln/detail/CVE-2026-12802) (CMS
`AuthEnvelopedData` does not enforce tag length on decryption, 8.7),
[CVE-2026-14682](https://nvd.nist.gov/vuln/detail/CVE-2026-14682) (unbounded up-front allocation on a
definite-length read, 8.7), [CVE-2026-58059](https://nvd.nist.gov/vuln/detail/CVE-2026-58059)
(quadratic-time X.500 DN stringification, 8.7) and
[CVE-2026-58061](https://nvd.nist.gov/vuln/detail/CVE-2026-58061) (CCM-family modes write plaintext to
the caller buffer before the tag check, 8.7).

`bctls-jdk18on` is not used on this branch, so
[CVE-2026-59638](https://nvd.nist.gov/vuln/detail/CVE-2026-59638) (JSSE hostname verifier CN-fallback
enabled by default, 9.3) does not apply.

Note that these advisories are currently still *Undergoing Analysis* at NVD and are **not yet mapped
to Maven coordinates in OSV / the GitHub Advisory Database**, so scanners querying those sources will
not flag 1.84 today. The applicability above was read from the NVD records directly.

This is the `branch-4.2` counterpart of the master-branch upgrade in #26349.

### Modifications

`pom.xml`:

| property | from | to |
|---|---|---|
| `bouncycastle.version` (bcpkix-jdk18on, bcutil-jdk18on) | 1.84 | 1.85 |
| `bouncycastle.bcprov-jdk18on.version` | `${bouncycastle.version}` | **1.85.2** |
| `bouncycastle.bc-fips.version` | 2.0.1 | 2.0.2 |
| `bouncycastle.bcpkix-fips.version` | 2.0.11 | 2.0.12 |
| `bouncycastle.bcutil-fips.version` | 2.0.6 | 2.0.7 |

Plus the corresponding jar names in the server and shell distribution `LICENSE.bin.txt` files.

**`bcprov-jdk18on` no longer inherits `${bouncycastle.version}`.** BouncyCastle published a
provider-only patch release, 1.85.2, that was *not* released for `bcpkix-jdk18on` or
`bcutil-jdk18on` — those remain at 1.85 on Maven Central — so the shared property can no longer
express all three. `bcpkix-jdk18on:1.85` declares `bcutil-jdk18on:1.85`, and all three are pinned in
`dependencyManagement`, so the resolved set is bcprov 1.85.2 / bcpkix 1.85 / bcutil 1.85 — which is
what both `LICENSE.bin.txt` files now list.

**On the FIPS bumps.** These are test-scope only — `bc-fips` is in no distribution and in no
`LICENSE.bin.txt` — but the current pins are below the vendor's fixed versions for the same batch
(`bc-fips 2.0.1` is affected by both 9.3s above, `bcpkix-fips 2.0.11` by CVE-2026-59639 and four
others, `bcutil-fips 2.0.6` by CVE-2026-59645), so they are brought up too. The bumps stay **within
the 2.0.x line**, so the FIPS 140-3 certificate line is unchanged:
[CMVP #4743](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4743),
Active, sunset 2029-07-28, which validates `bc-fips-2.0.0.jar`. (As explained in #26349, no certified
`bc-fips` jar is free of known CVEs, because BouncyCastle certifies the base release and ships
security fixes in the later "Provider (patched)" releases; 2.0.0 itself has 11. The previous 2.0.1
pin was not a certified version either, so this changes nothing on that axis.)

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This is a dependency version change with no code changes; it is covered by the existing test suite,
and the *Build and License check* job verifies the `LICENSE.bin.txt` entries against the actual
assembled distributions.

### Does this pull request potentially affect one of the following parts:

- [x] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [x] Anything that affects deployment

The non-FIPS BouncyCastle jars bundled in the server and shell distributions change version.
