### PR TITLE
[fix][admin] PIP-478: build() must not share the builder's configuration

### DIFF
--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/PulsarAdminBuilderImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/PulsarAdminBuilderImpl.java
@@ -47,7 +47,7 @@ public class PulsarAdminBuilderImpl implements PulsarAdminBuilder {
 
     @Override
     public PulsarAdmin build() throws PulsarClientException {
-        return new PulsarAdminImpl(conf.getServiceUrl(), conf,
+        return new PulsarAdminImpl(conf.getServiceUrl(), conf.clone(),
                 clientBuilderClassLoader, acceptGzipCompression, sharedResources);
     }
 


### PR DESCRIPTION
Fixes #26398

`PulsarAdminBuilderImpl.build()` hands the builder's own `ClientConfigurationData`
to `PulsarAdminImpl`, which folds the OAuth2 IdP TLS policy into its TLS policy
map (`foldOAuth2IdpPolicy`). The first `build()` installs a `CLIENT_OAUTH2` entry
that stays reachable from the builder, so a second `build()` with different
OAuth2 credentials resolves against the first IdP's trust material — the wrong
private CA or mTLS client key, silently.

### Fix

Hand the admin a clone of the configuration (`conf.clone()`), matching the
client builder pattern applied in #26326.

**1 line, +1/-1.**