### PR TITLE
[fix][fn] Allow retainKeyOrdering on Go functions

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -297,10 +297,11 @@ public class CmdFunctions extends CmdBase {
         @Option(names = "--retainOrdering",
                 description = "Function consumes and processes messages in order", hidden = true)
         protected Boolean deprecatedRetainOrdering;
-        @Option(names = "--retain-ordering", description = "Function consumes and processes messages in order #Java")
+        @Option(names = "--retain-ordering",
+                description = "Function consumes and processes messages in order #Java, Python, Go")
         protected Boolean retainOrdering;
         @Option(names = "--retain-key-ordering",
-                description = "Function consumes and processes messages in key order #Java")
+                description = "Function consumes and processes messages in key order #Java, Python, Go")
         protected Boolean retainKeyOrdering;
         @Option(names = "--batch-builder", description = "BatcherBuilder provides two types of "
                 + "batch construction methods, DEFAULT and KEY_BASED. The default value is: DEFAULT")

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
@@ -774,12 +774,6 @@ public class FunctionConfigUtils {
         if (functionConfig.getMaxMessageRetries() != null && functionConfig.getMaxMessageRetries() >= 0) {
             throw new IllegalArgumentException("Message retries not yet supported in Go function");
         }
-
-        // retainKeyOrdering is no longer refused: the Go runtime honours it, selecting a KeyShared
-        // subscription in resolveSubscriptionType (pulsar-function-go/pf/instance.go), the same way
-        // python_instance.py does. doCommonChecks still rejects the two combinations that would be
-        // contradictory -- retainKeyOrdering with EFFECTIVELY_ONCE, and retainKeyOrdering together
-        // with retainOrdering -- so nothing here needs to repeat them for Go.
     }
 
     private static void verifyNoTopicClash(Collection<String> inputTopics, String outputTopic)

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
@@ -775,9 +775,11 @@ public class FunctionConfigUtils {
             throw new IllegalArgumentException("Message retries not yet supported in Go function");
         }
 
-        if (functionConfig.getRetainKeyOrdering() != null && functionConfig.getRetainKeyOrdering()) {
-            throw new IllegalArgumentException("Retain Key Orderering not yet supported in Go function");
-        }
+        // retainKeyOrdering is no longer refused: the Go runtime honours it, selecting a KeyShared
+        // subscription in resolveSubscriptionType (pulsar-function-go/pf/instance.go), the same way
+        // python_instance.py does. doCommonChecks still rejects the two combinations that would be
+        // contradictory -- retainKeyOrdering with EFFECTIVELY_ONCE, and retainKeyOrdering together
+        // with retainOrdering -- so nothing here needs to repeat them for Go.
     }
 
     private static void verifyNoTopicClash(Collection<String> inputTopics, String outputTopic)

--- a/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/FunctionConfigUtilsTest.java
+++ b/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/FunctionConfigUtilsTest.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.functions.utils;
 
 import static org.apache.pulsar.common.functions.FunctionConfig.ProcessingGuarantees.EFFECTIVELY_ONCE;
+import static org.apache.pulsar.common.functions.FunctionConfig.Runtime.GO;
 import static org.apache.pulsar.common.functions.FunctionConfig.Runtime.PYTHON;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -29,6 +30,7 @@ import com.google.gson.Gson;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
@@ -762,5 +764,70 @@ public class FunctionConfigUtilsTest {
             assertEquals(producerSpec2.getCryptoSpec().getProducerEncryptionKeyNameAt(i),
                     producerSpec.getCryptoSpec().getProducerEncryptionKeyNameAt(i));
         }
+    }
+
+    private static FunctionConfig minimalGoFunctionConfig() {
+        FunctionConfig functionConfig = new FunctionConfig();
+        functionConfig.setTenant("test-tenant");
+        functionConfig.setNamespace("test-namespace");
+        functionConfig.setName("test-function");
+        functionConfig.setInputs(Collections.singletonList("persistent://public/default/input"));
+        functionConfig.setRuntime(GO);
+        functionConfig.setGo("/path/to/function");
+        return functionConfig;
+    }
+
+    @Test
+    public void testGoFunctionAcceptsRetainKeyOrdering() {
+        FunctionConfig functionConfig = minimalGoFunctionConfig();
+        functionConfig.setRetainKeyOrdering(true);
+
+        FunctionConfigUtils.validateNonJavaFunction(functionConfig);
+
+        // The KeyShared subscription the Go runtime selects has to survive conversion, otherwise the
+        // instance never sees it.
+        assertEquals(FunctionConfigUtils.convert(functionConfig).getSource().getSubscriptionType(),
+                SubscriptionType.KEY_SHARED);
+    }
+
+    @Test
+    public void testGoFunctionAcceptsRetainOrdering() {
+        FunctionConfig functionConfig = minimalGoFunctionConfig();
+        functionConfig.setRetainOrdering(true);
+
+        FunctionConfigUtils.validateNonJavaFunction(functionConfig);
+
+        assertEquals(FunctionConfigUtils.convert(functionConfig).getSource().getSubscriptionType(),
+                SubscriptionType.FAILOVER);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class,
+            expectedExceptionsMessageRegExp = "Only one of retain ordering or retain key ordering can be set")
+    public void testGoFunctionRejectsBothOrderingModes() {
+        FunctionConfig functionConfig = minimalGoFunctionConfig();
+        functionConfig.setRetainOrdering(true);
+        functionConfig.setRetainKeyOrdering(true);
+
+        FunctionConfigUtils.validateNonJavaFunction(functionConfig);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class,
+            expectedExceptionsMessageRegExp =
+                    "When effectively once processing guarantee is specified, retain Key ordering cannot be set")
+    public void testGoFunctionRejectsRetainKeyOrderingWithEffectivelyOnce() {
+        FunctionConfig functionConfig = minimalGoFunctionConfig();
+        functionConfig.setRetainKeyOrdering(true);
+        functionConfig.setProcessingGuarantees(EFFECTIVELY_ONCE);
+
+        FunctionConfigUtils.validateNonJavaFunction(functionConfig);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class,
+            expectedExceptionsMessageRegExp = "Message retries not yet supported in Go function")
+    public void testGoFunctionStillRejectsMessageRetries() {
+        FunctionConfig functionConfig = minimalGoFunctionConfig();
+        functionConfig.setMaxMessageRetries(3);
+
+        FunctionConfigUtils.validateNonJavaFunction(functionConfig);
     }
 }


### PR DESCRIPTION
Master Issue: #26404
Follow-up to #26414, which closed #26405.

### Motivation

#26414 taught the Go runtime to honour `retainOrdering` and `retainKeyOrdering`: `resolveSubscriptionType` in `pulsar-function-go/pf/instance.go` selects `Failover` for the first and `KeyShared` for the second, matching `python_instance.py`.

**Half of it cannot be reached.** `doGolangChecks` still refuses `retainKeyOrdering` outright:

```java
if (functionConfig.getRetainKeyOrdering() != null && functionConfig.getRetainKeyOrdering()) {
    throw new IllegalArgumentException("Retain Key Orderering not yet supported in Go function");
}
```

`validateNonJavaFunction` has a single caller, the worker REST API (`FunctionsImpl`), so cluster submission is exactly what the guard blocks. `LocalRunner` never calls it, which is why the `KeyShared` branch is reachable under `localrun` and nowhere else. As master stands, `pulsar-admin functions create --go ... --retain-key-ordering` fails at creation, and the code #26414 added for it is dead on the cluster path.

`retainOrdering` is unaffected — it was never gated — so that half of #26414 works today.

This is the same shape of gap as the Python dead letter queue in #26400, with one difference: `convert` carries `retainKeyOrdering` into `FunctionDetails` unconditionally (L297), so this guard is the only thing in the way.

#26405 was auto-closed when #26414 merged. Its body only described the runtime gap, so the validation half was never in its scope; happy to reopen it instead of tracking this here if that is preferred.

### Modifications

**Drop the guard from `doGolangChecks`.**

The combinations that would genuinely be contradictory are already rejected in `doCommonChecks`, for every runtime:

- `retainKeyOrdering` with `EFFECTIVELY_ONCE` — *"When effectively once processing guarantee is specified, retain Key ordering cannot be set"*
- `retainKeyOrdering` together with `retainOrdering` — *"Only one of retain ordering or retain key ordering can be set"*

`doGolangChecks` refuses `EFFECTIVELY_ONCE` for Go before either is reached, so nothing needs repeating for Go specifically. The `maxMessageRetries` guard stays — the Go runtime does not honour `retryDetails` yet (#26406) — and a test pins it so this change cannot be widened by accident.

The Go client needs no extra configuration for `KeyShared`: `ConsumerOptions` leaves `KeySharedPolicy` nil, `toProtoKeySharedMeta(nil)` returns nil, and the broker then applies its default auto-split hash range.

**Correct the CLI runtime markers.** The `@Option` descriptions in `CmdFunctions` carry a marker that the docs sync parses into the **Support** column of the published [pulsar-admin CLI reference](https://pulsar.apache.org/reference/), and that `functions create --help` prints verbatim. `--retain-ordering` and `--retain-key-ordering` were both `#Java`, which has been wrong for **Python** since long before #26414 — `python_instance.py` has always selected `Failover` and `KeyShared` for them. Both now read `#Java, Python, Go`.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- Five tests in `FunctionConfigUtilsTest`: Go accepts `retainKeyOrdering` and converts to a `KEY_SHARED` subscription; accepts `retainOrdering` and converts to `FAILOVER`; rejects both ordering modes together; rejects `retainKeyOrdering` with `EFFECTIVELY_ONCE`; and still refuses message retries.
- `FunctionConfigUtilsTest`: 42/42 pass.
- Confirmed the tests are not vacuous: restoring the guard fails `testGoFunctionAcceptsRetainKeyOrdering` and nothing else.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints

This is **relaxing** only. A configuration that was accepted before is still accepted; one input that was rejected — `retainKeyOrdering` on a Go function — is now accepted, and behaves as the runtime already implements. Java and Python functions are untouched.

### Documentation

- [ ] `doc-required`
- [x] `doc-not-needed`

The `FunctionConfig` table in `docs/functions-cli.md` documents `retainOrdering` and `retainKeyOrdering` with no runtime qualification. With this change that is accurate for the first time — all three runtimes honour both — so the table needs no edit. The `#Java, Python, Go` markers above keep the generated CLI reference in step.
