### PR TITLE
[fix][client] Shut down the admin TLS factory executor on resolution failure

### DIFF
--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/http/AsyncHttpConnector.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/http/AsyncHttpConnector.java
@@ -363,10 +363,18 @@ public class AsyncHttpConnector implements Connector, AsyncHttpRequestExecutor {
         // both (there is no shared client scheduler here, unlike the PulsarClientImpl funnel).
         ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(
                 new DefaultThreadFactory("pulsar-admin-tls-factory"));
-        PulsarTlsFactory factory = ClientTlsFactorySupport.resolveClientTlsFactory(conf, executor,
-                executor, conf.getOpenTelemetry());
-        this.tlsFactoryOwnership = TlsFactoryOwnership.owning(factory, executor);
-        return factory;
+        try {
+            PulsarTlsFactory factory = ClientTlsFactorySupport.resolveClientTlsFactory(conf, executor,
+                    executor, conf.getOpenTelemetry());
+            this.tlsFactoryOwnership = TlsFactoryOwnership.owning(factory, executor);
+            return factory;
+        } catch (Exception e) {
+            // Never leave the pulsar-admin-tls-factory thread alive on a failed resolution: Netty's
+            // DefaultThreadFactory creates non-daemon threads by default, so an un-shutdown executor
+            // would keep the JVM from exiting. Mirrors AsyncHttpConnectorProvider.sharedTlsFactory().
+            executor.shutdownNow();
+            throw e;
+        }
     }
 
     /**


### PR DESCRIPTION
### Motivation

`AsyncHttpConnector.resolveNewTlsFactory` creates the `pulsar-admin-tls-factory` executor and then calls `ClientTlsFactorySupport.resolveClientTlsFactory` with no `try`, so when the resolution throws (e.g. a non-existent `tlsTrustCertsFilePath`, or a by-name custom factory whose `initialize()` fails) the executor is never shut down. Because Netty's `DefaultThreadFactory` creates **non-daemon** threads by default, the leaked thread keeps the JVM from exiting.

`AsyncHttpConnectorProvider.sharedTlsFactory()` — the sibling that creates the same named executor for the same purpose — already guards the identical call with `try/catch` + `executor.shutdownNow()`. The connector is the odd one out.

### Modifications

Wrap the `resolveClientTlsFactory` call in `resolveNewTlsFactory` the same way `sharedTlsFactory()` does: shut the executor down (`shutdownNow`) before rethrowing, so a failed resolution leaves no `pulsar-admin-tls-factory` thread running.

Fixes #26427
