### PR TITLE
fix: preserve schemaProperties in SinkConfigUtils inputSpecs round-trip

### DIFF
--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfigUtils.java
@@ -167,6 +167,9 @@ public class SinkConfigUtils {
                 if (spec.getConsumerProperties() != null) {
                     spec.getConsumerProperties().forEach(bldr::putConsumerProperties);
                 }
+                if (spec.getSchemaProperties() != null) {
+                    spec.getSchemaProperties().forEach(bldr::putSchemaProperties);
+                }
                 bldr.setPoolMessages(spec.isPoolMessages());
             });
         }
@@ -309,6 +312,9 @@ public class SinkConfigUtils {
             Map<String, String> consumerProps = new HashMap<>();
             input.forEachConsumerProperties(consumerProps::put);
             consumerConfig.setConsumerProperties(consumerProps);
+            Map<String, String> schemaProps = new HashMap<>();
+            input.forEachSchemaProperties(schemaProps::put);
+            consumerConfig.setSchemaProperties(schemaProps);
             consumerConfig.setPoolMessages(input.isPoolMessages());
             consumerConfigMap.put(topicName, consumerConfig);
             inputs.add(topicName);

--- a/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/SinkConfigUtilsTest.java
+++ b/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/SinkConfigUtilsTest.java
@@ -663,6 +663,29 @@ public class SinkConfigUtilsTest {
     }
 
     @Test
+    public void testInputSpecSchemaPropertiesRoundTrip() throws IOException {
+        SinkConfig sinkConfig = createSinkConfig();
+        Map<String, String> schemaProperties = new HashMap<>();
+        schemaProperties.put("__alwaysAllowNull", "true");
+        Map<String, ConsumerConfig> inputSpecs = new HashMap<>();
+        inputSpecs.put("test-input", ConsumerConfig.builder()
+                .isRegexPattern(true)
+                .serdeClassName("test-serde")
+                .schemaProperties(schemaProperties)
+                .build());
+        sinkConfig.setInputSpecs(inputSpecs);
+
+        FunctionDetails functionDetails = SinkConfigUtils.convert(sinkConfig,
+                new SinkConfigUtils.ExtractedSinkDetails(null, null, null));
+        assertEquals("true",
+                functionDetails.getSource().getInputSpecs("test-input").getSchemaProperties("__alwaysAllowNull"));
+
+        SinkConfig convertedConfig = SinkConfigUtils.convertFromDetails(functionDetails);
+        assertEquals(schemaProperties,
+                convertedConfig.getInputSpecs().get("test-input").getSchemaProperties());
+    }
+
+    @Test
     public void testAllowDisableSinkTimeout() {
         SinkConfig sinkConfig = createSinkConfig();
         sinkConfig.setInputSpecs(null);


### PR DESCRIPTION
Fixes #26425

Added `schemaProperties` copy in both `convert()` and `convertFromDetails()` in `SinkConfigUtils`, mirroring the `consumerProperties` handling and `FunctionConfigUtils` reference implementation.