### PR TITLE
[fix][fn] Honour negativeAckRedeliveryDelayMs in the Python function runtime

### DIFF
--- a/pulsar-functions/instance/src/main/python/python_instance.py
+++ b/pulsar-functions/instance/src/main/python/python_instance.py
@@ -150,6 +150,8 @@ class PythonInstance(object):
     elif self.instance_config.function_details.retainKeyOrdering:
       mode = pulsar._pulsar.ConsumerType.KeyShared
 
+    nack_args = self.get_negative_ack_args()
+
     position = pulsar._pulsar.InitialPosition.Latest
     if self.instance_config.function_details.source.subscriptionPosition == Function_pb2.SubscriptionPosition.Value("EARLIEST"):
       position = pulsar._pulsar.InitialPosition.Earliest
@@ -181,7 +183,8 @@ class PythonInstance(object):
         message_listener=partial(self.message_listener, self.input_serdes[topic], DEFAULT_SCHEMA),
         unacked_messages_timeout_ms=int(self.timeout_ms) if self.timeout_ms else None,
         initial_position=position,
-        properties=properties
+        properties=properties,
+        **nack_args
       )
 
     for topic, consumer_conf in self.instance_config.function_details.source.inputSpecs.items():
@@ -207,6 +210,7 @@ class PythonInstance(object):
         "properties": properties,
         "crypto_key_reader": crypto_key_reader
       }
+      consumer_args.update(nack_args)
       if consumer_conf.HasField("receiverQueueSize"):
         consumer_args["receiver_queue_size"] = consumer_conf.receiverQueueSize.value
 
@@ -584,6 +588,26 @@ class PythonInstance(object):
         except:
           pass
       return record_kclass
+  def get_negative_ack_args(self):
+    """Build the negative-ack redelivery delay argument for Client.subscribe().
+
+    Returns a dict to splat into the subscribe() call: either empty, or carrying
+    negative_ack_redelivery_delay_ms.
+
+    SourceSpec.negativeAckRedeliveryDelayMs is a proto3 scalar with no presence, so an unset field
+    reads as 0. Only a positive value is forwarded, leaving the client default (60s) in place
+    otherwise - the same guard the Java runtime applies in JavaInstanceRunnable.
+
+    The argument is omitted rather than passed as None because subscribe() validates it with
+    _check_type(int, ...) rather than _check_type_or_none, so None would fail for every function
+    that does not configure it.
+    """
+    delay_ms = self.instance_config.function_details.source.negativeAckRedeliveryDelayMs
+    if delay_ms <= 0:
+      return {}
+
+    return {"negative_ack_redelivery_delay_ms": delay_ms}
+
   def get_crypto_reader(self, crypto_spec):
     crypto_key_reader = None
     if crypto_spec is not None:

--- a/pulsar-functions/instance/src/test/python/test_python_instance.py
+++ b/pulsar-functions/instance/src/test/python/test_python_instance.py
@@ -149,3 +149,39 @@ class TestPropertiesForwarding(unittest.TestCase):
     self.assertNotIn("custom-key", kwargs['properties'])
     self.assertIn("__pfn_input_topic__", kwargs['properties'])
 
+
+class TestNegativeAckRedeliveryDelay(unittest.TestCase):
+  """Covers SourceSpec.negativeAckRedeliveryDelayMs reaching the consumer.
+
+  The runtime negatively acknowledges on failure but never configured the delay, so the client
+  default of 60s always applied. The Java runtime guards on > 0 in JavaInstanceRunnable.
+  """
+
+  def _instance(self, delay_ms=None):
+    function_details = Function_pb2.FunctionDetails()
+    function_details.sink.topic = "test_sink_topic"
+    if delay_ms is not None:
+      function_details.source.negativeAckRedeliveryDelayMs = delay_ms
+
+    return PythonInstance('test_instance', 'test_func', '1.0', function_details, 100, 30,
+                          'user_code', Mock(), Mock(), 'test_cluster', 'test_url', None)
+
+  def test_positive_delay_is_forwarded(self):
+    args = self._instance(delay_ms=5000).get_negative_ack_args()
+    self.assertEqual({"negative_ack_redelivery_delay_ms": 5000}, args)
+
+  def test_unset_delay_is_omitted(self):
+    # proto3 scalar with no presence: unset reads as 0. The argument must be omitted rather than
+    # sent - subscribe() validates it with _check_type(int), so None would fail for every function
+    # that does not set it, and 0 would mean immediate redelivery instead of the 60s default.
+    self.assertEqual({}, self._instance().get_negative_ack_args())
+
+  def test_explicit_zero_is_omitted(self):
+    self.assertEqual({}, self._instance(delay_ms=0).get_negative_ack_args())
+
+  def test_result_is_splattable_into_subscribe_kwargs(self):
+    # The value is consumed via **nack_args and consumer_args.update(...), so it must be a dict
+    # with exactly the keyword subscribe() expects.
+    args = self._instance(delay_ms=250).get_negative_ack_args()
+    self.assertIsInstance(args, dict)
+    self.assertEqual(["negative_ack_redelivery_delay_ms"], list(args.keys()))


### PR DESCRIPTION
Fixes #26411
Master Issue: #26412

### Motivation

`SourceSpec.negativeAckRedeliveryDelayMs` sets how long the broker waits before redelivering a negatively acknowledged message. The Python runtime negatively acknowledges on failure:

```python
# python_instance.py:286, 299, 310
msg.consumer.negative_acknowledge(msg.message)
```

but never configured the delay, so `subscribe()`'s default of `60000` applied regardless of what the function was created with. A function configured for fast retry, or for a long back-off from a struggling downstream, silently got one minute either way.

The Java runtime applies it. The Go runtime has the same gap, tracked at #26409.

### Modifications

Add `PythonInstance.get_negative_ack_args()` and splat its result into all three `subscribe()` call sites — the `topicsToSerDeClassName` loop and both branches of the `inputSpecs` loop.

Two details worth a reviewer's attention, both of which shaped the API rather than being incidental:

1. **Unset reads as zero.** The field is a proto3 scalar with no presence, so a function that never set it arrives with `0`. Only a positive value is forwarded, leaving the client default in place otherwise — the same guard `JavaInstanceRunnable` applies (`if (sourceSpec.getNegativeAckRedeliveryDelayMs() > 0)`). Forwarding `0` would mean immediate redelivery rather than the 60s default, which is not what an unconfigured function should get.

2. **The argument is omitted, not passed as `None`.** `subscribe()` validates this one with `_check_type(int, negative_ack_redelivery_delay_ms, ...)` rather than `_check_type_or_none` — unlike the neighbouring `unacked_messages_timeout_ms`, which the existing code does pass `None` to. Passing `None` here would raise for **every** function that does not configure the field. Returning a dict to splat keeps that decision in one place, since the first call site passes explicit keywords while the other two build a `consumer_args` dict.

The helper is a method rather than inline code so it is directly testable, matching `get_dead_letter_policy()` added in #26400.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- Four unit tests in `test_python_instance.py` (`TestNegativeAckRedeliveryDelay`): a positive delay is forwarded; an unset field is omitted; an explicit `0` is omitted; and the return value is a dict carrying exactly the keyword `subscribe()` expects, since it is consumed via `**` and `.update()`.
- Full file: 8/8 pass via `pulsar-functions/instance/src/scripts/run_python_instance_tests.sh`.
- Confirmed the tests are not vacuous: making `get_negative_ack_args()` return `{}` unconditionally fails 2 of them.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints

A function that does not set `negativeAckRedeliveryDelayMs` is unaffected: the argument is omitted and the client default applies exactly as before.

### Documentation

- [ ] `doc-required`
- [x] `doc-not-needed`
- [ ] `doc`
- [ ] `doc-complete`

The configuration option is already documented; this makes the Python runtime honour it.
