### PR TITLE
[fix][offload] Cache and reuse entry offsets discovered while skipping in BlobStoreBackedReadHandleImpl

### DIFF
--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedReadHandleImpl.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedReadHandleImpl.java
@@ -60,6 +60,11 @@ public class BlobStoreBackedReadHandleImpl implements ReadHandle, OffloadedLedge
     protected static final AtomicIntegerFieldUpdater<BlobStoreBackedReadHandleImpl> PENDING_READ_UPDATER =
             AtomicIntegerFieldUpdater.newUpdater(BlobStoreBackedReadHandleImpl.class, "pendingRead");
 
+    // Bound on how far seekToEntryOffset() probes backwards through entryOffsetsCache for an anchor
+    // before falling back to re-walking from the sparse index marker.
+    private static final long MAX_OFFSET_PROBE =
+            Long.getLong("pulsar.jclouds.readhandleimpl.offsetprobe.max", 1024);
+
     private final long ledgerId;
     private final OffloadIndexBlock index;
     private final BackedInputStream inputStream;
@@ -247,6 +252,7 @@ public class BlobStoreBackedReadHandleImpl implements ReadHandle, OffloadedLedge
                 }
                 long entryId = dataStream.readLong();
                 if (entryId == nextExpectedEntryId) {
+                    entryOffsetsCache.put(ledgerId, entryId, offset);
                     long skipped = inputStream.skip(len);
                     if (skipped != len) {
                         LedgerMetadata ledgerMetadata = getLedgerMetadata();
@@ -291,13 +297,19 @@ public class BlobStoreBackedReadHandleImpl implements ReadHandle, OffloadedLedge
                 inputStream.seek(indexOfNearestEntry.getDataOffset());
                 return;
             }
-            // 2. Try to use the previous index. Since the entry-0 must have a precise index, we can skip to check
-            //    whether "expectedEntryId" is larger than 0;
-            Long cachedPreviousKnownOffset = entryOffsetsCache.getIfPresent(ledgerId, expectedEntryId - 1);
-            if (cachedPreviousKnownOffset != null) {
-                inputStream.seek(cachedPreviousKnownOffset);
-                skipPreviousEntry(expectedEntryId - 1, expectedEntryId);
-                return;
+            // 2. Probe backwards for the nearest cached offset within a bounded window. Since entry-0
+            //    must have a precise index, we can skip checking whether "expectedEntryId" is larger
+            //    than 0. skipPreviousEntry() below caches every entry it walks past, so once a block
+            //    has been walked once, a later jump into the same block lands on that cached run
+            //    within "gap" probes instead of re-walking from the sparse index marker in step 3.
+            long probeFloor = Math.max(indexOfNearestEntry.getEntryId(), expectedEntryId - MAX_OFFSET_PROBE);
+            for (long probe = expectedEntryId - 1; probe >= probeFloor; probe--) {
+                Long cachedOffset = entryOffsetsCache.getIfPresent(ledgerId, probe);
+                if (cachedOffset != null) {
+                    inputStream.seek(cachedOffset);
+                    skipPreviousEntry(probe, expectedEntryId);
+                    return;
+                }
             }
             // 3. Use the persistent index of the nearest entry that is smaller than "expectedEntryId".
             //    Because it is a sparse index, some entries need to be skipped.


### PR DESCRIPTION
seekToEntryOffset() falls back to skipPreviousEntry() when it has neither a cached nor a persisted precise offset for the target entry. That walk learns every entry's exact offset along the way but never records it in entryOffsetsCache, and step 2's cache lookup only ever probes for expectedEntryId - 1, so a cached offset is only reachable when consecutive reads land on strictly adjacent entry ids. Real cursor traffic on fragmented acks jumps by the gap between un-acked entries instead, so a cursor whose backlog is fragmented into many individually-acked ranges pays a full rescan of the offload block on every jump across an acked gap.

entryOffsetsCache.put() is now called in skipPreviousEntry() at the point the entry id is confirmed, mirroring the existing call in the main read loop. seekToEntryOffset()'s step 2 becomes a bounded backward probe: walk from expectedEntryId - 1 down to whichever is larger of the sparse index marker's entry id or expectedEntryId - MAX_OFFSET_PROBE (default 1024, pulsar.jclouds.readhandleimpl.offsetprobe.max), seeking and skipping from the first cache hit. A later jump into an already-walked block now resolves in "gap" probes instead of a full rescan, and each walk extends the cached run forward, so only the first jump into a given region pays the full walk cost. Cache growth remains bounded by OffsetsCache's existing maximumSize/expireAfterAccess eviction.