### PR TITLE
[fix][test] Fix OneWayReplicatorSchemaValidationEnforcedTest racing the replicator's remote topic creation

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorSchemaValidationEnforcedTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorSchemaValidationEnforcedTest.java
@@ -70,12 +70,15 @@ public class OneWayReplicatorSchemaValidationEnforcedTest extends OneWayReplicat
         Schema<MyClass> myClassSchema = Schema.AVRO(MyClass.class);
         final String topicName =
                 BrokerTestUtil.newUniqueName("persistent://" + sourceClusterAlwaysSchemaCompatibleNamespace + "/tp_");
+        // Create the topic and schema in the remote cluster (r2) first. Creating the topic in the local
+        // cluster starts the replicator, which creates the topic on the remote cluster itself when it is
+        // missing (GeoPersistentReplicator#createRemoteTopicIfDoesNotExist), so creating r2's topic
+        // afterwards races with it and fails with "This topic already exists".
+        admin2.topics().createNonPartitionedTopic(topicName);
+        admin2.schemas().createSchema(topicName, myClassSchema.getSchemaInfo());
         // create the topic and schema in the local cluster (r1)
         admin1.topics().createNonPartitionedTopic(topicName);
         admin1.schemas().createSchema(topicName, myClassSchema.getSchemaInfo());
-        // create the topic and schema in the remote cluster (r2)
-        admin2.topics().createNonPartitionedTopic(topicName);
-        admin2.schemas().createSchema(topicName, myClassSchema.getSchemaInfo());
 
         // consume from the remote cluster (r2)
         org.apache.pulsar.client.api.Consumer<MyClass> consumer2 = client2.newConsumer(myClassSchema)


### PR DESCRIPTION
### Motivation

`testReplicationWithAvroSchemaWithSchemaValidationEnforced` creates the topic in the local cluster (r1) first and only then in the remote cluster (r2):

```java
// create the topic and schema in the local cluster (r1)
admin1.topics().createNonPartitionedTopic(topicName);
admin1.schemas().createSchema(topicName, myClassSchema.getSchemaInfo());
// create the topic and schema in the remote cluster (r2)
admin2.topics().createNonPartitionedTopic(topicName);   // <-- fails
```

Creating the topic on r1 starts the replicator, and the replicator creates the missing topic on the remote cluster itself, via `GeoPersistentReplicator#createRemoteTopicIfDoesNotExist`:

https://github.com/apache/pulsar/blob/master/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/GeoPersistentReplicator.java#L112

The test's own `admin2.topics().createNonPartitionedTopic(...)` therefore races that create and fails with:

```
org.apache.pulsar.client.admin.PulsarAdminException$ConflictException: This topic already exists
	at org.apache.pulsar.client.admin.internal.TopicsImpl.createNonPartitionedTopic(TopicsImpl.java:322)
	at org.apache.pulsar.broker.service.OneWayReplicatorSchemaValidationEnforcedTest.testReplicationWithAvroSchemaWithSchemaValidationEnforced(...)
```

The broker request log shows the sequence plainly — the r2 topic is created by the replicator's admin client (`204`), and the test's own create then gets `409`:

```
PUT /admin/v2/persistent/.../tp_...  204   (r1, the test)
PUT /admin/v2/persistent/.../tp_...  204   (r2, the replicator)
PUT /admin/v2/persistent/.../tp_...  409   (r2, the test)  <-- "This topic already exists"
```

The race has been latent since the test was added. #25437 then added `testReplicationReconnectWithSchemaValidationEnforced` to the same class; TestNG runs the new test first, and it leaves the two-cluster fixture warm, so the older test now loses the race consistently — it fails on every local attempt, in ~0.1s.

### Modifications

Create the topic and schema on the remote cluster (r2) **before** creating them on the local cluster (r1), so the replicator finds the remote topic already present and there is nothing to race.

This is a reordering only: the test still creates the topic and schema on both clusters before producing, and every assertion is unchanged.

`createTopicToRemoteClusterForReplication` is deliberately left at its default. The other test in the class only creates the topic on r1 and relies on the replicator creating it on r2, so turning that off would break it.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests, namely `OneWayReplicatorSchemaValidationEnforcedTest` itself.

Before this change the class fails 1 of 2 tests; after it, it passed 3 runs out of 3:

```shell
./gradlew :pulsar-broker:test -PexcludedTestGroups='' --tests "OneWayReplicatorSchemaValidationEnforcedTest"
```

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment