### PR TITLE
[fix][offload] Normalize offloader cache directory path

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/offload/OffloadersCache.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/offload/OffloadersCache.java
@@ -19,6 +19,7 @@
 package org.apache.bookkeeper.mledger.offload;
 
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import lombok.CustomLog;
@@ -41,7 +42,8 @@ public class OffloadersCache implements AutoCloseable {
      * @throws IOException when fail to retrieve the pulsar offloader class
      */
     public Offloaders getOrLoadOffloaders(String offloadersPath, String narExtractionDirectory) {
-        return loadedOffloaders.computeIfAbsent(offloadersPath,
+        String normalizedOffloadersPath = Paths.get(offloadersPath).toAbsolutePath().normalize().toString();
+        return loadedOffloaders.computeIfAbsent(normalizedOffloadersPath,
                 (directory) -> {
                     try {
                         return OffloaderUtils.searchForOffloaders(directory, narExtractionDirectory);

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/offload/OffloadersCacheTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/offload/OffloadersCacheTest.java
@@ -19,7 +19,10 @@
 package org.apache.bookkeeper.mledger.offload;
 
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.testng.Assert.assertSame;
+import java.nio.file.Paths;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
@@ -29,9 +32,10 @@ public class OffloadersCacheTest {
     @Test
     public void testLoadsOnlyOnce() throws Exception {
         Offloaders expectedOffloaders = new Offloaders();
+        String normalizedPath = Paths.get("./offloaders").toAbsolutePath().normalize().toString();
 
         try (MockedStatic<OffloaderUtils> offloaderUtils = Mockito.mockStatic(OffloaderUtils.class)) {
-            offloaderUtils.when(() -> OffloaderUtils.searchForOffloaders(eq("./offloaders"), eq("/tmp")))
+            offloaderUtils.when(() -> OffloaderUtils.searchForOffloaders(eq(normalizedPath), eq("/tmp")))
                     .thenReturn(expectedOffloaders);
 
             OffloadersCache cache = new OffloadersCache();
@@ -45,6 +49,32 @@ public class OffloadersCacheTest {
             Offloaders offloaders2 = cache.getOrLoadOffloaders("./offloaders", "/tmp");
 
             assertSame(offloaders2, expectedOffloaders, "The offloaders should be the mocked one.");
+        }
+    }
+
+    @Test
+    public void testEquivalentPathsLoadOnlyOnce() throws Exception {
+        String relativePath = "./offloaders";
+        String normalizedPath = Paths.get(relativePath).toAbsolutePath().normalize().toString();
+        Offloaders expectedOffloaders = new Offloaders();
+
+        try (MockedStatic<OffloaderUtils> offloaderUtils = Mockito.mockStatic(OffloaderUtils.class)) {
+            offloaderUtils.when(() -> OffloaderUtils.searchForOffloaders(eq(relativePath), eq("/tmp")))
+                    .thenReturn(expectedOffloaders);
+            offloaderUtils.when(() -> OffloaderUtils.searchForOffloaders(eq(normalizedPath), eq("/tmp")))
+                    .thenReturn(expectedOffloaders);
+
+            OffloadersCache cache = new OffloadersCache();
+
+            Offloaders offloaders1 = cache.getOrLoadOffloaders(relativePath, "/tmp");
+            Offloaders offloaders2 = cache.getOrLoadOffloaders(normalizedPath, "/tmp");
+
+            assertSame(offloaders1, expectedOffloaders, "The relative path should load the mocked offloaders.");
+            assertSame(offloaders2, expectedOffloaders, "The absolute path should reuse the cached offloaders.");
+            offloaderUtils.verify(
+                    () -> OffloaderUtils.searchForOffloaders(eq(normalizedPath), eq("/tmp")), times(1));
+            offloaderUtils.verify(
+                    () -> OffloaderUtils.searchForOffloaders(eq(relativePath), eq("/tmp")), never());
         }
     }
 }


### PR DESCRIPTION
### Motivation

`OffloadersCache` currently uses the raw `offloadersDirectory` string as its cache key, while `OffloaderUtils` resolves that directory to a normalized absolute path when scanning NAR files. As a result, equivalent path spellings such as `./offloaders` and an absolute path to the same directory create separate `Offloaders` instances and separate NAR classloaders.

Loading the same offloader NAR more than once can duplicate process-wide registrations made by the plugin, such as metrics registered in a shared registry.

### Modifications

- Normalize `offloadersDirectory` to an absolute path before using it as the cache key.
- Use the normalized path when loading offloader NARs.
- Add a regression test that verifies equivalent relative and absolute paths load the offloaders only once.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- `./gradlew :managed-ledger:spotlessCheck :managed-ledger:test --tests org.apache.bookkeeper.mledger.offload.OffloadersCacheTest`

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
