### PR TITLE
[fix][broker] Clear delayed delivery state before resetting the cursor

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -983,88 +983,83 @@ public class PersistentSubscription extends AbstractSubscription {
             }
         }
 
-        disconnectFuture.whenComplete((aVoid, throwable) -> {
-            if (dispatcher != null) {
-                dispatcher.resetCloseFuture();
-            }
-
-            if (throwable != null) {
-                log.error()
-                        .exception(throwable)
-                        .log("Failed to disconnect consumer from subscription");
-                IS_FENCED_UPDATER.set(PersistentSubscription.this, FALSE);
-                inProgressResetCursorFuture = null;
-                future.completeExceptionally(
-                        new SubscriptionBusyException("Failed to disconnect consumers from subscription"));
-                return;
-            }
-
-            log.info()
-                    .log("Successfully disconnected consumers from subscription, proceeding with cursor reset");
-
-            CompletableFuture<Boolean> forceReset = new CompletableFuture<>();
-            if (topic.getTopicCompactionService() == null) {
-                forceReset.complete(false);
-            } else {
-                topic.getTopicCompactionService().getLastCompactedPosition().thenAccept(lastCompactedPosition -> {
-                    Position resetTo = finalPosition;
-                    if (lastCompactedPosition != null && resetTo.compareTo(lastCompactedPosition.getLedgerId(),
-                            lastCompactedPosition.getEntryId()) <= 0) {
-                        forceReset.complete(true);
-                    } else {
-                        forceReset.complete(false);
+        disconnectFuture
+                .thenCompose(__ -> {
+                    log.info()
+                            .log("Successfully disconnected consumers from subscription, proceeding with cursor reset");
+                    if (dispatcher != null) {
+                        dispatcher.resetCloseFuture();
+                        return dispatcher.clearDelayedMessages();
                     }
-                }).exceptionally(ex -> {
-                    forceReset.completeExceptionally(ex);
+                    return CompletableFuture.completedFuture(null);
+                })
+                .thenCompose(__ -> {
+                    CompletableFuture<Boolean> forceReset = new CompletableFuture<>();
+                    if (topic.getTopicCompactionService() == null) {
+                        forceReset.complete(false);
+                    } else {
+                        topic.getTopicCompactionService().getLastCompactedPosition()
+                                .thenAccept(lastCompactedPosition -> {
+                                    Position resetTo = finalPosition;
+                                    if (lastCompactedPosition != null
+                                            && resetTo.compareTo(lastCompactedPosition.getLedgerId(),
+                                            lastCompactedPosition.getEntryId()) <= 0) {
+                                        forceReset.complete(true);
+                                    } else {
+                                        forceReset.complete(false);
+                                    }
+                                }).exceptionally(ex -> {
+                                    forceReset.completeExceptionally(ex);
+                                    return null;
+                                });
+                    }
+                    return forceReset;
+                })
+                .thenAccept(forceResetValue -> {
+                    cursor.asyncResetCursor(finalPosition, forceResetValue, new AsyncCallbacks.ResetCursorCallback() {
+                        @Override
+                        public void resetComplete(Object ctx) {
+                            log.debug()
+                                    .attr("finalPosition", finalPosition)
+                                    .log("Successfully reset subscription to position");
+                            if (dispatcher != null) {
+                                dispatcher.cursorIsReset();
+                                dispatcher.afterAckMessages(null, finalPosition);
+                            }
+                            IS_FENCED_UPDATER.set(PersistentSubscription.this, FALSE);
+                            inProgressResetCursorFuture = null;
+                            future.complete(null);
+                        }
+
+                        @Override
+                        public void resetFailed(ManagedLedgerException exception, Object ctx) {
+                            log.error()
+                                    .attr("finalPosition", finalPosition)
+                                    .exception(exception)
+                                    .log("Failed to reset subscription to position");
+                            IS_FENCED_UPDATER.set(PersistentSubscription.this, FALSE);
+                            inProgressResetCursorFuture = null;
+                            // todo - retry on InvalidCursorPositionException
+                            // or should we just ask user to retry one more time?
+                            if (exception instanceof InvalidCursorPositionException) {
+                                future.completeExceptionally(
+                                        new SubscriptionInvalidCursorPosition(exception.getMessage()));
+                            } else if (exception instanceof ConcurrentFindCursorPositionException) {
+                                future.completeExceptionally(new SubscriptionBusyException(exception.getMessage()));
+                            } else {
+                                future.completeExceptionally(new BrokerServiceException(exception));
+                            }
+                        }
+                    });
+                }).exceptionally((e) -> {
+                    log.error()
+                            .exception(e)
+                            .log("Error while resetting cursor");
+                    IS_FENCED_UPDATER.set(PersistentSubscription.this, FALSE);
+                    inProgressResetCursorFuture = null;
+                    future.completeExceptionally(new BrokerServiceException(e));
                     return null;
                 });
-            }
-
-            forceReset.thenAccept(forceResetValue -> {
-                cursor.asyncResetCursor(finalPosition, forceResetValue, new AsyncCallbacks.ResetCursorCallback() {
-                    @Override
-                    public void resetComplete(Object ctx) {
-                        log.debug()
-                                .attr("finalPosition", finalPosition)
-                                .log("Successfully reset subscription to position");
-                        if (dispatcher != null) {
-                            dispatcher.cursorIsReset();
-                            dispatcher.afterAckMessages(null, finalPosition);
-                        }
-                        IS_FENCED_UPDATER.set(PersistentSubscription.this, FALSE);
-                        inProgressResetCursorFuture = null;
-                        future.complete(null);
-                    }
-
-                    @Override
-                    public void resetFailed(ManagedLedgerException exception, Object ctx) {
-                        log.error()
-                                .attr("finalPosition", finalPosition)
-                                .exception(exception)
-                                .log("Failed to reset subscription to position");
-                        IS_FENCED_UPDATER.set(PersistentSubscription.this, FALSE);
-                        inProgressResetCursorFuture = null;
-                        // todo - retry on InvalidCursorPositionException
-                        // or should we just ask user to retry one more time?
-                        if (exception instanceof InvalidCursorPositionException) {
-                            future.completeExceptionally(new SubscriptionInvalidCursorPosition(exception.getMessage()));
-                        } else if (exception instanceof ConcurrentFindCursorPositionException) {
-                            future.completeExceptionally(new SubscriptionBusyException(exception.getMessage()));
-                        } else {
-                            future.completeExceptionally(new BrokerServiceException(exception));
-                        }
-                    }
-                });
-            }).exceptionally((e) -> {
-                log.error()
-                        .exception(e)
-                        .log("Error while resetting cursor");
-                IS_FENCED_UPDATER.set(PersistentSubscription.this, FALSE);
-                inProgressResetCursorFuture = null;
-                future.completeExceptionally(new BrokerServiceException(e));
-                return null;
-            });
-        });
         return future;
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -54,6 +54,7 @@ import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.ScanOutcome;
 import org.apache.commons.lang3.tuple.MutablePair;
 import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.delayed.BucketDelayedDeliveryTrackerFactory;
 import org.apache.pulsar.broker.intercept.BrokerInterceptor;
 import org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl;
 import org.apache.pulsar.broker.loadbalance.extensions.data.BrokerLookupData;
@@ -984,13 +985,34 @@ public class PersistentSubscription extends AbstractSubscription {
         }
 
         disconnectFuture
-                .thenCompose(__ -> {
-                    log.info()
-                            .log("Successfully disconnected consumers from subscription, proceeding with cursor reset");
+                .handle((ignore, throwable) -> {
                     if (dispatcher != null) {
                         dispatcher.resetCloseFuture();
+                    }
+
+                    if (throwable != null) {
+                        log.error()
+                                .exception(throwable)
+                                .log("Failed to disconnect consumer from subscription");
+
+                        return CompletableFuture.<Void>failedFuture(
+                                new SubscriptionBusyException(
+                                        "Failed to disconnect consumers from subscription"));
+                    }
+
+                    log.info()
+                            .log("Successfully disconnected consumers from subscription, proceeding with cursor reset");
+
+                    if (dispatcher != null) {
                         return dispatcher.clearDelayedMessages();
                     }
+
+                    if (topic.isDelayedDeliveryEnabled()
+                            && topic.getBrokerService().getDelayedDeliveryTrackerFactory()
+                            instanceof BucketDelayedDeliveryTrackerFactory bucketDelayedDeliveryTrackerFactory) {
+                        return bucketDelayedDeliveryTrackerFactory.cleanResidualSnapshots(cursor);
+                    }
+
                     return CompletableFuture.completedFuture(null);
                 })
                 .thenCompose(__ -> {
@@ -1057,7 +1079,9 @@ public class PersistentSubscription extends AbstractSubscription {
                             .log("Error while resetting cursor");
                     IS_FENCED_UPDATER.set(PersistentSubscription.this, FALSE);
                     inProgressResetCursorFuture = null;
-                    future.completeExceptionally(new BrokerServiceException(e));
+                    Throwable cause = FutureUtil.unwrapCompletionException(e);
+                    future.completeExceptionally(cause instanceof BrokerServiceException exception
+                            ? exception : new BrokerServiceException(cause));
                     return null;
                 });
         return future;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -32,6 +32,7 @@ import java.util.Optional;
 import java.util.TreeMap;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -995,14 +996,16 @@ public class PersistentSubscription extends AbstractSubscription {
                                 .exception(throwable)
                                 .log("Failed to disconnect consumer from subscription");
 
-                        return CompletableFuture.<Void>failedFuture(
+                        throw new CompletionException(
                                 new SubscriptionBusyException(
                                         "Failed to disconnect consumers from subscription"));
                     }
 
                     log.info()
                             .log("Successfully disconnected consumers from subscription, proceeding with cursor reset");
-
+                    return null;
+                })
+                .thenCompose(__ -> {
                     if (dispatcher != null) {
                         return dispatcher.clearDelayedMessages();
                     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/BucketDelayedDeliveryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/BucketDelayedDeliveryTest.java
@@ -129,6 +129,51 @@ public class BucketDelayedDeliveryTest extends DelayedDeliveryTest {
     }
 
     @Test
+    public void testResetCursorClearsDelayedMessages() throws Exception {
+        String topic = BrokerTestUtil.newUniqueName("persistent://public/default/testResetClearsDelayed");
+
+        @Cleanup
+        Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
+                .topic(topic)
+                .subscriptionName("sub")
+                .subscriptionType(SubscriptionType.Shared)
+                .subscribe();
+
+        @Cleanup
+        Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
+                .topic(topic)
+                .create();
+
+        for (int i = 0; i < 100; i++) {
+            producer.newMessage()
+                    .value("msg")
+                    .deliverAfter(1, TimeUnit.HOURS)
+                    .send();
+        }
+
+        Dispatcher dispatcher = pulsar.getBrokerService().getTopicReference(topic)
+                .get().getSubscription("sub").getDispatcher();
+        Awaitility.await().untilAsserted(() ->
+                Assert.assertEquals(dispatcher.getNumberOfDelayedMessages(), 100));
+        List<String> bucketKeys =
+                ((AbstractPersistentDispatcherMultipleConsumers) dispatcher).getCursor().getCursorProperties()
+                        .keySet().stream().filter(x -> x.startsWith(CURSOR_INTERNAL_PROPERTY_PREFIX)).toList();
+        assertFalse(bucketKeys.isEmpty());
+
+        // Resetting the cursor disconnects the consumer, so nothing gets re-tracked while we
+        // observe the post-reset state.
+        admin.topics().resetCursor(topic, "sub", MessageId.earliest);
+
+        assertEquals(dispatcher.getNumberOfDelayedMessages(), 0,
+                "The delayed delivery tracker should be cleared by the cursor reset");
+        List<String> bucketKeysAfterReset =
+                ((AbstractPersistentDispatcherMultipleConsumers) dispatcher).getCursor().getCursorProperties()
+                        .keySet().stream().filter(x -> x.startsWith(CURSOR_INTERNAL_PROPERTY_PREFIX)).toList();
+        assertTrue(bucketKeysAfterReset.isEmpty(),
+                "The bucket cursor properties should be removed by the cursor reset");
+    }
+
+    @Test
     public void testIncrementPartitionsDoesNotCopyBucketDelayedDeliveryState() throws Exception {
         String topic = BrokerTestUtil.newUniqueName("persistent://public/default/testBucketStatePartitionExpansion");
         String subscriptionName = "sub";

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/BucketDelayedDeliveryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/BucketDelayedDeliveryTest.java
@@ -24,6 +24,7 @@ import static org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient.
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import com.google.common.collect.Multimap;
 import java.io.ByteArrayOutputStream;
@@ -160,8 +161,8 @@ public class BucketDelayedDeliveryTest extends DelayedDeliveryTest {
                         .keySet().stream().filter(x -> x.startsWith(CURSOR_INTERNAL_PROPERTY_PREFIX)).toList();
         assertFalse(bucketKeys.isEmpty());
 
-        // Resetting the cursor disconnects the consumer, so nothing gets re-tracked while we
-        // observe the post-reset state.
+        consumer.close();
+
         admin.topics().resetCursor(topic, "sub", MessageId.earliest);
 
         assertEquals(dispatcher.getNumberOfDelayedMessages(), 0,
@@ -171,6 +172,53 @@ public class BucketDelayedDeliveryTest extends DelayedDeliveryTest {
                         .keySet().stream().filter(x -> x.startsWith(CURSOR_INTERNAL_PROPERTY_PREFIX)).toList();
         assertTrue(bucketKeysAfterReset.isEmpty(),
                 "The bucket cursor properties should be removed by the cursor reset");
+    }
+
+    @Test
+    public void testResetCursorWithoutDispatcherCleansResidualBucketSnapshots() throws Exception {
+        String topic = BrokerTestUtil.newUniqueName("persistent://public/default/testResetNoDispatcher");
+
+        @Cleanup
+        Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
+                .topic(topic)
+                .subscriptionName("sub")
+                .subscriptionType(SubscriptionType.Shared)
+                .subscribe();
+
+        @Cleanup
+        Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
+                .topic(topic)
+                .create();
+
+        for (int i = 0; i < 100; i++) {
+            producer.newMessage()
+                    .value("msg")
+                    .deliverAfter(1, TimeUnit.HOURS)
+                    .send();
+        }
+
+        PersistentSubscription subscription = (PersistentSubscription) pulsar.getBrokerService()
+                .getTopicReference(topic).get().getSubscription("sub");
+        Dispatcher dispatcher = subscription.getDispatcher();
+        Awaitility.await().untilAsserted(() ->
+                Assert.assertEquals(dispatcher.getNumberOfDelayedMessages(), 100));
+        List<String> bucketKeys = subscription.getCursor().getCursorProperties().keySet().stream()
+                .filter(x -> x.startsWith(CURSOR_INTERNAL_PROPERTY_PREFIX)).toList();
+        assertFalse(bucketKeys.isEmpty());
+
+        consumer.close();
+        admin.topics().unload(topic);
+
+        admin.topics().resetCursor(topic, "sub", MessageId.earliest);
+
+        PersistentSubscription reloadedSubscription = (PersistentSubscription) pulsar.getBrokerService()
+                .getTopicReference(topic).get().getSubscription("sub");
+        assertNull(reloadedSubscription.getDispatcher(),
+                "No consumer has connected since the topic was reloaded");
+        List<String> bucketKeysAfterReset = reloadedSubscription.getCursor().getCursorProperties()
+                .keySet().stream().filter(x -> x.startsWith(CURSOR_INTERNAL_PROPERTY_PREFIX)).toList();
+        assertTrue(bucketKeysAfterReset.isEmpty(),
+                "A reset without a dispatcher should still remove the residual bucket cursor properties");
     }
 
     @Test


### PR DESCRIPTION
### Motivation

`PersistentSubscription#resetCursorInternal` reset the cursor without touching the delayed delivery tracker. The tracker state is a derived cache of the backlog (the source of truth is `deliverAtTime` in the message metadata), and a reset moves the consumption baseline, so the whole derivation is invalidated:

- bucket snapshots, index bits and queued entries from before the reset survived into the replay, and re-added messages deduped against the stale index instead of being re-tracked cleanly;
- in-flight trims/loads/deletes from before the reset could race the replayed state;
- the bucket cursor properties stayed on the cursor, so a later tracker recovery would load pre-reset buckets.

`clearBacklog` and unsubscribe already clear the delayed state for the same reason; the reset path was the odd one out.

### Modifications

- `resetCursorInternal` now clears the delayed messages and waits for the clear to settle after disconnecting consumers and before `asyncResetCursor`; a clear failure unfences the subscription and fails the reset.
- Without a dispatcher there is no in-flight work and the recovered bucket snapshots stay valid for the replay (re-added messages dedup through the index bitmap), so there is nothing to clear.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

  - `BucketDelayedDeliveryTest#testResetCursorClearsDelayedMessages`: tracks 100 delayed messages, resets the cursor to the earliest position and verifies the tracker count is 0 and the bucket cursor properties are removed. Without the fix the assertion fails: the tracker still reports 100 delayed messages and the bucket cursor property survives the reset.

### Does this pull request potentially affect one of the following parts:

*Check the boxes that apply*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment