### PR TITLE
[fix][fn] Honour retainOrdering and retainKeyOrdering in the Go function runtime

### DIFF
--- a/pulsar-function-go/pf/instance.go
+++ b/pulsar-function-go/pf/instance.go
@@ -303,11 +303,35 @@ func (gi *goInstance) getProducer(topicName string) (pulsar.Producer, error) {
 	return producer, err
 }
 
-func (gi *goInstance) setupConsumer() (chan pulsar.ConsumerMessage, error) {
+// resolveSubscriptionType picks the consumer subscription type for the function.
+//
+// The ordering flags are applied after the explicit SubscriptionType, matching the Java and Python
+// runtimes: retainOrdering requires a single consumer per partition, so it selects Failover, and
+// retainKeyOrdering selects KeyShared. Ordering wins when both are set, which is the precedence
+// python_instance.py applies.
+//
+// EFFECTIVELY_ONCE needs no arm here: instanceConf.go refuses it before an instance is built.
+func resolveSubscriptionType(configured pb.SubscriptionType, retainOrdering,
+	retainKeyOrdering bool) pulsar.SubscriptionType {
 	subscriptionType := pulsar.Shared
-	if int32(gi.context.instanceConf.funcDetails.Source.SubscriptionType) == pb.SubscriptionType_value["FAILOVER"] {
+	if int32(configured) == pb.SubscriptionType_value["FAILOVER"] {
 		subscriptionType = pulsar.Failover
 	}
+
+	if retainOrdering {
+		subscriptionType = pulsar.Failover
+	} else if retainKeyOrdering {
+		subscriptionType = pulsar.KeyShared
+	}
+
+	return subscriptionType
+}
+
+func (gi *goInstance) setupConsumer() (chan pulsar.ConsumerMessage, error) {
+	subscriptionType := resolveSubscriptionType(
+		gi.context.instanceConf.funcDetails.Source.SubscriptionType,
+		gi.context.instanceConf.funcDetails.RetainOrdering,
+		gi.context.instanceConf.funcDetails.RetainKeyOrdering)
 
 	funcDetails := gi.context.instanceConf.funcDetails
 	subscriptionName := funcDetails.Tenant + "/" + funcDetails.Namespace + "/" + funcDetails.Name

--- a/pulsar-function-go/pf/subscriptionType_test.go
+++ b/pulsar-function-go/pf/subscriptionType_test.go
@@ -1,0 +1,88 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package pf
+
+import (
+	"testing"
+
+	"github.com/apache/pulsar-client-go/pulsar"
+	"github.com/stretchr/testify/assert"
+
+	pb "github.com/apache/pulsar/pulsar-function-go/pb"
+)
+
+// The Go runtime previously read only SubscriptionType, so retainOrdering and retainKeyOrdering
+// were accepted and silently dropped: a function created with --retain-key-ordering ran on a
+// Shared subscription and lost per-key ordering. These pin the rules the Java and Python runtimes
+// apply.
+func TestResolveSubscriptionType(t *testing.T) {
+	tests := []struct {
+		name              string
+		configured        pb.SubscriptionType
+		retainOrdering    bool
+		retainKeyOrdering bool
+		expected          pulsar.SubscriptionType
+	}{
+		{
+			name:       "default is shared",
+			configured: pb.SubscriptionType_SHARED,
+			expected:   pulsar.Shared,
+		},
+		{
+			name:       "explicit failover is honoured",
+			configured: pb.SubscriptionType_FAILOVER,
+			expected:   pulsar.Failover,
+		},
+		{
+			name:           "retainOrdering selects failover",
+			configured:     pb.SubscriptionType_SHARED,
+			retainOrdering: true,
+			expected:       pulsar.Failover,
+		},
+		{
+			name:              "retainKeyOrdering selects key_shared",
+			configured:        pb.SubscriptionType_SHARED,
+			retainKeyOrdering: true,
+			expected:          pulsar.KeyShared,
+		},
+		{
+			// python_instance.py applies retainOrdering first and only falls to retainKeyOrdering
+			// in the else branch, so ordering wins. Pinned so the two runtimes cannot drift.
+			name:              "retainOrdering wins over retainKeyOrdering",
+			configured:        pb.SubscriptionType_SHARED,
+			retainOrdering:    true,
+			retainKeyOrdering: true,
+			expected:          pulsar.Failover,
+		},
+		{
+			name:              "retainKeyOrdering overrides an explicit failover",
+			configured:        pb.SubscriptionType_FAILOVER,
+			retainKeyOrdering: true,
+			expected:          pulsar.KeyShared,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected,
+				resolveSubscriptionType(test.configured, test.retainOrdering, test.retainKeyOrdering))
+		})
+	}
+}


### PR DESCRIPTION
Fixes #26405
Master Issue: #26404

### Motivation

The Go runtime picked the subscription type from one field:

```go
// pulsar-function-go/pf/instance.go:307-310
subscriptionType := pulsar.Shared
if int32(gi.context.instanceConf.funcDetails.Source.SubscriptionType) == pb.SubscriptionType_value["FAILOVER"] {
	subscriptionType = pulsar.Failover
}
```

`RetainOrdering` and `RetainKeyOrdering` appeared nowhere in `pulsar-function-go` outside the generated `pb` package, so both were accepted by `pulsar-admin`, reported back by `functions get`, carried into the instance in the protobuf, and dropped.

For `retainKeyOrdering` that is a correctness problem rather than a missing feature. This is accepted:

```
pulsar-admin functions create --go fn --retain-key-ordering ...
```

and the function runs on a **Shared** subscription, so messages sharing a key are distributed across instances and processed concurrently — precisely the guarantee the flag exists to provide. Nothing fails, nothing is logged, and the only symptom is out-of-order processing observed downstream.

The Python runtime applies both (`python_instance.py:147-151`), as does Java.

### Modifications

Extract `resolveSubscriptionType` and apply the ordering flags after the explicit `SubscriptionType`:

- `retainOrdering` → `Failover`
- `retainKeyOrdering` → `KeyShared`
- ordering wins when both are set, which is the precedence `python_instance.py` applies in its `if`/`elif`

`EFFECTIVELY_ONCE` needs no arm here: `instanceConf.go:137` refuses it before an instance is built.

The helper takes the three fields rather than a `FunctionDetails` so it is directly testable and so it does not copy a protobuf message by value — `go vet` reports that as copying a lock, and the version of this change that passed the struct added three new warnings on top of the three already present on master.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- Six table-driven cases in `pf/subscriptionType_test.go`: the Shared default; an explicit Failover; `retainOrdering` selecting Failover; `retainKeyOrdering` selecting KeyShared; ordering winning when both are set; and `retainKeyOrdering` overriding an explicit Failover.
- Confirmed the tests are not vacuous: removing the two new arms fails the suite.
- `go build ./...` and the full `go test ./pf/` pass; `go vet` reports the same three pre-existing lock-copy warnings as master and no new ones.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [x] Anything that affects deployment

**Deployment note.** A Go function already deployed with `--retain-ordering` or `--retain-key-ordering` changes subscription type on the next restart — Shared to Failover or KeyShared respectively. That is the configured behaviour taking effect for the first time, but it is a change for anyone who set the flag, observed Shared behaviour and adapted to it. A function that sets neither flag is unaffected.

### Documentation

- [ ] `doc-required`
- [x] `doc-not-needed`
- [ ] `doc`
- [ ] `doc-complete`

Both options are already documented; this makes the Go runtime honour them.
