### PR TITLE
[fix][cli][branch-4.2] Don't pass unset pulsar-perf pending-message options to the producer

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ProducerConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ProducerConfigurationData.java
@@ -252,9 +252,17 @@ public class ProducerConfigurationData implements Serializable, Cloneable {
         this.maxPendingMessages = maxPendingMessages;
     }
 
+    /**
+     * The across-partitions budget used to be rejected when it was below {@link #maxPendingMessages},
+     * which made the two setters order-dependent: whether a value is accepted depended on which of them
+     * had been called first, so setting only this one on a builder that already carries a default for
+     * the other throws. The relationship is enforced where it is used instead — {@code
+     * PartitionedProducerImpl} lowers the per-partition limit to the share of the budget when a budget
+     * is set, and the budget means nothing on a non-partitioned topic.
+     */
     public void setMaxPendingMessagesAcrossPartitions(int maxPendingMessagesAcrossPartitions) {
-        checkArgument(maxPendingMessagesAcrossPartitions >= maxPendingMessages,
-                "maxPendingMessagesAcrossPartitions needs to be >= maxPendingMessages");
+        checkArgument(maxPendingMessagesAcrossPartitions >= 0,
+                "maxPendingMessagesAcrossPartitions needs to be >= 0");
         this.maxPendingMessagesAcrossPartitions = maxPendingMessagesAcrossPartitions;
     }
 

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ProducerBuilderImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ProducerBuilderImplTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
@@ -375,9 +376,23 @@ public class ProducerBuilderImplTest {
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp =
-            "maxPendingMessagesAcrossPartitions needs to be >= maxPendingMessages")
+            "maxPendingMessagesAcrossPartitions needs to be >= 0")
     public void testProducerBuilderImplWhenMaxPendingMessagesAcrossPartitionsPropertyIsInvalidErrorMessages() {
         producerBuilderImpl.maxPendingMessagesAcrossPartitions(-1);
+    }
+
+    /**
+     * The across-partitions budget is allowed to be below {@code maxPendingMessages}: it is a budget
+     * shared by every partition, and the per-partition limit is lowered to its share where it is used.
+     * Rejecting it here made the two setters order-dependent, so setting only this one on a builder
+     * that already carried a default for the other threw.
+     */
+    @Test
+    public void testAcrossPartitionsLimitBelowMaxPendingMessagesIsAccepted() {
+        ProducerBuilderImpl<byte[]> builder = new ProducerBuilderImpl<>(client, Schema.BYTES);
+        builder.maxPendingMessages(1000).maxPendingMessagesAcrossPartitions(500);
+
+        assertEquals(builder.getConf().getMaxPendingMessagesAcrossPartitions(), 500);
     }
 
     @Test

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
@@ -22,8 +22,6 @@ import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.pulsar.client.impl.conf.ProducerConfigurationData.DEFAULT_BATCHING_MAX_MESSAGES;
-import static org.apache.pulsar.client.impl.conf.ProducerConfigurationData.DEFAULT_MAX_PENDING_MESSAGES;
-import static org.apache.pulsar.client.impl.conf.ProducerConfigurationData.DEFAULT_MAX_PENDING_MESSAGES_ACROSS_PARTITIONS;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.google.common.collect.Range;
@@ -64,6 +62,7 @@ import org.apache.pulsar.client.api.ProducerAccessMode;
 import org.apache.pulsar.client.api.ProducerBuilder;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.TypedMessageBuilder;
 import org.apache.pulsar.client.api.transaction.Transaction;
 import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
@@ -134,12 +133,13 @@ public class PerformanceProducer extends PerformanceTopicListArguments{
             + "larger than allowed max size")
     private boolean chunkingAllowed = false;
 
-    @Option(names = { "-o", "--max-outstanding" }, description = "Max number of outstanding messages")
-    public int maxOutstanding = DEFAULT_MAX_PENDING_MESSAGES;
+    @Option(names = { "-o", "--max-outstanding" }, description = "Max number of outstanding messages. "
+            + "Left to the client default when unset")
+    public Integer maxOutstanding;
 
     @Option(names = { "-p", "--max-outstanding-across-partitions" }, description = "Max number of outstanding "
-            + "messages across partitions")
-    public int maxPendingMessagesAcrossPartitions = DEFAULT_MAX_PENDING_MESSAGES_ACROSS_PARTITIONS;
+            + "messages across partitions. Left to the client default when unset")
+    public Integer maxPendingMessagesAcrossPartitions;
 
     @Option(names = { "-np", "--partitions" }, description = "Create partitioned topics with the given number "
             + "of partitions, set 0 to not try to create the topic")
@@ -447,14 +447,21 @@ public class PerformanceProducer extends PerformanceTopicListArguments{
     }
 
     ProducerBuilder<byte[]> createProducerBuilder(PulsarClient client, int producerId) {
-        ProducerBuilder<byte[]> producerBuilder = client.newProducer() //
+        // Schema.BYTES rather than the no-argument newProducer(): the latter skips the pending-message
+        // defaults the client applies when its memory limit is disabled, which is how pulsar-perf runs
+        // unless --memory-limit is given.
+        ProducerBuilder<byte[]> producerBuilder = client.newProducer(Schema.BYTES) //
                 .sendTimeout(this.sendTimeout, TimeUnit.SECONDS) //
                 .compressionType(this.compression) //
-                .maxPendingMessages(this.maxOutstanding) //
                 .accessMode(this.producerAccessMode)
                 // enable round robin message routing if it is a partitioned topic
                 .messageRoutingMode(MessageRoutingMode.RoundRobinPartition);
-        if (this.maxPendingMessagesAcrossPartitions > 0) {
+        // Only pass a limit the user actually asked for. Their unset value is 0, which the client reads
+        // as "no message-count limit", so passing it through would leave the producer unbounded.
+        if (this.maxOutstanding != null) {
+            producerBuilder.maxPendingMessages(this.maxOutstanding);
+        }
+        if (this.maxPendingMessagesAcrossPartitions != null) {
             producerBuilder.maxPendingMessagesAcrossPartitions(this.maxPendingMessagesAcrossPartitions);
         }
 

--- a/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerformanceProducerTest.java
+++ b/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerformanceProducerTest.java
@@ -236,6 +236,49 @@ public class PerformanceProducerTest extends MockedPulsarServiceBaseTest {
         consumer.close();
     }
 
+    /**
+     * pulsar-perf runs with the client memory limit disabled unless {@code --memory-limit} is given, so
+     * the producer's only backpressure is its pending-message queue. Leaving the options unset has to
+     * leave the client's own defaults in place; passing their unset value of 0 through would read as an
+     * explicit "no message-count limit" and leave the producer unbounded, which is what exhausts direct
+     * memory against a slow broker on a non-partitioned topic.
+     */
+    @Test(timeOut = 20000)
+    public void testPendingMessageLimitsAreLeftToTheClientWhenUnset() throws Exception {
+        PerformanceProducer producer = new PerformanceProducer();
+        producer.topics = List.of(testTopic + UUID.randomUUID());
+        producer.serviceURL = pulsar.getBrokerServiceUrl();
+
+        @Cleanup
+        PulsarClient client = PerfClientUtils.createClientBuilderFromArguments(producer).build();
+        ProducerBuilderImpl<byte[]> builder =
+                (ProducerBuilderImpl<byte[]>) producer.createProducerBuilder(client, 0);
+
+        Assert.assertNull(producer.maxOutstanding);
+        Assert.assertNull(producer.maxPendingMessagesAcrossPartitions);
+        Assert.assertTrue(builder.getConf().getMaxPendingMessages() > 0);
+        Assert.assertTrue(builder.getConf().getMaxPendingMessagesAcrossPartitions() > 0);
+    }
+
+    /**
+     * An option that is given still wins over the client default, and either one can be given on its
+     * own — the across-partitions budget is allowed to be below the per-producer limit.
+     */
+    @Test(timeOut = 20000)
+    public void testGivenPendingMessageLimitsAreApplied() throws Exception {
+        PerformanceProducer producer = new PerformanceProducer();
+        producer.topics = List.of(testTopic + UUID.randomUUID());
+        producer.serviceURL = pulsar.getBrokerServiceUrl();
+        producer.maxPendingMessagesAcrossPartitions = 500;
+
+        @Cleanup
+        PulsarClient client = PerfClientUtils.createClientBuilderFromArguments(producer).build();
+        ProducerBuilderImpl<byte[]> builder =
+                (ProducerBuilderImpl<byte[]>) producer.createProducerBuilder(client, 0);
+
+        Assert.assertEquals(builder.getConf().getMaxPendingMessagesAcrossPartitions(), 500);
+    }
+
     @Test
     public void testRangeConvert() {
         PerformanceProducer.RangeConvert rangeConvert = new PerformanceProducer.RangeConvert();


### PR DESCRIPTION
Fixes #26340

> This targets `branch-4.2` only. On master, #25887 moved `pulsar-perf` to the V5 client, where these options no longer reach a producer at all, so there is nothing to fix there. The client-side half of this — making the no-memory-limit defaults behave as defaults rather than being overwritten by a pass-through — is #26342 on master.

### Motivation

`pulsar-perf produce` can exhaust the client's direct memory against a slow broker (#26340), because on `branch-4.2` nothing bounds its producer at all:

- `PerformanceBaseArguments.memoryLimit` is a `long` with no initializer, and `PerfClientUtils` passes it on unconditionally, so the **client memory limit is disabled** unless `--memory-limit` is given.
- `--max-outstanding` defaults to `ProducerConfigurationData.DEFAULT_MAX_PENDING_MESSAGES`, which is `0`, and that value was passed to `maxPendingMessages(...)` unconditionally. `0` is the client's "no message-count limit", so **the pending-message queue is unbounded too**.

With both bounds gone, a producer that outruns its broker buffers without limit. `ProducerImpl` only creates its semaphore `if (conf.getMaxPendingMessages() > 0)`.

#15283 already fixed exactly this shape for `--max-outstanding-across-partitions`, by only applying the option when it was set. It could not fix `--max-outstanding` the same way, because at the time there was nothing for an unset value to fall back to on the producer path this tool uses. There is: `PulsarClient.newProducer(Schema)` gives a producer the pre-PIP-120 defaults (1000 / 50000) when the client memory limit is disabled — #15723 added that precisely so a producer without byte-based backpressure still has some. `pulsar-perf` misses it only because it calls the no-argument `newProducer()`, which never got that treatment.

Note that #15283's fix is for partitioned topics: the across-partitions budget is what `PartitionedProducerImpl` divides between partitions, and it is ignored on a non-partitioned topic. `--max-outstanding` is the one that matters there, and it is the one still being passed through.

### Modifications

`pulsar-testclient`:

- `--max-outstanding` and `--max-outstanding-across-partitions` become `Integer` with no default, so "the user did not pass this flag" is distinguishable from "the user asked for 0". Each is applied to the builder only when it was given, which is #15283's fix generalised to both options.
- `createProducerBuilder` uses `newProducer(Schema.BYTES)` instead of the no-argument `newProducer()`. They are the same builder for a `byte[]` producer, except that this one carries the client's defaults for a client with the memory limit disabled — which is what an unset option now falls back to.

`pulsar-client`:

- `ProducerConfigurationData.setMaxPendingMessagesAcrossPartitions` no longer rejects a value below `maxPendingMessages`. That check makes the two setters order-dependent, and it is what forced #15283 to guard on `> 0` rather than on "was it set": with the per-producer default now in place at 1000, `pulsar-perf -p 500` would throw `IllegalArgumentException` before this change. The relationship is enforced where it is used — `PartitionedProducerImpl` lowers the per-partition limit to its share of the budget when a budget is set, and the budget means nothing on a non-partitioned topic.

Effective behaviour for `pulsar-perf produce` with no flags, on a client whose memory limit is disabled: `maxPendingMessages = 1000`, `maxPendingMessagesAcrossPartitions = 50000`, `blockIfQueueFull = true` — so it throttles instead of buffering without limit, on partitioned and non-partitioned topics alike. Passing `-o` or `-p` still overrides, including `-o 0` for the old unbounded behaviour.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- `PerformanceProducerTest#testPendingMessageLimitsAreLeftToTheClientWhenUnset` — with no flags, the builder carries positive limits. Fails before this change, where they are 0.
- `PerformanceProducerTest#testGivenPendingMessageLimitsAreApplied` — `-p` on its own is applied and does not fail producer creation. Fails without the `pulsar-client` change.
- `ProducerBuilderImplTest#testAcrossPartitionsLimitBelowMaxPendingMessagesIsAccepted` — pins the relaxed validation.
- `ProducerBuilderImplTest#testProducerBuilderImplWhenMaxPendingMessagesAcrossPartitionsPropertyIsInvalidErrorMessages` — updated for the new message; a negative value is still rejected.
- The existing `PerformanceProducerTest#testMaxOutstanding` (added by #15283) and `#testBatchingDisabled` still pass.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [x] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [x] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

- `pulsar-perf produce` without `-o` / `-p` now has a bounded pending-message queue where it previously had none. It blocks rather than failing, since it sets `blockIfQueueFull(true)`, so a run against a slow broker is throttled instead of ending in an `OutOfMemoryError`. A run that relied on unbounded buffering can restore it with `-o 0`, or raise the bound with `-o <n>`.
- `-o` and `-p` no longer report a default in `--help`, because they no longer have one.
- `maxPendingMessagesAcrossPartitions` no longer throws `IllegalArgumentException` when set below `maxPendingMessages`; it is accepted, and the per-partition limit is lowered to its share as before. Only code that relied on the exception is affected, and such a call could not previously succeed.

### Documentation

- [ ] `doc-required`
- [x] `doc-not-needed`
- [ ] `doc`
- [ ] `doc-complete`

The option help text states that an unset value is left to the client.
