### PR TITLE
[fix][fn] Support deadLetterTopic and maxMessageRetries for Python functions

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -370,7 +370,7 @@ public class CmdFunctions extends CmdBase {
         @Option(names = "--timeout-ms", description = "The message timeout in milliseconds #Java, Python")
         protected Long timeoutMs;
         @Option(names = "--max-message-retries",
-                description = "How many times should we try to process a message before giving up #Java")
+                description = "How many times should we try to process a message before giving up #Java, Python")
         protected Integer maxMessageRetries;
         @Option(names = "--custom-runtime-options", description = "A string that encodes options to "
                 + "customize the runtime, see docs for configured runtime for details #Java")
@@ -379,7 +379,7 @@ public class CmdFunctions extends CmdBase {
                 + "how the secret is fetched by the underlying secrets provider #Java, Python")
         protected String secretsString;
         @Option(names = "--dead-letter-topic",
-                description = "The topic where messages that are not processed successfully are sent to #Java")
+                description = "The topic where messages that are not processed successfully are sent to #Java, Python")
         protected String deadLetterTopic;
         @Option(names = "--runtime-flags", description = "Any flags that you want to pass to a runtime"
                 + " (for process & Kubernetes runtime only).")

--- a/pulsar-functions/instance/src/main/python/README.md
+++ b/pulsar-functions/instance/src/main/python/README.md
@@ -1,5 +1,25 @@
 # Pulsar Functions Python Runtime
 
+### pulsar-client-python requirements
+
+The runtime requires **pulsar-client-python 3.3.0 or newer**. `Client.subscribe()` grew its
+`dead_letter_policy` parameter in 3.3.0 (as did `ConsumerDeadLetterPolicy`, in the same release), and
+the runtime passes the keyword on every subscription — as `None` when the function configures no
+`maxMessageRetries` or `deadLetterTopic`, which `Client.subscribe()` treats as a no-op. Every other
+argument the runtime passes is present in 3.2.0, so this is the only thing setting the floor.
+
+Everything Pulsar ships already satisfies this: the `pulsar-client-python` version in
+[`gradle/libs.versions.toml`](../../../../../gradle/libs.versions.toml) is what the
+[Docker images](../../../../../docker/pulsar/Dockerfile) install and what CI runs the instance tests
+against. The floor is only visible on a self-managed worker, where the process runtime launches the
+host's `python3` (see `RuntimeUtils`) and the installed client is the operator's. For a
+zip-packaged function, pin it in the function's own `requirements.txt`, which
+`python_instance_main.py` pip-installs before the instance starts:
+
+```
+pulsar-client>=3.3.0
+```
+
 ### Producer configuration
 
 Both producers the runtime creates — the sink (output topic) producer in `python_instance.py` and the

--- a/pulsar-functions/instance/src/main/python/README.md
+++ b/pulsar-functions/instance/src/main/python/README.md
@@ -8,12 +8,16 @@ the runtime passes the keyword on every subscription — as `None` when the func
 `maxMessageRetries` or `deadLetterTopic`, which `Client.subscribe()` treats as a no-op. Every other
 argument the runtime passes is present in 3.2.0, so this is the only thing setting the floor.
 
-Everything Pulsar ships already satisfies this: the `pulsar-client-python` version in
-[`gradle/libs.versions.toml`](../../../../../gradle/libs.versions.toml) is what the
-[Docker images](../../../../../docker/pulsar/Dockerfile) install and what CI runs the instance tests
-against. The floor is only visible on a self-managed worker, where the process runtime launches the
-host's `python3` (see `RuntimeUtils`) and the installed client is the operator's. For a
-zip-packaged function, pin it in the function's own `requirements.txt`, which
+Everything Pulsar ships already satisfies this. The
+[Docker images](../../../../../docker/pulsar/Dockerfile) derive their version from the
+`pulsar-client-python` entry in
+[`gradle/libs.versions.toml`](../../../../../gradle/libs.versions.toml), which
+[`docker/pulsar/build.gradle.kts`](../../../../../docker/pulsar/build.gradle.kts) resolves and passes
+to the build as `PULSAR_CLIENT_PYTHON_VERSION`. CI pins its own copy of the same version separately,
+in [`run_python_instance_tests.sh`](../../scripts/run_python_instance_tests.sh) — the two agree by
+maintenance rather than derivation. The floor is only visible on a self-managed worker, where the
+process runtime launches the host's `python3` (see `RuntimeUtils`) and the installed client is the
+operator's. For a zip-packaged function, pin it in the function's own `requirements.txt`, which
 `python_instance_main.py` pip-installs before the instance starts:
 
 ```

--- a/pulsar-functions/instance/src/main/python/python_instance.py
+++ b/pulsar-functions/instance/src/main/python/python_instance.py
@@ -154,6 +154,8 @@ class PythonInstance(object):
     if self.instance_config.function_details.source.subscriptionPosition == Function_pb2.SubscriptionPosition.Value("EARLIEST"):
       position = pulsar._pulsar.InitialPosition.Earliest
 
+    dead_letter_policy = self.get_dead_letter_policy(mode)
+
     subscription_name = self.instance_config.function_details.source.subscriptionName
 
     if not (subscription_name and subscription_name.strip()):
@@ -181,7 +183,8 @@ class PythonInstance(object):
         message_listener=partial(self.message_listener, self.input_serdes[topic], DEFAULT_SCHEMA),
         unacked_messages_timeout_ms=int(self.timeout_ms) if self.timeout_ms else None,
         initial_position=position,
-        properties=properties
+        properties=properties,
+        dead_letter_policy=dead_letter_policy
       )
 
     for topic, consumer_conf in self.instance_config.function_details.source.inputSpecs.items():
@@ -205,7 +208,8 @@ class PythonInstance(object):
         "unacked_messages_timeout_ms": int(self.timeout_ms) if self.timeout_ms else None,
         "initial_position": position,
         "properties": properties,
-        "crypto_key_reader": crypto_key_reader
+        "crypto_key_reader": crypto_key_reader,
+        "dead_letter_policy": dead_letter_policy
       }
       if consumer_conf.HasField("receiverQueueSize"):
         consumer_args["receiver_queue_size"] = consumer_conf.receiverQueueSize.value
@@ -584,6 +588,44 @@ class PythonInstance(object):
         except:
           pass
       return record_kclass
+  def get_dead_letter_policy(self, consumer_type):
+    """Build the consumer dead letter policy from FunctionDetails.retryDetails.
+
+    Mirrors the Java runtime (JavaInstanceRunnable + PulsarSource): the policy is only considered
+    when retryDetails is present, and an empty deadLetterTopic is left to the client, which defaults
+    it to "<topic>-<subscription>-DLQ".
+
+    Returns None when no policy should be attached.
+    """
+    if not self.instance_config.function_details.HasField("retryDetails"):
+      return None
+
+    retry_details = self.instance_config.function_details.retryDetails
+    max_message_retries = retry_details.maxMessageRetries
+
+    # The Java runtime accepts maxMessageRetries >= 0, but the Python client rejects a
+    # maxRedeliverCount below 1, so zero cannot be expressed here. Warn rather than fail the
+    # instance, and rather than dropping it silently - silent drops are the bug this fixes.
+    if max_message_retries < 1:
+      if max_message_retries == 0 and retry_details.deadLetterTopic:
+        Log.warning(
+          "maxMessageRetries is 0, which the Python client cannot express (it requires a "
+          "redelivery count of at least 1); no dead letter policy will be applied and messages "
+          "will not be routed to %s" % retry_details.deadLetterTopic)
+      return None
+
+    # A dead letter policy only takes effect on Shared and KeyShared subscriptions.
+    if consumer_type not in (pulsar._pulsar.ConsumerType.Shared, pulsar._pulsar.ConsumerType.KeyShared):
+      Log.warning(
+        "a dead letter policy is configured but the subscription type is not Shared or "
+        "KeyShared, so it will have no effect; retainOrdering and EFFECTIVELY_ONCE both select "
+        "a Failover subscription")
+      return None
+
+    return pulsar.ConsumerDeadLetterPolicy(
+      max_redeliver_count=max_message_retries,
+      dead_letter_topic=retry_details.deadLetterTopic or None)
+
   def get_crypto_reader(self, crypto_spec):
     crypto_key_reader = None
     if crypto_spec is not None:

--- a/pulsar-functions/instance/src/main/python/python_instance.py
+++ b/pulsar-functions/instance/src/main/python/python_instance.py
@@ -140,94 +140,7 @@ class PythonInstance(object):
     self.state_context = self.setup_state()
 
     # Setup consumers and input deserializers
-    mode = pulsar._pulsar.ConsumerType.Shared
-    if self.instance_config.function_details.source.subscriptionType == Function_pb2.SubscriptionType.Value("FAILOVER"):
-      mode = pulsar._pulsar.ConsumerType.Failover
-
-    if self.instance_config.function_details.retainOrdering or \
-      self.instance_config.function_details.processingGuarantees == Function_pb2.ProcessingGuarantees.Value("EFFECTIVELY_ONCE"):
-      mode = pulsar._pulsar.ConsumerType.Failover
-    elif self.instance_config.function_details.retainKeyOrdering:
-      mode = pulsar._pulsar.ConsumerType.KeyShared
-
-    nack_args = self.get_negative_ack_args()
-
-    position = pulsar._pulsar.InitialPosition.Latest
-    if self.instance_config.function_details.source.subscriptionPosition == Function_pb2.SubscriptionPosition.Value("EARLIEST"):
-      position = pulsar._pulsar.InitialPosition.Earliest
-
-    dead_letter_policy = self.get_dead_letter_policy()
-
-    subscription_name = self.instance_config.function_details.source.subscriptionName
-
-    if not (subscription_name and subscription_name.strip()):
-      subscription_name = str(self.instance_config.function_details.tenant) + "/" + \
-                          str(self.instance_config.function_details.namespace) + "/" + \
-                          str(self.instance_config.function_details.name)
-
-    properties = util.get_properties(util.getFullyQualifiedFunctionName(
-                        self.instance_config.function_details.tenant,
-                        self.instance_config.function_details.namespace,
-                        self.instance_config.function_details.name),
-                        self.instance_config.instance_id)
-
-    for topic, serde in self.instance_config.function_details.source.topicsToSerDeClassName.items():
-      if not serde:
-        serde_kclass = util.import_class(os.path.dirname(self.user_code), DEFAULT_SERIALIZER)
-      else:
-        serde_kclass = util.import_class(os.path.dirname(self.user_code), serde)
-      self.input_serdes[topic] = serde_kclass()
-      Log.debug("Setting up consumer for topic %s with subname %s" % (topic, subscription_name))
-
-      self.consumers[topic] = self.pulsar_client.subscribe(
-        str(topic), subscription_name,
-        consumer_type=mode,
-        message_listener=partial(self.message_listener, self.input_serdes[topic], DEFAULT_SCHEMA),
-        unacked_messages_timeout_ms=int(self.timeout_ms) if self.timeout_ms else None,
-        initial_position=position,
-        properties=properties,
-        dead_letter_policy=dead_letter_policy,
-        **nack_args
-      )
-
-    for topic, consumer_conf in self.instance_config.function_details.source.inputSpecs.items():
-      if not consumer_conf.serdeClassName:
-        serde_kclass = util.import_class(os.path.dirname(self.user_code), DEFAULT_SERIALIZER)
-      else:
-        serde_kclass = util.import_class(os.path.dirname(self.user_code), consumer_conf.serdeClassName)
-      self.input_serdes[topic] = serde_kclass()
-
-      self.input_schema[topic] = self.get_schema(consumer_conf.schemaType,
-                                                 self.instance_config.function_details.source.typeClassName,
-                                                 consumer_conf.schemaProperties)
-      Log.debug("Setting up consumer for topic %s with subname %s" % (topic, subscription_name))
-
-      crypto_key_reader = self.get_crypto_reader(consumer_conf.cryptoSpec)
-
-      consumer_args = {
-        "consumer_type": mode,
-        "schema": self.input_schema[topic],
-        "message_listener": partial(self.message_listener, self.input_serdes[topic], self.input_schema[topic]),
-        "unacked_messages_timeout_ms": int(self.timeout_ms) if self.timeout_ms else None,
-        "initial_position": position,
-        "properties": properties,
-        "crypto_key_reader": crypto_key_reader,
-        "dead_letter_policy": dead_letter_policy
-      }
-      consumer_args.update(nack_args)
-      if consumer_conf.HasField("receiverQueueSize"):
-        consumer_args["receiver_queue_size"] = consumer_conf.receiverQueueSize.value
-
-      if consumer_conf.isRegexPattern:
-        self.consumers[topic] = self.pulsar_client.subscribe(
-          re.compile(str(topic)), subscription_name,
-          **consumer_args
-        )
-      else:
-        self.consumers[topic] = self.pulsar_client.subscribe(
-          str(topic), subscription_name,
-          **consumer_args
-        )
+    self.setup_consumers()
 
     function_kclass = util.import_class(os.path.dirname(self.user_code), self.instance_config.function_details.className)
     if function_kclass is None:
@@ -586,6 +499,103 @@ class PythonInstance(object):
         except:
           pass
       return record_kclass
+  def setup_consumers(self):
+    """Subscribe to every input topic and build the matching input deserializers.
+
+    Kept separate from run() so the consumer configuration can be exercised the same way
+    setup_producer() is: the two subscribe() call sites below - the topicsToSerDeClassName path
+    and the inputSpecs path, which also covers the regex variant - must stay in step with each
+    other, and only a test that reaches the client can show that they do.
+    """
+    mode = pulsar._pulsar.ConsumerType.Shared
+    if self.instance_config.function_details.source.subscriptionType == Function_pb2.SubscriptionType.Value("FAILOVER"):
+      mode = pulsar._pulsar.ConsumerType.Failover
+
+    if self.instance_config.function_details.retainOrdering or \
+      self.instance_config.function_details.processingGuarantees == Function_pb2.ProcessingGuarantees.Value("EFFECTIVELY_ONCE"):
+      mode = pulsar._pulsar.ConsumerType.Failover
+    elif self.instance_config.function_details.retainKeyOrdering:
+      mode = pulsar._pulsar.ConsumerType.KeyShared
+
+    nack_args = self.get_negative_ack_args()
+
+    position = pulsar._pulsar.InitialPosition.Latest
+    if self.instance_config.function_details.source.subscriptionPosition == Function_pb2.SubscriptionPosition.Value("EARLIEST"):
+      position = pulsar._pulsar.InitialPosition.Earliest
+
+    dead_letter_policy = self.get_dead_letter_policy()
+
+    subscription_name = self.instance_config.function_details.source.subscriptionName
+
+    if not (subscription_name and subscription_name.strip()):
+      subscription_name = str(self.instance_config.function_details.tenant) + "/" + \
+                          str(self.instance_config.function_details.namespace) + "/" + \
+                          str(self.instance_config.function_details.name)
+
+    properties = util.get_properties(util.getFullyQualifiedFunctionName(
+                        self.instance_config.function_details.tenant,
+                        self.instance_config.function_details.namespace,
+                        self.instance_config.function_details.name),
+                        self.instance_config.instance_id)
+
+    for topic, serde in self.instance_config.function_details.source.topicsToSerDeClassName.items():
+      if not serde:
+        serde_kclass = util.import_class(os.path.dirname(self.user_code), DEFAULT_SERIALIZER)
+      else:
+        serde_kclass = util.import_class(os.path.dirname(self.user_code), serde)
+      self.input_serdes[topic] = serde_kclass()
+      Log.debug("Setting up consumer for topic %s with subname %s" % (topic, subscription_name))
+
+      self.consumers[topic] = self.pulsar_client.subscribe(
+        str(topic), subscription_name,
+        consumer_type=mode,
+        message_listener=partial(self.message_listener, self.input_serdes[topic], DEFAULT_SCHEMA),
+        unacked_messages_timeout_ms=int(self.timeout_ms) if self.timeout_ms else None,
+        initial_position=position,
+        properties=properties,
+        dead_letter_policy=dead_letter_policy,
+        **nack_args
+      )
+
+    for topic, consumer_conf in self.instance_config.function_details.source.inputSpecs.items():
+      if not consumer_conf.serdeClassName:
+        serde_kclass = util.import_class(os.path.dirname(self.user_code), DEFAULT_SERIALIZER)
+      else:
+        serde_kclass = util.import_class(os.path.dirname(self.user_code), consumer_conf.serdeClassName)
+      self.input_serdes[topic] = serde_kclass()
+
+      self.input_schema[topic] = self.get_schema(consumer_conf.schemaType,
+                                                 self.instance_config.function_details.source.typeClassName,
+                                                 consumer_conf.schemaProperties)
+      Log.debug("Setting up consumer for topic %s with subname %s" % (topic, subscription_name))
+
+      crypto_key_reader = self.get_crypto_reader(consumer_conf.cryptoSpec)
+
+      consumer_args = {
+        "consumer_type": mode,
+        "schema": self.input_schema[topic],
+        "message_listener": partial(self.message_listener, self.input_serdes[topic], self.input_schema[topic]),
+        "unacked_messages_timeout_ms": int(self.timeout_ms) if self.timeout_ms else None,
+        "initial_position": position,
+        "properties": properties,
+        "crypto_key_reader": crypto_key_reader,
+        "dead_letter_policy": dead_letter_policy
+      }
+      consumer_args.update(nack_args)
+      if consumer_conf.HasField("receiverQueueSize"):
+        consumer_args["receiver_queue_size"] = consumer_conf.receiverQueueSize.value
+
+      if consumer_conf.isRegexPattern:
+        self.consumers[topic] = self.pulsar_client.subscribe(
+          re.compile(str(topic)), subscription_name,
+          **consumer_args
+        )
+      else:
+        self.consumers[topic] = self.pulsar_client.subscribe(
+          str(topic), subscription_name,
+          **consumer_args
+        )
+
   def get_negative_ack_args(self):
     """Build the negative-ack redelivery delay argument for Client.subscribe().
 
@@ -610,8 +620,9 @@ class PythonInstance(object):
     """Build the consumer dead letter policy from FunctionDetails.retryDetails.
 
     Mirrors the Java runtime (JavaInstanceRunnable + PulsarSource): the policy is only considered
-    when retryDetails is present, and an empty deadLetterTopic is left to the client, which defaults
-    it to "<topic>-<subscription>-DLQ".
+    when retryDetails is present, and the deadLetterTopic is forwarded as configured. An unset one
+    reads as "" from the proto, and the client treats an empty topic as unset - it derives
+    "<topic>-<subscription>-DLQ" from the topic and subscription instead.
 
     The configured value is passed through unchanged. Java forwards it the same way - PulsarSource
     builds the policy for any maxMessageRetries >= 0 and ConsumerBuilderImpl.deadLetterPolicy then
@@ -628,7 +639,7 @@ class PythonInstance(object):
 
     return pulsar.ConsumerDeadLetterPolicy(
       max_redeliver_count=retry_details.maxMessageRetries,
-      dead_letter_topic=retry_details.deadLetterTopic or None)
+      dead_letter_topic=retry_details.deadLetterTopic)
 
   def get_crypto_reader(self, crypto_spec):
     crypto_key_reader = None

--- a/pulsar-functions/instance/src/main/python/python_instance.py
+++ b/pulsar-functions/instance/src/main/python/python_instance.py
@@ -588,6 +588,7 @@ class PythonInstance(object):
         except:
           pass
       return record_kclass
+
   def get_dead_letter_policy(self, consumer_type):
     """Build the consumer dead letter policy from FunctionDetails.retryDetails.
 

--- a/pulsar-functions/instance/src/main/python/python_instance.py
+++ b/pulsar-functions/instance/src/main/python/python_instance.py
@@ -154,7 +154,7 @@ class PythonInstance(object):
     if self.instance_config.function_details.source.subscriptionPosition == Function_pb2.SubscriptionPosition.Value("EARLIEST"):
       position = pulsar._pulsar.InitialPosition.Earliest
 
-    dead_letter_policy = self.get_dead_letter_policy(mode)
+    dead_letter_policy = self.get_dead_letter_policy()
 
     subscription_name = self.instance_config.function_details.source.subscriptionName
 
@@ -589,12 +589,18 @@ class PythonInstance(object):
           pass
       return record_kclass
 
-  def get_dead_letter_policy(self, consumer_type):
+  def get_dead_letter_policy(self):
     """Build the consumer dead letter policy from FunctionDetails.retryDetails.
 
     Mirrors the Java runtime (JavaInstanceRunnable + PulsarSource): the policy is only considered
     when retryDetails is present, and an empty deadLetterTopic is left to the client, which defaults
     it to "<topic>-<subscription>-DLQ".
+
+    The configured value is passed through unchanged. Java forwards it the same way - PulsarSource
+    builds the policy for any maxMessageRetries >= 0 and ConsumerBuilderImpl.deadLetterPolicy then
+    rejects a redelivery count below 1 - so an unusable value fails the instance here too rather
+    than starting with retries quietly disabled. Whether a subscription type can act on the policy
+    is left to the client, as it is for Java.
 
     Returns None when no policy should be attached.
     """
@@ -602,29 +608,9 @@ class PythonInstance(object):
       return None
 
     retry_details = self.instance_config.function_details.retryDetails
-    max_message_retries = retry_details.maxMessageRetries
-
-    # The Java runtime accepts maxMessageRetries >= 0, but the Python client rejects a
-    # maxRedeliverCount below 1, so zero cannot be expressed here. Warn rather than fail the
-    # instance, and rather than dropping it silently - silent drops are the bug this fixes.
-    if max_message_retries < 1:
-      if max_message_retries == 0 and retry_details.deadLetterTopic:
-        Log.warning(
-          "maxMessageRetries is 0, which the Python client cannot express (it requires a "
-          "redelivery count of at least 1); no dead letter policy will be applied and messages "
-          "will not be routed to %s" % retry_details.deadLetterTopic)
-      return None
-
-    # A dead letter policy only takes effect on Shared and KeyShared subscriptions.
-    if consumer_type not in (pulsar._pulsar.ConsumerType.Shared, pulsar._pulsar.ConsumerType.KeyShared):
-      Log.warning(
-        "a dead letter policy is configured but the subscription type is not Shared or "
-        "KeyShared, so it will have no effect; retainOrdering and EFFECTIVELY_ONCE both select "
-        "a Failover subscription")
-      return None
 
     return pulsar.ConsumerDeadLetterPolicy(
-      max_redeliver_count=max_message_retries,
+      max_redeliver_count=retry_details.maxMessageRetries,
       dead_letter_topic=retry_details.deadLetterTopic or None)
 
   def get_crypto_reader(self, crypto_spec):

--- a/pulsar-functions/instance/src/main/python/python_instance.py
+++ b/pulsar-functions/instance/src/main/python/python_instance.py
@@ -499,6 +499,7 @@ class PythonInstance(object):
         except:
           pass
       return record_kclass
+
   def setup_consumers(self):
     """Subscribe to every input topic and build the matching input deserializers.
 

--- a/pulsar-functions/instance/src/test/python/test_python_instance.py
+++ b/pulsar-functions/instance/src/test/python/test_python_instance.py
@@ -157,6 +157,11 @@ class TestDeadLetterPolicy(unittest.TestCase):
   The Java runtime applies these in JavaInstanceRunnable (guarded on hasRetryDetails) and
   PulsarSource (maxMessageRetries >= 0, deadLetterTopic only when non-empty). The Python runtime
   previously ignored retryDetails entirely.
+
+  The configured redelivery count is passed straight through, matching Java: PulsarSource builds a
+  policy for any value >= 0 and ConsumerBuilderImpl.deadLetterPolicy then rejects anything below 1.
+  Whether a subscription type can act on the policy is a client concern, so the runtime does not
+  gate on it.
   """
 
   def _instance(self, max_message_retries=None, dead_letter_topic=None):
@@ -172,13 +177,12 @@ class TestDeadLetterPolicy(unittest.TestCase):
 
   def test_no_retry_details_means_no_policy(self):
     instance = self._instance()
-    self.assertIsNone(
-      instance.get_dead_letter_policy(pulsar._pulsar.ConsumerType.Shared))
+    self.assertIsNone(instance.get_dead_letter_policy())
 
   def test_policy_built_from_retry_details(self):
     instance = self._instance(max_message_retries=3,
                               dead_letter_topic="persistent://public/default/my-dlq")
-    policy = instance.get_dead_letter_policy(pulsar._pulsar.ConsumerType.Shared)
+    policy = instance.get_dead_letter_policy()
 
     self.assertIsNotNone(policy)
     self.assertEqual(3, policy.max_redeliver_count)
@@ -188,38 +192,33 @@ class TestDeadLetterPolicy(unittest.TestCase):
     # The Java runtime only sets the topic when non-empty, leaving the client to derive
     # "<topic>-<subscription>-DLQ". Passing "" through would override that with an invalid name.
     instance = self._instance(max_message_retries=2)
-    policy = instance.get_dead_letter_policy(pulsar._pulsar.ConsumerType.Shared)
+    policy = instance.get_dead_letter_policy()
 
     self.assertIsNotNone(policy)
     self.assertEqual(2, policy.max_redeliver_count)
 
-  def test_zero_retries_attaches_no_policy(self):
-    # Java accepts maxMessageRetries >= 0, but ConsumerDeadLetterPolicy rejects a redelivery count
-    # below 1, so zero cannot be expressed here. It must not raise and take the instance down.
+  def test_zero_retries_fails_fast(self):
+    # Java does not start with this value either: PulsarSource forwards 0 and
+    # ConsumerBuilderImpl.deadLetterPolicy rejects "MaxRedeliverCount must be > 0". Returning None
+    # here instead would let localrun - which bypasses validateNonJavaFunction - start with retries
+    # silently disabled while Java fails.
     instance = self._instance(max_message_retries=0,
                               dead_letter_topic="persistent://public/default/my-dlq")
-    self.assertIsNone(
-      instance.get_dead_letter_policy(pulsar._pulsar.ConsumerType.Shared))
+    with self.assertRaises(ValueError):
+      instance.get_dead_letter_policy()
 
-  def test_negative_retries_attaches_no_policy(self):
+  def test_negative_retries_fails_fast(self):
     instance = self._instance(max_message_retries=-1)
-    self.assertIsNone(
-      instance.get_dead_letter_policy(pulsar._pulsar.ConsumerType.Shared))
+    with self.assertRaises(ValueError):
+      instance.get_dead_letter_policy()
 
-  def test_key_shared_subscription_gets_policy(self):
-    instance = self._instance(max_message_retries=3)
-    self.assertIsNotNone(
-      instance.get_dead_letter_policy(pulsar._pulsar.ConsumerType.KeyShared))
-
-  def test_failover_subscription_gets_no_policy(self):
-    # A dead letter policy has no effect on Failover, which retainOrdering and EFFECTIVELY_ONCE
-    # both select. Returning None keeps that explicit rather than silently ineffective.
+  def test_policy_is_not_gated_on_subscription_type(self):
+    # Subscription-type support is a client concern; the Java runtime always forwards a configured
+    # policy. Gating here would add a second support matrix that can drift from the client.
     instance = self._instance(max_message_retries=3,
                               dead_letter_topic="persistent://public/default/my-dlq")
-    self.assertIsNone(
-      instance.get_dead_letter_policy(pulsar._pulsar.ConsumerType.Failover))
+    policy = instance.get_dead_letter_policy()
 
-  def test_exclusive_subscription_gets_no_policy(self):
-    instance = self._instance(max_message_retries=3)
-    self.assertIsNone(
-      instance.get_dead_letter_policy(pulsar._pulsar.ConsumerType.Exclusive))
+    self.assertIsNotNone(policy)
+    self.assertEqual(3, policy.max_redeliver_count)
+

--- a/pulsar-functions/instance/src/test/python/test_python_instance.py
+++ b/pulsar-functions/instance/src/test/python/test_python_instance.py
@@ -32,7 +32,6 @@ sys.modules['bookkeeper.proto.stream_pb2'] = Mock()
 
 from contextimpl import ContextImpl
 from python_instance import PythonInstance, InstanceConfig
-import pulsar
 from pulsar import Message
 
 import Function_pb2
@@ -398,6 +397,77 @@ class TestNegativeAckRedeliveryDelay(unittest.TestCase):
     self.assertIsInstance(args, dict)
     self.assertEqual(["negative_ack_redelivery_delay_ms"], list(args.keys()))
 
+class TestConsumerSubscribeArgs(unittest.TestCase):
+  """The dead letter policy must actually reach Client.subscribe().
+
+  get_dead_letter_policy() returning the right object is only half of it: setup_consumers()
+  subscribes on two paths - source.topicsToSerDeClassName and source.inputSpecs, the latter also
+  covering the regex variant - and the policy has to reach the client on each. Without this, the
+  policy could be dropped from one call site, or passed under a keyword the client does not accept,
+  and the rest of the suite would stay green.
+  """
+
+  def _subscribe_kwargs(self, max_message_retries=None, dead_letter_topic=None,
+                        via_input_specs=False, regex=False):
+    function_details = Function_pb2.FunctionDetails()
+    function_details.sink.topic = "test_sink_topic"
+    if max_message_retries is not None:
+      function_details.retryDetails.maxMessageRetries = max_message_retries
+    if dead_letter_topic is not None:
+      function_details.retryDetails.deadLetterTopic = dead_letter_topic
+
+    topic = "persistent://public/default/.*" if regex else "persistent://public/default/in"
+    if via_input_specs:
+      consumer_conf = function_details.source.inputSpecs[topic]
+      consumer_conf.isRegexPattern = regex
+    else:
+      function_details.source.topicsToSerDeClassName[topic] = ""
+
+    mock_pulsar_client = Mock()
+    instance = PythonInstance('test_instance', 'test_func', '1.0', function_details, 100, 30,
+                              'user_code', mock_pulsar_client, Mock(), 'test_cluster', 'test_url',
+                              None)
+    instance.get_schema = Mock(return_value="DEFAULT_SCHEMA")
+    instance.get_crypto_reader = Mock(return_value=None)
+    instance.setup_consumers()
+
+    self.assertEqual(1, mock_pulsar_client.subscribe.call_count)
+    _, kwargs = mock_pulsar_client.subscribe.call_args
+    return kwargs
+
+  def test_policy_reaches_the_topics_to_serde_path(self):
+    kwargs = self._subscribe_kwargs(max_message_retries=3,
+                                    dead_letter_topic="persistent://public/default/my-dlq")
+
+    policy = kwargs["dead_letter_policy"]
+    self.assertEqual(3, policy.max_redeliver_count)
+    self.assertEqual("persistent://public/default/my-dlq", policy.dead_letter_topic)
+
+  def test_policy_reaches_the_input_specs_path(self):
+    kwargs = self._subscribe_kwargs(max_message_retries=3,
+                                    dead_letter_topic="persistent://public/default/my-dlq",
+                                    via_input_specs=True)
+
+    policy = kwargs["dead_letter_policy"]
+    self.assertEqual(3, policy.max_redeliver_count)
+    self.assertEqual("persistent://public/default/my-dlq", policy.dead_letter_topic)
+
+  def test_policy_reaches_the_regex_path(self):
+    kwargs = self._subscribe_kwargs(max_message_retries=3,
+                                    dead_letter_topic="persistent://public/default/my-dlq",
+                                    via_input_specs=True, regex=True)
+
+    self.assertEqual(3, kwargs["dead_letter_policy"].max_redeliver_count)
+
+  def test_keyword_is_passed_as_none_without_retry_details(self):
+    # The keyword is always passed, so the runtime requires pulsar-client-python 3.3.0 or newer -
+    # see README.md. Client.subscribe() guards with "if dead_letter_policy:", so None is a no-op
+    # there. Both paths must agree on this; one of them dropping the keyword would be the kind of
+    # drift this class exists to catch.
+    self.assertIsNone(self._subscribe_kwargs()["dead_letter_policy"])
+    self.assertIsNone(self._subscribe_kwargs(via_input_specs=True)["dead_letter_policy"])
+
+
 class TestDeadLetterPolicy(unittest.TestCase):
   """Covers FunctionDetails.retryDetails -> ConsumerDeadLetterPolicy.
 
@@ -411,13 +481,15 @@ class TestDeadLetterPolicy(unittest.TestCase):
   gate on it.
   """
 
-  def _instance(self, max_message_retries=None, dead_letter_topic=None):
+  def _instance(self, max_message_retries=None, dead_letter_topic=None, configure=None):
     function_details = Function_pb2.FunctionDetails()
     function_details.sink.topic = "test_sink_topic"
     if max_message_retries is not None:
       function_details.retryDetails.maxMessageRetries = max_message_retries
     if dead_letter_topic is not None:
       function_details.retryDetails.deadLetterTopic = dead_letter_topic
+    if configure is not None:
+      configure(function_details)
 
     return PythonInstance('test_instance', 'test_func', '1.0', function_details, 100, 30,
                           'user_code', Mock(), Mock(), 'test_cluster', 'test_url', None)
@@ -436,13 +508,21 @@ class TestDeadLetterPolicy(unittest.TestCase):
     self.assertEqual("persistent://public/default/my-dlq", policy.dead_letter_topic)
 
   def test_empty_dead_letter_topic_defers_to_client_default(self):
-    # The Java runtime only sets the topic when non-empty, leaving the client to derive
-    # "<topic>-<subscription>-DLQ". Passing "" through would override that with an invalid name.
+    # An unset deadLetterTopic reads as "" from the proto and is forwarded as configured. The
+    # client treats an empty topic as unset: ConsumerDeadLetterPolicy skips the builder call only
+    # for None, and DeadLetterPolicyBuilder.deadLetterTopic("") leaves getDeadLetterTopic() == "",
+    # which is exactly what an unset policy reports. Either way the client derives
+    # "<topic>-<subscription>-DLQ".
+    #
+    # So what is pinned here is the runtime's half of that: retryDetails without a topic still
+    # produces a policy carrying the redelivery count, and the runtime does not invent a DLQ name
+    # of its own.
     instance = self._instance(max_message_retries=2)
     policy = instance.get_dead_letter_policy()
 
     self.assertIsNotNone(policy)
     self.assertEqual(2, policy.max_redeliver_count)
+    self.assertEqual("", policy.dead_letter_topic)
 
   def test_zero_retries_fails_fast(self):
     # Java does not start with this value either: PulsarSource forwards 0 and
@@ -462,10 +542,35 @@ class TestDeadLetterPolicy(unittest.TestCase):
   def test_policy_is_not_gated_on_subscription_type(self):
     # Subscription-type support is a client concern; the Java runtime always forwards a configured
     # policy. Gating here would add a second support matrix that can drift from the client.
-    instance = self._instance(max_message_retries=3,
-                              dead_letter_topic="persistent://public/default/my-dlq")
-    policy = instance.get_dead_letter_policy()
+    #
+    # Each case below is one the earlier revision's gate suppressed the policy for. run() derives
+    # the consumer type from FunctionDetails - retainOrdering, EFFECTIVELY_ONCE and a FAILOVER
+    # subscriptionType each select Failover, and retainKeyOrdering selects KeyShared - so a gate
+    # reintroduced here would have to read one of these, and would fail this test. A default
+    # instance selects Shared, which the gate allowed, so it cannot pin this on its own.
+    def retain_ordering(details):
+      details.retainOrdering = True
 
-    self.assertIsNotNone(policy)
-    self.assertEqual(3, policy.max_redeliver_count)
+    def effectively_once(details):
+      details.processingGuarantees = Function_pb2.ProcessingGuarantees.Value("EFFECTIVELY_ONCE")
+
+    def failover_subscription(details):
+      details.source.subscriptionType = Function_pb2.SubscriptionType.Value("FAILOVER")
+
+    def retain_key_ordering(details):
+      details.retainKeyOrdering = True
+
+    for label, configure in (("retainOrdering", retain_ordering),
+                             ("EFFECTIVELY_ONCE", effectively_once),
+                             ("FAILOVER subscriptionType", failover_subscription),
+                             ("retainKeyOrdering", retain_key_ordering)):
+      with self.subTest(selects_consumer_type_via=label):
+        instance = self._instance(max_message_retries=3,
+                                  dead_letter_topic="persistent://public/default/my-dlq",
+                                  configure=configure)
+        policy = instance.get_dead_letter_policy()
+
+        self.assertIsNotNone(policy)
+        self.assertEqual(3, policy.max_redeliver_count)
+        self.assertEqual("persistent://public/default/my-dlq", policy.dead_letter_topic)
 

--- a/pulsar-functions/instance/src/test/python/test_python_instance.py
+++ b/pulsar-functions/instance/src/test/python/test_python_instance.py
@@ -32,6 +32,7 @@ sys.modules['bookkeeper.proto.stream_pb2'] = Mock()
 
 from contextimpl import ContextImpl
 from python_instance import PythonInstance, InstanceConfig
+import pulsar
 from pulsar import Message
 
 import Function_pb2
@@ -149,3 +150,76 @@ class TestPropertiesForwarding(unittest.TestCase):
     self.assertNotIn("custom-key", kwargs['properties'])
     self.assertIn("__pfn_input_topic__", kwargs['properties'])
 
+
+class TestDeadLetterPolicy(unittest.TestCase):
+  """Covers FunctionDetails.retryDetails -> ConsumerDeadLetterPolicy.
+
+  The Java runtime applies these in JavaInstanceRunnable (guarded on hasRetryDetails) and
+  PulsarSource (maxMessageRetries >= 0, deadLetterTopic only when non-empty). The Python runtime
+  previously ignored retryDetails entirely.
+  """
+
+  def _instance(self, max_message_retries=None, dead_letter_topic=None):
+    function_details = Function_pb2.FunctionDetails()
+    function_details.sink.topic = "test_sink_topic"
+    if max_message_retries is not None:
+      function_details.retryDetails.maxMessageRetries = max_message_retries
+    if dead_letter_topic is not None:
+      function_details.retryDetails.deadLetterTopic = dead_letter_topic
+
+    return PythonInstance('test_instance', 'test_func', '1.0', function_details, 100, 30,
+                          'user_code', Mock(), Mock(), 'test_cluster', 'test_url', None)
+
+  def test_no_retry_details_means_no_policy(self):
+    instance = self._instance()
+    self.assertIsNone(
+      instance.get_dead_letter_policy(pulsar._pulsar.ConsumerType.Shared))
+
+  def test_policy_built_from_retry_details(self):
+    instance = self._instance(max_message_retries=3,
+                              dead_letter_topic="persistent://public/default/my-dlq")
+    policy = instance.get_dead_letter_policy(pulsar._pulsar.ConsumerType.Shared)
+
+    self.assertIsNotNone(policy)
+    self.assertEqual(3, policy.max_redeliver_count)
+    self.assertEqual("persistent://public/default/my-dlq", policy.dead_letter_topic)
+
+  def test_empty_dead_letter_topic_defers_to_client_default(self):
+    # The Java runtime only sets the topic when non-empty, leaving the client to derive
+    # "<topic>-<subscription>-DLQ". Passing "" through would override that with an invalid name.
+    instance = self._instance(max_message_retries=2)
+    policy = instance.get_dead_letter_policy(pulsar._pulsar.ConsumerType.Shared)
+
+    self.assertIsNotNone(policy)
+    self.assertEqual(2, policy.max_redeliver_count)
+
+  def test_zero_retries_attaches_no_policy(self):
+    # Java accepts maxMessageRetries >= 0, but ConsumerDeadLetterPolicy rejects a redelivery count
+    # below 1, so zero cannot be expressed here. It must not raise and take the instance down.
+    instance = self._instance(max_message_retries=0,
+                              dead_letter_topic="persistent://public/default/my-dlq")
+    self.assertIsNone(
+      instance.get_dead_letter_policy(pulsar._pulsar.ConsumerType.Shared))
+
+  def test_negative_retries_attaches_no_policy(self):
+    instance = self._instance(max_message_retries=-1)
+    self.assertIsNone(
+      instance.get_dead_letter_policy(pulsar._pulsar.ConsumerType.Shared))
+
+  def test_key_shared_subscription_gets_policy(self):
+    instance = self._instance(max_message_retries=3)
+    self.assertIsNotNone(
+      instance.get_dead_letter_policy(pulsar._pulsar.ConsumerType.KeyShared))
+
+  def test_failover_subscription_gets_no_policy(self):
+    # A dead letter policy has no effect on Failover, which retainOrdering and EFFECTIVELY_ONCE
+    # both select. Returning None keeps that explicit rather than silently ineffective.
+    instance = self._instance(max_message_retries=3,
+                              dead_letter_topic="persistent://public/default/my-dlq")
+    self.assertIsNone(
+      instance.get_dead_letter_policy(pulsar._pulsar.ConsumerType.Failover))
+
+  def test_exclusive_subscription_gets_no_policy(self):
+    instance = self._instance(max_message_retries=3)
+    self.assertIsNone(
+      instance.get_dead_letter_policy(pulsar._pulsar.ConsumerType.Exclusive))

--- a/pulsar-functions/instance/src/test/python/test_python_instance.py
+++ b/pulsar-functions/instance/src/test/python/test_python_instance.py
@@ -408,9 +408,11 @@ class TestConsumerSubscribeArgs(unittest.TestCase):
   """
 
   def _subscribe_kwargs(self, max_message_retries=None, dead_letter_topic=None,
-                        via_input_specs=False, regex=False):
+                        via_input_specs=False, regex=False, configure=None):
     function_details = Function_pb2.FunctionDetails()
     function_details.sink.topic = "test_sink_topic"
+    if configure is not None:
+      configure(function_details)
     if max_message_retries is not None:
       function_details.retryDetails.maxMessageRetries = max_message_retries
     if dead_letter_topic is not None:
@@ -458,6 +460,43 @@ class TestConsumerSubscribeArgs(unittest.TestCase):
                                     via_input_specs=True, regex=True)
 
     self.assertEqual(3, kwargs["dead_letter_policy"].max_redeliver_count)
+
+  def test_policy_reaches_subscribe_for_a_non_shared_consumer_type(self):
+    # setup_consumers() derives the consumer type two lines above the policy, so this is where a
+    # subscription-type gate would go now that get_dead_letter_policy() no longer sees one - and
+    # TestDeadLetterPolicy's own tests cannot see it there.
+    #
+    # Every other FunctionDetails in this class leaves retainOrdering, retainKeyOrdering,
+    # processingGuarantees and source.subscriptionType at their proto defaults, so mode is always
+    # Shared - precisely the value such a gate would let through. Each case below drives mode to
+    # something else: retainOrdering, EFFECTIVELY_ONCE and a FAILOVER subscriptionType select
+    # Failover, retainKeyOrdering selects KeyShared. Covering both non-default modes pins the
+    # intent against any gate shape, not just one that happens to spare KeyShared.
+    def retain_ordering(details):
+      details.retainOrdering = True
+
+    def effectively_once(details):
+      details.processingGuarantees = Function_pb2.ProcessingGuarantees.Value("EFFECTIVELY_ONCE")
+
+    def failover_subscription(details):
+      details.source.subscriptionType = Function_pb2.SubscriptionType.Value("FAILOVER")
+
+    def retain_key_ordering(details):
+      details.retainKeyOrdering = True
+
+    for label, configure in (("retainOrdering", retain_ordering),
+                             ("EFFECTIVELY_ONCE", effectively_once),
+                             ("FAILOVER subscriptionType", failover_subscription),
+                             ("retainKeyOrdering", retain_key_ordering)):
+      with self.subTest(selects_consumer_type_via=label):
+        kwargs = self._subscribe_kwargs(max_message_retries=3,
+                                        dead_letter_topic="persistent://public/default/my-dlq",
+                                        configure=configure)
+
+        policy = kwargs["dead_letter_policy"]
+        self.assertIsNotNone(policy)
+        self.assertEqual(3, policy.max_redeliver_count)
+        self.assertEqual("persistent://public/default/my-dlq", policy.dead_letter_topic)
 
   def test_keyword_is_passed_as_none_without_retry_details(self):
     # The keyword is always passed, so the runtime requires pulsar-client-python 3.3.0 or newer -

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
@@ -757,8 +757,15 @@ public class FunctionConfigUtils {
             throw new IllegalArgumentException("There is currently no support windowing in python");
         }
 
-        if (functionConfig.getMaxMessageRetries() != null && functionConfig.getMaxMessageRetries() >= 0) {
-            throw new IllegalArgumentException("Message retries not yet supported in python");
+        // The Python runtime honours FunctionDetails.retryDetails, so message retries and a dead letter
+        // topic are no longer refused outright. Zero is still refused: it asks for no redelivery at all
+        // before the dead letter topic, and the Python client cannot express that -- ConsumerDeadLetterPolicy
+        // requires a maxRedeliverCount of at least 1. Accepting it would create a function whose dead letter
+        // topic never receives anything, which is the silently ineffective configuration this support was
+        // added to remove. A negative value leaves retries unset, as it does on the Java path.
+        if (functionConfig.getMaxMessageRetries() != null && functionConfig.getMaxMessageRetries() == 0) {
+            throw new IllegalArgumentException("maxMessageRetries must be at least 1 in python; the Python "
+                    + "client cannot express a redelivery count of 0");
         }
     }
 

--- a/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/FunctionConfigUtilsTest.java
+++ b/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/FunctionConfigUtilsTest.java
@@ -562,13 +562,28 @@ public class FunctionConfigUtilsTest {
         FunctionConfigUtils.validateNonJavaFunction(functionConfig);
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class,
-            expectedExceptionsMessageRegExp = "Message retries not yet supported in Go function")
-    public void testGoFunctionStillRejectsMessageRetries() {
-        // The Go runtime does not honour retryDetails yet, so its guard stays until it does.
+    @Test
+    public void testPythonFunctionTreatsNegativeMessageRetriesAsUnset() {
+        // doPythonChecks refuses exactly 0; a negative count means "unset", as it does on the Java path,
+        // and convert() emits retryDetails only for a count >= 0. Pinned so tightening that guard to <= 0
+        // cannot pass silently.
         FunctionConfig functionConfig = createPythonFunctionConfig();
-        functionConfig.setRuntime(FunctionConfig.Runtime.GO);
-        functionConfig.setMaxMessageRetries(3);
+        functionConfig.setMaxMessageRetries(-1);
+
+        FunctionConfigUtils.validateNonJavaFunction(functionConfig);
+
+        assertFalse(FunctionConfigUtils.convert(functionConfig).hasRetryDetails());
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class,
+            expectedExceptionsMessageRegExp = "Dead Letter Topic specified, however max retries is set to infinity")
+    public void testPythonFunctionRejectsDeadLetterTopicWithoutMessageRetries() {
+        // doCommonChecks refuses a dead letter topic nothing can route to: with maxMessageRetries unset the
+        // redelivery count is infinite, so the topic would never receive anything. Same shape as the zero
+        // case above, reached from the other side.
+        FunctionConfig functionConfig = createPythonFunctionConfig();
+        functionConfig.setDeadLetterTopic("test-dlq");
+
         FunctionConfigUtils.validateNonJavaFunction(functionConfig);
     }
 
@@ -868,8 +883,20 @@ public class FunctionConfigUtilsTest {
     @Test(expectedExceptions = IllegalArgumentException.class,
             expectedExceptionsMessageRegExp = "Message retries not yet supported in Go function")
     public void testGoFunctionStillRejectsMessageRetries() {
+        // The Go runtime does not honour retryDetails yet, so its guard stays until it does.
         FunctionConfig functionConfig = minimalGoFunctionConfig();
         functionConfig.setMaxMessageRetries(3);
+
+        FunctionConfigUtils.validateNonJavaFunction(functionConfig);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class,
+            expectedExceptionsMessageRegExp = "Message retries not yet supported in Go function")
+    public void testGoFunctionRejectsZeroMessageRetries() {
+        // doGolangChecks refuses every count >= 0, not only a positive one -- unlike Python, which refuses
+        // only 0. Pinned so the two guards cannot be quietly aligned.
+        FunctionConfig functionConfig = minimalGoFunctionConfig();
+        functionConfig.setMaxMessageRetries(0);
 
         FunctionConfigUtils.validateNonJavaFunction(functionConfig);
     }

--- a/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/FunctionConfigUtilsTest.java
+++ b/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/FunctionConfigUtilsTest.java
@@ -533,6 +533,49 @@ public class FunctionConfigUtilsTest {
     }
 
     @SuppressWarnings("deprecation")
+    @Test
+    public void testPythonFunctionAcceptsMessageRetriesAndDeadLetterTopic() {
+        FunctionConfig functionConfig = createPythonFunctionConfig();
+        functionConfig.setMaxMessageRetries(3);
+        functionConfig.setDeadLetterTopic("test-dlq");
+        FunctionConfigUtils.validateNonJavaFunction(functionConfig);
+    }
+
+    @Test
+    public void testPythonFunctionAcceptsMessageRetriesWithoutADeadLetterTopic() {
+        // The client defaults the topic to "<topic>-<subscription>-DLQ" when it is left empty.
+        FunctionConfig functionConfig = createPythonFunctionConfig();
+        functionConfig.setMaxMessageRetries(1);
+        FunctionConfigUtils.validateNonJavaFunction(functionConfig);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class,
+            expectedExceptionsMessageRegExp = "maxMessageRetries must be at least 1 in python.*")
+    public void testPythonFunctionRejectsZeroMessageRetries() {
+        // Zero asks for no redelivery before the dead letter topic, which the Python client cannot
+        // express, so the dead letter topic would never receive anything.
+        FunctionConfig functionConfig = createPythonFunctionConfig();
+        functionConfig.setMaxMessageRetries(0);
+        functionConfig.setDeadLetterTopic("test-dlq");
+        FunctionConfigUtils.validateNonJavaFunction(functionConfig);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class,
+            expectedExceptionsMessageRegExp = "Message retries not yet supported in Go function")
+    public void testGoFunctionStillRejectsMessageRetries() {
+        // The Go runtime does not honour retryDetails yet, so its guard stays until it does.
+        FunctionConfig functionConfig = createPythonFunctionConfig();
+        functionConfig.setRuntime(FunctionConfig.Runtime.GO);
+        functionConfig.setMaxMessageRetries(3);
+        FunctionConfigUtils.validateNonJavaFunction(functionConfig);
+    }
+
+    private FunctionConfig createPythonFunctionConfig() {
+        FunctionConfig functionConfig = createFunctionConfig();
+        functionConfig.setRuntime(FunctionConfig.Runtime.PYTHON);
+        return functionConfig;
+    }
+
     private FunctionConfig createFunctionConfig() {
         FunctionConfig functionConfig = new FunctionConfig();
         functionConfig.setTenant("test-tenant");

--- a/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/FunctionConfigUtilsTest.java
+++ b/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/FunctionConfigUtilsTest.java
@@ -534,7 +534,6 @@ public class FunctionConfigUtilsTest {
         );
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void testPythonFunctionAcceptsMessageRetriesAndDeadLetterTopic() {
         FunctionConfig functionConfig = createPythonFunctionConfig();
@@ -593,6 +592,7 @@ public class FunctionConfigUtilsTest {
         return functionConfig;
     }
 
+    @SuppressWarnings("deprecation")
     private FunctionConfig createFunctionConfig() {
         FunctionConfig functionConfig = new FunctionConfig();
         functionConfig.setTenant("test-tenant");


### PR DESCRIPTION
Fixes #26397

### Motivation

`FunctionConfig` accepts `maxMessageRetries` and `deadLetterTopic`, both are carried into the instance as `FunctionDetails.retryDetails` (`Function.proto` L58-61, L91), and the Java runtime applies them. **The Python runtime ignored them entirely** — `grep -i "dead_letter\|retryDetails" python_instance.py` returned nothing on master.

The failure mode is silent, which is the damaging part. This is accepted without warning:

```
pulsar-admin functions create --py fn.py --classname fn.F \
  --dead-letter-topic persistent://public/default/my-dlq \
  --max-message-retries 3 ...
```

`functions get` reports the configuration back faithfully, and at runtime nothing is ever routed to the DLQ.

**Teaching the runtime to honour `retryDetails` is necessary but not sufficient.** Two gates in `FunctionConfigUtils` line up exactly and, between them, keep a Python function from ever reaching a `retryDetails` message on the cluster path:

- `doPythonChecks` refuses any `maxMessageRetries >= 0` outright ("Message retries not yet supported in python").
- `convert` only populates `retryDetails` when `maxMessageRetries != null && >= 0` (L304) — the very condition `doPythonChecks` rejects. So `--dead-letter-topic` on its own never produces a `retryDetails` message at all, and the runtime has nothing to honour.

`validateNonJavaFunction` has a single caller, the worker REST API (`FunctionsImpl`), so this refusal applies to cluster submission only. `LocalRunner` never calls it, which is why the runtime path is reachable under `localrun` today and nowhere else. Fixing only the runtime would ship a fix that no user could invoke.

### Modifications

**Runtime (`python_instance.py`).** Add `get_dead_letter_policy()` to `PythonInstance` and pass its result to all three `subscribe()` call sites in `run()` — the `topicsToSerDeClassName` loop and both branches of the `inputSpecs` loop.

The rules follow the Java runtime:

- Guard on `HasField("retryDetails")`, matching `JavaInstanceRunnable`'s `hasRetryDetails()` check. `HasField` is already the idiom in this file (used for `receiverQueueSize`).
- Set the dead letter topic only when non-empty, matching `PulsarSource`, so the client derives its `<topic>-<subscription>-DLQ` default rather than receiving an empty name.

**Validation (`FunctionConfigUtils.doPythonChecks`).** Replace the blanket refusal with a narrow one on zero.

Zero asks for no redelivery at all before the dead letter topic, and the Python client cannot express it: `ConsumerDeadLetterPolicy` requires a `maxRedeliverCount` of at least 1 ([`pulsar/__init__.py` L761-762](https://github.com/apache/pulsar-client-python/blob/main/pulsar/__init__.py)). Accepting it would create a function whose dead letter topic never receives anything — precisely the silently ineffective configuration this change exists to remove — so it is rejected at creation, where the mistake is still cheap to fix, rather than warned about in an instance log nobody reads. A negative value leaves retries unset, as on the Java path.

**CLI metadata (`CmdFunctions`).** The `@Option` descriptions carry a runtime marker that the docs sync parses into the **Support** column of the published [pulsar-admin CLI reference](https://pulsar.apache.org/reference/), and that `pulsar-admin functions create --help` prints verbatim. `--max-message-retries` and `--dead-letter-topic` were both marked `#Java`; they are now `#Java, Python`.

`doGolangChecks` keeps its guard: the Go runtime does not honour `retryDetails` yet, and a test now pins that so this cannot be widened to Go by accident.

The pre-existing cross-cutting checks in `doCommonChecks` still apply to Python and cover the rest of the space: a dead letter topic with retries unset is refused ("Dead Letter Topic specified, however max retries is set to infinity"), as is `maxMessageRetries` combined with `EFFECTIVELY_ONCE`.

**Two runtime cases still cannot mirror Java exactly**, and both **warn** rather than failing the instance or silently doing nothing:

1. **`maxMessageRetries == 0`.** Now rejected at creation on the cluster path, but still reachable under `localrun`, which skips `validateNonJavaFunction`. Attaching no policy is the only available behaviour there; the warning names the dead letter topic that will not receive messages. Raising would take down a function the Java runtime would have started.
2. **Non-Shared subscriptions.** A dead letter policy only takes effect on `Shared` and `KeyShared`. `retainOrdering` and `EFFECTIVELY_ONCE` both select `Failover`, where the policy would be silently ineffective — the same class of bug as this issue — so that combination warns as well.

I did not change the Java-side `>= 0` behaviour or the client's `>= 1` constraint; reconciling them is a larger discussion than this fix.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- **8 unit tests** in `test_python_instance.py` (`TestDeadLetterPolicy`), covering: no `retryDetails` → no policy; a policy built from `retryDetails`; an empty dead letter topic deferring to the client default; `maxMessageRetries` of 0 and of -1 attaching no policy rather than raising; `KeyShared` receiving a policy; `Failover` and `Exclusive` not.
- **4 unit tests** in `FunctionConfigUtilsTest.java`: Python accepts retries with and without an explicit dead letter topic, rejects zero with the new message, and Go still refuses retries.
- Full Python file: 12/12 pass via `pulsar-functions/instance/src/scripts/run_python_instance_tests.sh`. `FunctionConfigUtilsTest`: 41/41 pass.
- Confirmed the Python tests are not vacuous: making `get_dead_letter_policy()` return `None` unconditionally fails 3 of them.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints

A function that does not set `retryDetails` is unaffected: `get_dead_letter_policy()` returns `None` and `dead_letter_policy=None` is what the client already defaults to.

The validation change is **relaxing** only: configurations that were accepted before are still accepted. The one newly-rejected input, `maxMessageRetries == 0` on a Python function, was previously rejected too, by the broader guard this replaces — no configuration that used to be creatable stops being creatable.

### Documentation

- [x] `doc-required`

`docs/functions-cli.md` in [apache/pulsar-site](https://github.com/apache/pulsar-site) documents `maxMessageRetries` and `deadLetterTopic` with no runtime qualification, so the table needs a note that Java and Python honour them (Python requiring at least `1`) while Go does not. That table is hand-maintained, so it needs its own PR there; the `#Java, Python` marker above covers the generated CLI reference from this side.

For the record, the note added when #6084 was closed in 2020 -- "This parameter is not supported in Python Functions" -- is **no longer present** in the current docs. It survives only in `versioned_docs/version-2.3.0` through `version-2.10.x`, where it was accurate for those releases and should stay; it was dropped from the live docs in the 2.11 `functions-cli.md` rewrite. So there is no incorrect statement to retract, only a missing caveat to add.

I have not opened the apache/pulsar-site PR yet -- flagging it so it is not lost, and happy to open it once the behaviour here is settled in review.
