### PR TITLE
[fix][misc][branch-4.2] Pass webServiceTlsCiphers to Jetty factory

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/WebService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/WebService.java
@@ -25,6 +25,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -171,7 +172,8 @@ public class WebService implements AutoCloseable {
                 SslContextFactory.Server sslCtxFactory =
                         JettySslContextFactory.createSslContextFactory(config.getWebServiceTlsProvider(),
                                 this.sslFactory, config.isTlsRequireTrustedClientCertOnConnect(),
-                                config.getTlsCiphers(), config.getTlsProtocols());
+                                firstNonEmpty(config.getWebServiceTlsCiphers(), config.getTlsCiphers()),
+                                firstNonEmpty(config.getWebServiceTlsProtocols(), config.getTlsProtocols()));
                 List<ConnectionFactory> connectionFactories = new ArrayList<>();
                 if (config.isWebServiceHaProxyProtocolEnabled()) {
                     connectionFactories.add(new ProxyConnectionFactory());
@@ -530,6 +532,10 @@ public class WebService implements AutoCloseable {
         } catch (Exception e) {
             log.error("Failed to refresh SSL context", e);
         }
+    }
+
+    private static Set<String> firstNonEmpty(Set<String> preferred, Set<String> fallback) {
+        return preferred != null && !preferred.isEmpty() ? preferred : fallback;
     }
 
     private static final Logger log = LoggerFactory.getLogger(WebService.class);

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConnection.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConnection.java
@@ -797,6 +797,8 @@ public class ProxyConnection extends PulsarHandler {
                 clientConf.setTlsCertificateFilePath(proxyConfig.getBrokerClientCertificateFilePath());
             }
             clientConf.setTlsAllowInsecureConnection(proxyConfig.isTlsAllowInsecureConnection());
+            clientConf.setTlsCiphers(proxyConfig.getBrokerClientTlsCiphers());
+            clientConf.setTlsProtocols(proxyConfig.getBrokerClientTlsProtocols());
         }
         return clientConf;
     }


### PR DESCRIPTION
Fixes silent ignore of TLS cipher and protocol restrictions in the broker WebService and proxy lookup leg.

### Motivation

WebService.java:608 passes getTlsCiphers/getTlsProtocols to the Jetty factory, ignoring webServiceTlsCiphers/webServiceTlsProtocols. ProxyConnection.createClientConfiguration omits ciphers/protocols entirely for the broker lookup client. This allows silent bypass of TLS security restrictions configured by operators.

### Modifications

- WebService: use firstNonEmpty(getWebServiceTlsCiphers, getTlsCiphers) and same for protocols with fallback, mirroring DefaultBrokerTlsFactory.webPolicy
- ProxyConnection: propagate brokerClientTlsCiphers/brokerClientTlsProtocols to ClientConfigurationData for the lookup leg

### Verifying this change

- [x] Make sure that the change passes the CI checks.
- [x] This change is already covered by existing tests (WebService and ProxyConnection).

### Does this pull request potentially affect one of the following parts:

- [x] The default values of configurations
- [x] Anything that affects deployment
