### PR TITLE
[improve][client] Avoid recomputing entry-bucket hashes

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerImpl.java
@@ -26,7 +26,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.function.ToIntFunction;
 import lombok.CustomLog;
 import lombok.Getter;
 import lombok.Setter;
@@ -64,29 +63,24 @@ class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
     // keep track of callbacks for individual messages being published in a batch
     protected SendCallback firstCallback;
 
-    // PIP-486: when set, createOpSendMsg() stamps entry_hash_min/max on the batch metadata from the
-    // min/max entry-bucket hash of the batch's messages. Null for non-scalable producers (no stamping,
-    // so the path is byte-identical to before).
-    private ToIntFunction<MessageImpl<?>> entryBucketHashFn;
+    // PIP-486: when enabled, the min/max entry-bucket hash is maintained while messages are added and
+    // createOpSendMsg() stamps it on the batch metadata.
+    private boolean entryBucketHashStampingEnabled;
+    private int minEntryBucketHash = Integer.MAX_VALUE;
+    private int maxEntryBucketHash = Integer.MIN_VALUE;
 
-    void setEntryBucketHashFn(ToIntFunction<MessageImpl<?>> entryBucketHashFn) {
-        this.entryBucketHashFn = entryBucketHashFn;
+    void setEntryBucketHashStampingEnabled(boolean entryBucketHashStampingEnabled) {
+        this.entryBucketHashStampingEnabled = entryBucketHashStampingEnabled;
     }
 
-    /** PIP-486: stamp the effective entry-bucket hash range (min/max over the batch's messages). */
-    private void stampEntryBucketRange() {
-        if (entryBucketHashFn == null || messages.isEmpty()) {
+    /** PIP-486: stamp the entry-bucket hash range maintained while messages are added to the batch. */
+    @VisibleForTesting
+    void stampEntryBucketRange() {
+        if (!entryBucketHashStampingEnabled || messages.isEmpty()) {
             return;
         }
-        int min = Integer.MAX_VALUE;
-        int max = Integer.MIN_VALUE;
-        for (int i = 0; i < messages.size(); i++) {
-            int h = entryBucketHashFn.applyAsInt(messages.get(i));
-            min = Math.min(min, h);
-            max = Math.max(max, h);
-        }
-        messageMetadata.setEntryHashMin(min);
-        messageMetadata.setEntryHashMax(max);
+        messageMetadata.setEntryHashMin(minEntryBucketHash);
+        messageMetadata.setEntryHashMax(maxEntryBucketHash);
     }
 
     protected final ByteBufAllocator allocator;
@@ -113,10 +107,22 @@ class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
 
     @Override
     public boolean add(MessageImpl<?> msg, SendCallback callback) {
-            log.debug().attr("topic", topicName)
-                    .attr("producerName", () -> producer != null ? producer.getProducerName() : null)
-                    .attr("numMessagesInBatch", numMessagesInBatch)
-                    .log("add message to batch");
+        if (entryBucketHashStampingEnabled) {
+            throw new IllegalStateException(
+                    "The entry-bucket hash must be provided when entry-bucket hash stamping is enabled");
+        }
+        return add(msg, callback, 0);
+    }
+
+    /**
+     * Adds a message whose entry-bucket hash has already been computed, avoiding a second hash
+     * calculation when the send operation is created.
+     */
+    boolean add(MessageImpl<?> msg, SendCallback callback, int entryBucketHash) {
+        log.debug().attr("topic", topicName)
+                .attr("producerName", () -> producer != null ? producer.getProducerName() : null)
+                .attr("numMessagesInBatch", numMessagesInBatch)
+                .log("add message to batch");
 
         if (++numMessagesInBatch == 1) {
             try {
@@ -152,6 +158,10 @@ class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
         previousCallback = callback;
         currentBatchSizeBytes += msg.getDataBuffer().readableBytes();
         messages.add(msg);
+        if (entryBucketHashStampingEnabled) {
+            minEntryBucketHash = Math.min(minEntryBucketHash, entryBucketHash);
+            maxEntryBucketHash = Math.max(maxEntryBucketHash, entryBucketHash);
+        }
         tryUpdateTimestamp();
 
         if (lowestSequenceId == -1L) {
@@ -252,6 +262,8 @@ class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
         currentBatchSizeBytes = 0;
         lowestSequenceId = -1L;
         highestSequenceId = -1L;
+        minEntryBucketHash = Integer.MAX_VALUE;
+        maxEntryBucketHash = Integer.MIN_VALUE;
         batchedMessageMetadataAndPayload = null;
         currentTxnidMostBits = -1L;
         currentTxnidLeastBits = -1L;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerImpl.java
@@ -63,20 +63,13 @@ class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
     // keep track of callbacks for individual messages being published in a batch
     protected SendCallback firstCallback;
 
-    // PIP-486: when enabled, the min/max entry-bucket hash is maintained while messages are added and
-    // createOpSendMsg() stamps it on the batch metadata.
-    private boolean entryBucketHashStampingEnabled;
+    // PIP-486: createOpSendMsg() stamps the min/max entry-bucket hash maintained by the three-argument add.
     private int minEntryBucketHash = Integer.MAX_VALUE;
     private int maxEntryBucketHash = Integer.MIN_VALUE;
 
-    void setEntryBucketHashStampingEnabled(boolean entryBucketHashStampingEnabled) {
-        this.entryBucketHashStampingEnabled = entryBucketHashStampingEnabled;
-    }
-
     /** PIP-486: stamp the entry-bucket hash range maintained while messages are added to the batch. */
-    @VisibleForTesting
-    void stampEntryBucketRange() {
-        if (!entryBucketHashStampingEnabled || messages.isEmpty()) {
+    private void stampEntryBucketRange() {
+        if (minEntryBucketHash > maxEntryBucketHash) {
             return;
         }
         messageMetadata.setEntryHashMin(minEntryBucketHash);
@@ -107,18 +100,6 @@ class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
 
     @Override
     public boolean add(MessageImpl<?> msg, SendCallback callback) {
-        if (entryBucketHashStampingEnabled) {
-            throw new IllegalStateException(
-                    "The entry-bucket hash must be provided when entry-bucket hash stamping is enabled");
-        }
-        return add(msg, callback, 0);
-    }
-
-    /**
-     * Adds a message whose entry-bucket hash has already been computed, avoiding a second hash
-     * calculation when the send operation is created.
-     */
-    boolean add(MessageImpl<?> msg, SendCallback callback, int entryBucketHash) {
         log.debug().attr("topic", topicName)
                 .attr("producerName", () -> producer != null ? producer.getProducerName() : null)
                 .attr("numMessagesInBatch", numMessagesInBatch)
@@ -158,10 +139,6 @@ class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
         previousCallback = callback;
         currentBatchSizeBytes += msg.getDataBuffer().readableBytes();
         messages.add(msg);
-        if (entryBucketHashStampingEnabled) {
-            minEntryBucketHash = Math.min(minEntryBucketHash, entryBucketHash);
-            maxEntryBucketHash = Math.max(maxEntryBucketHash, entryBucketHash);
-        }
         tryUpdateTimestamp();
 
         if (lowestSequenceId == -1L) {
@@ -174,6 +151,19 @@ class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
         }
 
         return isBatchFull();
+    }
+
+    /**
+     * Adds a message whose entry-bucket hash has already been computed, avoiding a second hash
+     * calculation when the send operation is created.
+     */
+    boolean add(MessageImpl<?> msg, SendCallback callback, int entryBucketHash) {
+        boolean isBatchFull = add(msg, callback);
+        if (!isEmpty()) {
+            minEntryBucketHash = Math.min(minEntryBucketHash, entryBucketHash);
+            maxEntryBucketHash = Math.max(maxEntryBucketHash, entryBucketHash);
+        }
+        return isBatchFull;
     }
 
     protected ByteBuf getCompressedBatchMetadataAndPayload() {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/EntryBucketBatchContainer.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/EntryBucketBatchContainer.java
@@ -56,11 +56,8 @@ class EntryBucketBatchContainer extends AbstractBatchMessageContainer {
     public boolean add(MessageImpl<?> msg, SendCallback callback) {
         int hashCode = entryBucketHash(msg);
         int bucket = bucketOf(splits, hashCode);
-        final BatchMessageContainerImpl batchMessageContainer = batches.computeIfAbsent(bucket, __ -> {
-            BatchMessageContainerImpl c = new BatchMessageContainerImpl(producer);
-            c.setEntryBucketHashStampingEnabled(true);
-            return c;
-        });
+        final BatchMessageContainerImpl batchMessageContainer =
+            batches.computeIfAbsent(bucket, __ -> new BatchMessageContainerImpl(producer));
         batchMessageContainer.add(msg, callback, hashCode);
         // `add` fails iff the container was empty and `msg` (the first message) failed; then the
         // container is cleared and there is nothing to count.

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/EntryBucketBatchContainer.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/EntryBucketBatchContainer.java
@@ -54,13 +54,14 @@ class EntryBucketBatchContainer extends AbstractBatchMessageContainer {
 
     @Override
     public boolean add(MessageImpl<?> msg, SendCallback callback) {
-        int bucket = bucketOf(splits, entryBucketHash(msg));
+        int hashCode = entryBucketHash(msg);
+        int bucket = bucketOf(splits, hashCode);
         final BatchMessageContainerImpl batchMessageContainer = batches.computeIfAbsent(bucket, __ -> {
             BatchMessageContainerImpl c = new BatchMessageContainerImpl(producer);
-            c.setEntryBucketHashFn(this::entryBucketHash);
+            c.setEntryBucketHashStampingEnabled(true);
             return c;
         });
-        batchMessageContainer.add(msg, callback);
+        batchMessageContainer.add(msg, callback, hashCode);
         // `add` fails iff the container was empty and `msg` (the first message) failed; then the
         // container is cleared and there is nothing to count.
         if (!batchMessageContainer.isEmpty()) {

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BatchMessageContainerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BatchMessageContainerImplTest.java
@@ -24,7 +24,6 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import io.netty.buffer.ByteBufAllocator;
@@ -33,7 +32,6 @@ import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.pulsar.client.api.CompressionType;
 import org.apache.pulsar.client.api.Schema;
@@ -147,27 +145,7 @@ public class BatchMessageContainerImplTest {
 
     @Test
     public void testMessagesSize() throws Exception {
-        ProducerImpl<?> producer = mock(ProducerImpl.class);
-
-        final ProducerConfigurationData producerConfigurationData = new ProducerConfigurationData();
-        producerConfigurationData.setCompressionType(CompressionType.NONE);
-        PulsarClientImpl pulsarClient = mock(PulsarClientImpl.class);
-        ConnectionPool connectionPool = mock(ConnectionPool.class);
-        when(pulsarClient.getCnxPool()).thenReturn(connectionPool);
-        MemoryLimitController memoryLimitController = mock(MemoryLimitController.class);
-        when(pulsarClient.getMemoryLimitController()).thenReturn(memoryLimitController);
-        try {
-            Field clientFiled = HandlerState.class.getDeclaredField("client");
-            clientFiled.setAccessible(true);
-            clientFiled.set(producer, pulsarClient);
-        } catch (Exception e){
-            fail(e.getMessage());
-        }
-
-        ByteBuffer payload = ByteBuffer.wrap("payload".getBytes(StandardCharsets.UTF_8));
-
-        when(producer.getConfiguration()).thenReturn(producerConfigurationData);
-        when(producer.encryptMessage(any(), any())).thenReturn(ByteBufAllocator.DEFAULT.buffer().writeBytes(payload));
+        ProducerImpl<?> producer = createTestProducer();
 
         final int initNum = 32;
         BatchMessageContainerImpl batchMessageContainer = new BatchMessageContainerImpl(producer);
@@ -184,49 +162,30 @@ public class BatchMessageContainerImplTest {
     }
 
     @Test
-    public void testEntryBucketHashRangeIsMaintainedAndReset() {
-        BatchMessageContainerImpl batchMessageContainer = new BatchMessageContainerImpl();
-        batchMessageContainer.setEntryBucketHashStampingEnabled(true);
-
-        List<MessageImpl<?>> messages = new ArrayList<>();
+    public void testEntryBucketHashRangeIsStampedWhenCreatingSendOperation() throws Exception {
+        BatchMessageContainerImpl batchMessageContainer = new BatchMessageContainerImpl(createTestProducer());
+        ArrayList<MessageImpl<?>> messages = new ArrayList<>();
         try {
-            messages.add(createMessage(1));
-            messages.add(createMessage(2));
-            messages.add(createMessage(3));
-            batchMessageContainer.add(messages.get(0), null, 0x3000);
-            batchMessageContainer.add(messages.get(1), null, 0x1000);
-            batchMessageContainer.add(messages.get(2), null, 0x2000);
-
-            batchMessageContainer.stampEntryBucketRange();
-            assertEquals(batchMessageContainer.messageMetadata.getEntryHashMin(), 0x1000);
+            MessageImpl<?> singleMessage = createMessage(1);
+            messages.add(singleMessage);
+            batchMessageContainer.add(singleMessage, null, 0x3000);
+            batchMessageContainer.createOpSendMsg();
+            assertEquals(batchMessageContainer.messageMetadata.getEntryHashMin(), 0x3000);
             assertEquals(batchMessageContainer.messageMetadata.getEntryHashMax(), 0x3000);
 
-            batchMessageContainer.discard(null);
-            MessageImpl<?> message = createMessage(4);
-            messages.add(message);
-            batchMessageContainer.add(message, null, 0x2000);
-            batchMessageContainer.stampEntryBucketRange();
-            assertEquals(batchMessageContainer.messageMetadata.getEntryHashMin(), 0x2000);
+            batchMessageContainer.clear();
+            MessageImpl<?> firstMessage = createMessage(2);
+            MessageImpl<?> secondMessage = createMessage(3);
+            MessageImpl<?> thirdMessage = createMessage(4);
+            messages.add(firstMessage);
+            messages.add(secondMessage);
+            messages.add(thirdMessage);
+            batchMessageContainer.add(firstMessage, null, 0x2000);
+            batchMessageContainer.add(secondMessage, null, 0x1000);
+            batchMessageContainer.add(thirdMessage, null, 0x1800);
+            batchMessageContainer.createOpSendMsg();
+            assertEquals(batchMessageContainer.messageMetadata.getEntryHashMin(), 0x1000);
             assertEquals(batchMessageContainer.messageMetadata.getEntryHashMax(), 0x2000);
-        } finally {
-            batchMessageContainer.discard(null);
-            messages.forEach(ReferenceCountUtil::safeRelease);
-        }
-    }
-
-    @Test
-    public void testEntryBucketHashStampingCanBeDisabled() {
-        BatchMessageContainerImpl batchMessageContainer = new BatchMessageContainerImpl();
-        batchMessageContainer.setEntryBucketHashStampingEnabled(false);
-
-        List<MessageImpl<?>> messages = new ArrayList<>();
-        try {
-            messages.add(createMessage(1));
-            batchMessageContainer.add(messages.get(0), null, 0x1000);
-            batchMessageContainer.stampEntryBucketRange();
-
-            assertFalse(batchMessageContainer.messageMetadata.hasEntryHashMin());
-            assertFalse(batchMessageContainer.messageMetadata.hasEntryHashMax());
         } finally {
             batchMessageContainer.discard(null);
             messages.forEach(ReferenceCountUtil::safeRelease);
@@ -242,16 +201,27 @@ public class BatchMessageContainerImplTest {
         return MessageImpl.create(messageMetadata, payload, Schema.BYTES, null);
     }
 
+    private ProducerImpl<?> createTestProducer() throws Exception {
+        ProducerImpl<?> producer = mock(ProducerImpl.class);
+        ProducerConfigurationData producerConfigurationData = new ProducerConfigurationData();
+        producerConfigurationData.setCompressionType(CompressionType.NONE);
+        PulsarClientImpl pulsarClient = mock(PulsarClientImpl.class);
+        when(pulsarClient.getCnxPool()).thenReturn(mock(ConnectionPool.class));
+        when(pulsarClient.getMemoryLimitController()).thenReturn(mock(MemoryLimitController.class));
+        Field clientField = HandlerState.class.getDeclaredField("client");
+        clientField.setAccessible(true);
+        clientField.set(producer, pulsarClient);
+        when(producer.getConfiguration()).thenReturn(producerConfigurationData);
+        when(producer.encryptMessage(any(), any())).thenAnswer(__ -> ByteBufAllocator.DEFAULT.buffer()
+                .writeBytes("payload".getBytes(StandardCharsets.UTF_8)));
+        return producer;
+    }
+
     private void addMessagesAndCreateOpSendMsg(BatchMessageContainerImpl batchMessageContainer, int num)
             throws Exception{
         ArrayList<MessageImpl<?>> messages = new ArrayList<>();
         for (int i = 0; i < num; ++i) {
-            MessageMetadata messageMetadata = new MessageMetadata();
-            messageMetadata.setSequenceId(i);
-            messageMetadata.setProducerName("producer");
-            messageMetadata.setPublishTime(System.currentTimeMillis());
-            ByteBuffer payload = ByteBuffer.wrap("payload".getBytes(StandardCharsets.UTF_8));
-            MessageImpl<?> message = MessageImpl.create(messageMetadata, payload, Schema.BYTES, null);
+            MessageImpl<?> message = createMessage(i);
             messages.add(message);
             batchMessageContainer.add(message, null);
         }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BatchMessageContainerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BatchMessageContainerImplTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import io.netty.buffer.ByteBufAllocator;
@@ -32,6 +33,7 @@ import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.pulsar.client.api.CompressionType;
 import org.apache.pulsar.client.api.Schema;
@@ -179,6 +181,65 @@ public class BatchMessageContainerImplTest {
 
         addMessagesAndCreateOpSendMsg(batchMessageContainer, 10);
         assertEquals(batchMessageContainer.getMaxMessagesNum(), 200);
+    }
+
+    @Test
+    public void testEntryBucketHashRangeIsMaintainedAndReset() {
+        BatchMessageContainerImpl batchMessageContainer = new BatchMessageContainerImpl();
+        batchMessageContainer.setEntryBucketHashStampingEnabled(true);
+
+        List<MessageImpl<?>> messages = new ArrayList<>();
+        try {
+            messages.add(createMessage(1));
+            messages.add(createMessage(2));
+            messages.add(createMessage(3));
+            batchMessageContainer.add(messages.get(0), null, 0x3000);
+            batchMessageContainer.add(messages.get(1), null, 0x1000);
+            batchMessageContainer.add(messages.get(2), null, 0x2000);
+
+            batchMessageContainer.stampEntryBucketRange();
+            assertEquals(batchMessageContainer.messageMetadata.getEntryHashMin(), 0x1000);
+            assertEquals(batchMessageContainer.messageMetadata.getEntryHashMax(), 0x3000);
+
+            batchMessageContainer.discard(null);
+            MessageImpl<?> message = createMessage(4);
+            messages.add(message);
+            batchMessageContainer.add(message, null, 0x2000);
+            batchMessageContainer.stampEntryBucketRange();
+            assertEquals(batchMessageContainer.messageMetadata.getEntryHashMin(), 0x2000);
+            assertEquals(batchMessageContainer.messageMetadata.getEntryHashMax(), 0x2000);
+        } finally {
+            batchMessageContainer.discard(null);
+            messages.forEach(ReferenceCountUtil::safeRelease);
+        }
+    }
+
+    @Test
+    public void testEntryBucketHashStampingCanBeDisabled() {
+        BatchMessageContainerImpl batchMessageContainer = new BatchMessageContainerImpl();
+        batchMessageContainer.setEntryBucketHashStampingEnabled(false);
+
+        List<MessageImpl<?>> messages = new ArrayList<>();
+        try {
+            messages.add(createMessage(1));
+            batchMessageContainer.add(messages.get(0), null, 0x1000);
+            batchMessageContainer.stampEntryBucketRange();
+
+            assertFalse(batchMessageContainer.messageMetadata.hasEntryHashMin());
+            assertFalse(batchMessageContainer.messageMetadata.hasEntryHashMax());
+        } finally {
+            batchMessageContainer.discard(null);
+            messages.forEach(ReferenceCountUtil::safeRelease);
+        }
+    }
+
+    private MessageImpl<?> createMessage(long sequenceId) {
+        MessageMetadata messageMetadata = new MessageMetadata();
+        messageMetadata.setSequenceId(sequenceId);
+        messageMetadata.setProducerName("producer");
+        messageMetadata.setPublishTime(System.currentTimeMillis());
+        ByteBuffer payload = ByteBuffer.wrap("payload".getBytes(StandardCharsets.UTF_8));
+        return MessageImpl.create(messageMetadata, payload, Schema.BYTES, null);
     }
 
     private void addMessagesAndCreateOpSendMsg(BatchMessageContainerImpl batchMessageContainer, int num)


### PR DESCRIPTION

### Motivation

  Entry-bucket batching already computes each message's entry-bucket hash when it selects the bucket for that message. However, while building the batch send operation, `BatchMessageContainerImpl#createOpSendMsg()` recomputed
  the same hash for every message in the batch in order to stamp `entry_hash_min` and `entry_hash_max`.

  This means the hash of each message was calculated twice during the batching path:

  1. once in `EntryBucketBatchContainer#add()` for bucket selection;
  2. again in `BatchMessageContainerImpl#createOpSendMsg()` for metadata stamping.

  For producers using entry-bucket batching, this duplicated hashing work on every batch flush and made the hashing cost proportional to the batch size twice instead of once.

### Modifications

  - Compute the entry-bucket hash once in `EntryBucketBatchContainer#add()`.
  - Pass that already-computed hash to `BatchMessageContainerImpl` through a package-private overload:

    ```java
    add(MessageImpl<?> msg, SendCallback callback, int entryBucketHash)

  - Maintain the batch-level entry-bucket hash minimum and maximum incrementally while messages are added.
  - Replace the previous hash function field with a boolean flag indicating whether entry-bucket hash stamping is enabled.
  - Stamp entry_hash_min and entry_hash_max from the maintained minimum and maximum values instead of recomputing hashes for all messages.
  - Reset the maintained minimum and maximum values when the batch container is cleared.
  - Fail fast if the two-argument add() method is used on a container that requires a precomputed entry-bucket hash.
  - Add unit tests covering:
      - incremental hash range maintenance;
      - metadata stamping;
      - state reset after the batch is discarded;
      - disabled entry-bucket hash stamping.

  The additional add() overload is package-private on a package-private implementation class and is only used by EntryBucketBatchContainer; it does not change the public client API.


### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
### Matching PR in forked repository

PR in forked repository: https://github.com/3pacccccc/pulsar/pull/39