### PR TITLE
[fix][test] Fix flaky IsolatedBookieEnsemblePlacementPolicyTest by awaiting the initial rack config load

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/bookie/rackawareness/IsolatedBookieEnsemblePlacementPolicy.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/bookie/rackawareness/IsolatedBookieEnsemblePlacementPolicy.java
@@ -71,8 +71,13 @@ public class IsolatedBookieEnsemblePlacementPolicy extends RackawareEnsemblePlac
     /**
      * Completes once the rack configuration load started by
      * {@link #initialize(ClientConfiguration, Optional, HashedWheelTimer, FeatureProvider, StatsLogger,
-     * BookieAddressResolver)} has been applied to {@link #cachedRackConfiguration}. Until then no isolation is
-     * applied at all, so tests must wait for this future before asserting on placement decisions.
+     * BookieAddressResolver)} has been applied to {@link #cachedRackConfiguration}, and completes exceptionally
+     * when that load failed. Until it completes no isolation is applied at all, so tests must wait for this future
+     * before asserting on placement decisions.
+     *
+     * <p>It deliberately excludes the {@code exceptionally} stage that keeps initialization going on a failed
+     * load: a test awaiting this future must see the real failure rather than proceed against a still-null
+     * {@link #cachedRackConfiguration}, which looks exactly like the race this future exists to close.
      */
     @Getter
     @VisibleForTesting
@@ -103,13 +108,16 @@ public class IsolatedBookieEnsemblePlacementPolicy extends RackawareEnsemblePlac
             }
             // Only add the bookieMappingCache if we have defined an isolation group
             bookieMappingCache = store.getMetadataCache(BookiesRackConfiguration.class);
-            initialRackConfigurationLoadFuture = bookieMappingCache
+            CompletableFuture<Void> rackConfigurationLoad = bookieMappingCache
                     .get(BookieRackAffinityMapping.BOOKIE_INFO_ROOT_PATH).thenAccept(opt -> opt.ifPresent(
-                            bookiesRackConfiguration -> cachedRackConfiguration = bookiesRackConfiguration))
-                    .exceptionally(e -> {
-                        log.warn("Failed to load bookies rack configuration while initialize the PlacementPolicy.");
-                        return null;
-                    });
+                            bookiesRackConfiguration -> cachedRackConfiguration = bookiesRackConfiguration));
+            // Initialization continues when the load fails; isolation is simply not applied until a later refresh.
+            rackConfigurationLoad.exceptionally(e -> {
+                log.warn().exception(e)
+                        .log("Failed to load bookies rack configuration while initialize the PlacementPolicy.");
+                return null;
+            });
+            initialRackConfigurationLoadFuture = rackConfigurationLoad;
         }
         if (conf.getProperty(SECONDARY_ISOLATION_BOOKIE_GROUPS) != null) {
             String secondaryIsolationGroupsString = ConfigurationStringUtil

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/bookie/rackawareness/IsolatedBookieEnsemblePlacementPolicy.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/bookie/rackawareness/IsolatedBookieEnsemblePlacementPolicy.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import lombok.CustomLog;
 import lombok.Getter;
 import org.apache.bookkeeper.client.BKException.BKNotEnoughBookiesException;
@@ -67,6 +68,17 @@ public class IsolatedBookieEnsemblePlacementPolicy extends RackawareEnsemblePlac
 
     private volatile BookiesRackConfiguration cachedRackConfiguration = null;
 
+    /**
+     * Completes once the rack configuration load started by
+     * {@link #initialize(ClientConfiguration, Optional, HashedWheelTimer, FeatureProvider, StatsLogger,
+     * BookieAddressResolver)} has been applied to {@link #cachedRackConfiguration}. Until then no isolation is
+     * applied at all, so tests must wait for this future before asserting on placement decisions.
+     */
+    @Getter
+    @VisibleForTesting
+    private volatile CompletableFuture<Void> initialRackConfigurationLoadFuture =
+            CompletableFuture.completedFuture(null);
+
     public IsolatedBookieEnsemblePlacementPolicy() {
         super();
     }
@@ -91,7 +103,8 @@ public class IsolatedBookieEnsemblePlacementPolicy extends RackawareEnsemblePlac
             }
             // Only add the bookieMappingCache if we have defined an isolation group
             bookieMappingCache = store.getMetadataCache(BookiesRackConfiguration.class);
-            bookieMappingCache.get(BookieRackAffinityMapping.BOOKIE_INFO_ROOT_PATH).thenAccept(opt -> opt.ifPresent(
+            initialRackConfigurationLoadFuture = bookieMappingCache
+                    .get(BookieRackAffinityMapping.BOOKIE_INFO_ROOT_PATH).thenAccept(opt -> opt.ifPresent(
                             bookiesRackConfiguration -> cachedRackConfiguration = bookiesRackConfiguration))
                     .exceptionally(e -> {
                         log.warn("Failed to load bookies rack configuration while initialize the PlacementPolicy.");

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/bookie/rackawareness/IsolatedBookieEnsemblePlacementPolicyTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/bookie/rackawareness/IsolatedBookieEnsemblePlacementPolicyTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.bookie.rackawareness;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -42,6 +43,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import org.apache.bookkeeper.client.BKException.BKNotEnoughBookiesException;
 import org.apache.bookkeeper.client.RackawareEnsemblePlacementPolicy;
 import org.apache.bookkeeper.conf.ClientConfiguration;
@@ -57,6 +60,7 @@ import org.apache.pulsar.common.policies.data.EnsemblePlacementPolicyConfig;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.apache.pulsar.metadata.api.MetadataStore;
 import org.apache.pulsar.metadata.api.MetadataStoreConfig;
+import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.api.MetadataStoreFactory;
 import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
 import org.apache.pulsar.metadata.cache.impl.MetadataCacheImpl;
@@ -74,6 +78,7 @@ public class IsolatedBookieEnsemblePlacementPolicyTest {
     private static final String BOOKIE3 = "127.0.0.3:3181";
     private static final String BOOKIE4 = "127.0.0.4:3181";
     private static final String BOOKIE5 = "127.0.0.5:3181";
+    private static final int RACK_CONFIGURATION_LOAD_TIMEOUT_SECONDS = 30;
     private MetadataStore store;
 
     private final ObjectMapper jsonMapper = ObjectMapperFactory.create();
@@ -936,16 +941,52 @@ public class IsolatedBookieEnsemblePlacementPolicyTest {
     }
 
     /**
+     * A failed initial rack configuration load leaves {@code cachedRackConfiguration} null, which is
+     * indistinguishable from the load simply not having completed yet: no isolation is applied either way. The
+     * exposed future therefore reports that failure rather than completing normally, while initialization itself
+     * keeps its log-and-continue behaviour.
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testInitialRackConfigurationLoadFailureIsReportedWithoutFailingInitialize() throws Exception {
+        store = mock(MetadataStoreExtended.class);
+        MetadataCacheImpl<BookiesRackConfiguration> cache = mock(MetadataCacheImpl.class);
+        doReturn(cache).when(store).getMetadataCache(BookiesRackConfiguration.class);
+        MetadataStoreException loadFailure = new MetadataStoreException("simulated rack configuration load failure");
+        when(cache.get(BookieRackAffinityMapping.BOOKIE_INFO_ROOT_PATH))
+                .thenReturn(CompletableFuture.failedFuture(loadFailure));
+
+        ClientConfiguration bkClientConf = new ClientConfiguration();
+        bkClientConf.setProperty(BookieRackAffinityMapping.METADATA_STORE_INSTANCE, store);
+        bkClientConf.setProperty(IsolatedBookieEnsemblePlacementPolicy.ISOLATION_BOOKIE_GROUPS, isolationGroups);
+
+        IsolatedBookieEnsemblePlacementPolicy isolationPolicy = new IsolatedBookieEnsemblePlacementPolicy();
+        // A failed load must not break initialization; that is the pre-existing production behaviour.
+        isolationPolicy.initialize(bkClientConf, Optional.empty(), timer, SettableFeatureProvider.DISABLE_ALL,
+                NullStatsLogger.INSTANCE, BookieSocketAddress.LEGACY_BOOKIEID_RESOLVER);
+
+        assertThatThrownBy(() -> isolationPolicy.getInitialRackConfigurationLoadFuture()
+                .get(RACK_CONFIGURATION_LOAD_TIMEOUT_SECONDS, TimeUnit.SECONDS))
+                .isInstanceOf(ExecutionException.class)
+                .cause().isSameAs(loadFailure);
+    }
+
+    /**
      * Creates and initializes the policy under test, and waits until the rack configuration load started by
      * {@code initialize} has been applied. That load is asynchronous, and until it completes
      * {@code getExcludedBookiesWithIsolationGroups} finds a null {@code cachedRackConfiguration} and silently
      * applies no isolation at all, so any placement assertion made before it completes is racy.
+     *
+     * <p>The wait is bounded and propagates a failed load, so that a load which failed or never completed fails
+     * the test with its own cause instead of surfacing later as an unexplained placement assertion failure.
      */
-    private IsolatedBookieEnsemblePlacementPolicy createIsolationPolicy(ClientConfiguration bkClientConf) {
+    private IsolatedBookieEnsemblePlacementPolicy createIsolationPolicy(ClientConfiguration bkClientConf)
+            throws Exception {
         IsolatedBookieEnsemblePlacementPolicy isolationPolicy = new IsolatedBookieEnsemblePlacementPolicy();
         isolationPolicy.initialize(bkClientConf, Optional.empty(), timer, SettableFeatureProvider.DISABLE_ALL,
                 NullStatsLogger.INSTANCE, BookieSocketAddress.LEGACY_BOOKIEID_RESOLVER);
-        isolationPolicy.getInitialRackConfigurationLoadFuture().join();
+        isolationPolicy.getInitialRackConfigurationLoadFuture().get(RACK_CONFIGURATION_LOAD_TIMEOUT_SECONDS,
+                TimeUnit.SECONDS);
         return isolationPolicy;
     }
 

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/bookie/rackawareness/IsolatedBookieEnsemblePlacementPolicyTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/bookie/rackawareness/IsolatedBookieEnsemblePlacementPolicyTest.java
@@ -949,6 +949,8 @@ public class IsolatedBookieEnsemblePlacementPolicyTest {
     @SuppressWarnings("unchecked")
     @Test
     public void testInitialRackConfigurationLoadFailureIsReportedWithoutFailingInitialize() throws Exception {
+        // teardown() only closes whatever `store` points at, so close the real one before replacing it.
+        store.close();
         store = mock(MetadataStoreExtended.class);
         MetadataCacheImpl<BookiesRackConfiguration> cache = mock(MetadataCacheImpl.class);
         doReturn(cache).when(store).getMetadataCache(BookiesRackConfiguration.class);

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/bookie/rackawareness/IsolatedBookieEnsemblePlacementPolicyTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/bookie/rackawareness/IsolatedBookieEnsemblePlacementPolicyTest.java
@@ -117,12 +117,10 @@ public class IsolatedBookieEnsemblePlacementPolicyTest {
         store.put(BookieRackAffinityMapping.BOOKIE_INFO_ROOT_PATH, jsonMapper.writeValueAsBytes(bookieMapping),
                 Optional.empty()).join();
 
-        IsolatedBookieEnsemblePlacementPolicy isolationPolicy = new IsolatedBookieEnsemblePlacementPolicy();
         ClientConfiguration bkClientConf = new ClientConfiguration();
         bkClientConf.setProperty(BookieRackAffinityMapping.METADATA_STORE_INSTANCE, store);
         bkClientConf.setProperty(IsolatedBookieEnsemblePlacementPolicy.ISOLATION_BOOKIE_GROUPS, isolationGroups);
-        isolationPolicy.initialize(bkClientConf, Optional.empty(), timer, SettableFeatureProvider.DISABLE_ALL,
-                NullStatsLogger.INSTANCE, BookieSocketAddress.LEGACY_BOOKIEID_RESOLVER);
+        IsolatedBookieEnsemblePlacementPolicy isolationPolicy = createIsolationPolicy(bkClientConf);
         isolationPolicy.onClusterChanged(writableBookies, readOnlyBookies);
 
         List<BookieId> ensemble = isolationPolicy.newEnsemble(2, 2, 2,
@@ -176,12 +174,10 @@ public class IsolatedBookieEnsemblePlacementPolicyTest {
                 .thenReturn(waitingCompleteFuture).thenReturn(waitingCompleteFuture)
                 .thenReturn(emptyFuture).thenReturn(emptyFuture);
 
-        IsolatedBookieEnsemblePlacementPolicy isolationPolicy = new IsolatedBookieEnsemblePlacementPolicy();
         ClientConfiguration bkClientConf = new ClientConfiguration();
         bkClientConf.setProperty(BookieRackAffinityMapping.METADATA_STORE_INSTANCE, store);
         bkClientConf.setProperty(IsolatedBookieEnsemblePlacementPolicy.ISOLATION_BOOKIE_GROUPS, isolationGroups);
-        isolationPolicy.initialize(bkClientConf, Optional.empty(), timer, SettableFeatureProvider.DISABLE_ALL,
-                NullStatsLogger.INSTANCE, BookieSocketAddress.LEGACY_BOOKIEID_RESOLVER);
+        IsolatedBookieEnsemblePlacementPolicy isolationPolicy = createIsolationPolicy(bkClientConf);
         isolationPolicy.onClusterChanged(writableBookies, readOnlyBookies);
 
         MutablePair<Set<String>, Set<String>> groups = new MutablePair<>();
@@ -243,12 +239,10 @@ public class IsolatedBookieEnsemblePlacementPolicyTest {
         store.put(BookieRackAffinityMapping.BOOKIE_INFO_ROOT_PATH, jsonMapper.writeValueAsBytes(bookieMapping),
                 Optional.empty()).join();
 
-        IsolatedBookieEnsemblePlacementPolicy isolationPolicy = new IsolatedBookieEnsemblePlacementPolicy();
         ClientConfiguration bkClientConf = new ClientConfiguration();
         bkClientConf.setProperty(BookieRackAffinityMapping.METADATA_STORE_INSTANCE, store);
         bkClientConf.setProperty(IsolatedBookieEnsemblePlacementPolicy.ISOLATION_BOOKIE_GROUPS, isolationGroups);
-        isolationPolicy.initialize(bkClientConf, Optional.empty(), timer, SettableFeatureProvider.DISABLE_ALL,
-                NullStatsLogger.INSTANCE, BookieSocketAddress.LEGACY_BOOKIEID_RESOLVER);
+        IsolatedBookieEnsemblePlacementPolicy isolationPolicy = createIsolationPolicy(bkClientConf);
         isolationPolicy.onClusterChanged(writableBookies, readOnlyBookies);
 
         List<BookieId> ensemble = isolationPolicy.newEnsemble(3, 3, 2,
@@ -317,12 +311,10 @@ public class IsolatedBookieEnsemblePlacementPolicyTest {
 
     @Test
     public void testNoBookieInfo() throws Exception {
-        IsolatedBookieEnsemblePlacementPolicy isolationPolicy = new IsolatedBookieEnsemblePlacementPolicy();
         ClientConfiguration bkClientConf = new ClientConfiguration();
         bkClientConf.setProperty(BookieRackAffinityMapping.METADATA_STORE_INSTANCE, store);
         bkClientConf.setProperty(IsolatedBookieEnsemblePlacementPolicy.ISOLATION_BOOKIE_GROUPS, isolationGroups);
-        isolationPolicy.initialize(bkClientConf, Optional.empty(), timer, SettableFeatureProvider.DISABLE_ALL,
-                NullStatsLogger.INSTANCE, BookieSocketAddress.LEGACY_BOOKIEID_RESOLVER);
+        IsolatedBookieEnsemblePlacementPolicy isolationPolicy = createIsolationPolicy(bkClientConf);
         isolationPolicy.onClusterChanged(writableBookies, readOnlyBookies);
 
         isolationPolicy.newEnsemble(4, 4, 4, Collections.emptyMap(), new HashSet<>());
@@ -366,18 +358,11 @@ public class IsolatedBookieEnsemblePlacementPolicyTest {
         store.put(BookieRackAffinityMapping.BOOKIE_INFO_ROOT_PATH, jsonMapper.writeValueAsBytes(bookieMapping),
                 Optional.empty()).join();
 
-        IsolatedBookieEnsemblePlacementPolicy isolationPolicy = new IsolatedBookieEnsemblePlacementPolicy();
         ClientConfiguration bkClientConf = new ClientConfiguration();
         bkClientConf.setProperty(IsolatedBookieEnsemblePlacementPolicy.ISOLATION_BOOKIE_GROUPS, isolationGroups);
         bkClientConf.setProperty(BookieRackAffinityMapping.METADATA_STORE_INSTANCE, store);
-        isolationPolicy.initialize(bkClientConf, Optional.empty(), timer, SettableFeatureProvider.DISABLE_ALL,
-                NullStatsLogger.INSTANCE, BookieSocketAddress.LEGACY_BOOKIEID_RESOLVER);
+        IsolatedBookieEnsemblePlacementPolicy isolationPolicy = createIsolationPolicy(bkClientConf);
         isolationPolicy.onClusterChanged(writableBookies, readOnlyBookies);
-
-        // Wait for the async cache load triggered by initialize() to complete
-        Awaitility.await().atMost(Duration.ofSeconds(5)).untilAsserted(() ->
-                assertNotNull(isolationPolicy.getBookieMappingCache()
-                        .getIfCached(BookieRackAffinityMapping.BOOKIE_INFO_ROOT_PATH)));
 
         List<BookieId> ensemble = isolationPolicy.newEnsemble(2, 2, 2,
                 Collections.emptyMap(), new HashSet<>()).getResult();
@@ -418,11 +403,9 @@ public class IsolatedBookieEnsemblePlacementPolicyTest {
 
         Awaitility.await().until(() -> store.exists(BookieRackAffinityMapping.BOOKIE_INFO_ROOT_PATH).join());
 
-        IsolatedBookieEnsemblePlacementPolicy isolationPolicy = new IsolatedBookieEnsemblePlacementPolicy();
         ClientConfiguration bkClientConf = new ClientConfiguration();
         bkClientConf.setProperty(BookieRackAffinityMapping.METADATA_STORE_INSTANCE, store);
-        isolationPolicy.initialize(bkClientConf, Optional.empty(), timer, SettableFeatureProvider.DISABLE_ALL,
-                NullStatsLogger.INSTANCE, BookieSocketAddress.LEGACY_BOOKIEID_RESOLVER);
+        IsolatedBookieEnsemblePlacementPolicy isolationPolicy = createIsolationPolicy(bkClientConf);
         isolationPolicy.onClusterChanged(writableBookies, readOnlyBookies);
 
         isolationPolicy.newEnsemble(4, 4, 4, Collections.emptyMap(), new HashSet<>());
@@ -496,12 +479,10 @@ public class IsolatedBookieEnsemblePlacementPolicyTest {
         store.put(BookieRackAffinityMapping.BOOKIE_INFO_ROOT_PATH, jsonMapper.writeValueAsBytes(bookieMapping),
                 Optional.empty()).join();
 
-        IsolatedBookieEnsemblePlacementPolicy isolationPolicy = new IsolatedBookieEnsemblePlacementPolicy();
         ClientConfiguration bkClientConf = new ClientConfiguration();
         bkClientConf.setProperty(BookieRackAffinityMapping.METADATA_STORE_INSTANCE, store);
         bkClientConf.setProperty(IsolatedBookieEnsemblePlacementPolicy.ISOLATION_BOOKIE_GROUPS, isolatedGroup);
-        isolationPolicy.initialize(bkClientConf, Optional.empty(), timer, SettableFeatureProvider.DISABLE_ALL,
-                NullStatsLogger.INSTANCE, BookieSocketAddress.LEGACY_BOOKIEID_RESOLVER);
+        IsolatedBookieEnsemblePlacementPolicy isolationPolicy = createIsolationPolicy(bkClientConf);
         isolationPolicy.onClusterChanged(writableBookies, readOnlyBookies);
 
         List<BookieId> ensemble = isolationPolicy
@@ -540,14 +521,12 @@ public class IsolatedBookieEnsemblePlacementPolicyTest {
         store.put(BookieRackAffinityMapping.BOOKIE_INFO_ROOT_PATH, jsonMapper.writeValueAsBytes(bookieMapping),
                 Optional.empty()).join();
 
-        IsolatedBookieEnsemblePlacementPolicy isolationPolicy = new IsolatedBookieEnsemblePlacementPolicy();
         ClientConfiguration bkClientConf = new ClientConfiguration();
         bkClientConf.setProperty(BookieRackAffinityMapping.METADATA_STORE_INSTANCE, store);
         bkClientConf.setProperty(IsolatedBookieEnsemblePlacementPolicy.ISOLATION_BOOKIE_GROUPS, isolatedGroup);
         bkClientConf.setProperty(IsolatedBookieEnsemblePlacementPolicy.SECONDARY_ISOLATION_BOOKIE_GROUPS,
                 secondaryIsolatedGroup);
-        isolationPolicy.initialize(bkClientConf, Optional.empty(), timer, SettableFeatureProvider.DISABLE_ALL,
-                NullStatsLogger.INSTANCE, BookieSocketAddress.LEGACY_BOOKIEID_RESOLVER);
+        IsolatedBookieEnsemblePlacementPolicy isolationPolicy = createIsolationPolicy(bkClientConf);
         isolationPolicy.onClusterChanged(writableBookies, readOnlyBookies);
 
         List<BookieId> ensemble = isolationPolicy
@@ -580,21 +559,13 @@ public class IsolatedBookieEnsemblePlacementPolicyTest {
         store.put(BookieRackAffinityMapping.BOOKIE_INFO_ROOT_PATH, jsonMapper.writeValueAsBytes(bookieMapping),
                 Optional.empty()).join();
 
-        IsolatedBookieEnsemblePlacementPolicy isolationPolicy = new IsolatedBookieEnsemblePlacementPolicy();
         ClientConfiguration bkClientConf = new ClientConfiguration();
         bkClientConf.setProperty(BookieRackAffinityMapping.METADATA_STORE_INSTANCE, store);
         bkClientConf.setProperty(IsolatedBookieEnsemblePlacementPolicy.ISOLATION_BOOKIE_GROUPS, isolatedGroup);
         bkClientConf.setProperty(IsolatedBookieEnsemblePlacementPolicy.SECONDARY_ISOLATION_BOOKIE_GROUPS,
                 secondaryIsolatedGroup);
-        isolationPolicy.initialize(bkClientConf, Optional.empty(), timer, SettableFeatureProvider.DISABLE_ALL,
-                NullStatsLogger.INSTANCE, BookieSocketAddress.LEGACY_BOOKIEID_RESOLVER);
+        IsolatedBookieEnsemblePlacementPolicy isolationPolicy = createIsolationPolicy(bkClientConf);
         isolationPolicy.onClusterChanged(writableBookies, readOnlyBookies);
-
-        // Wait for the async cache load triggered by initialize() to complete; otherwise the
-        // first newEnsemble call can race with an empty cachedRackConfiguration and skip isolation.
-        Awaitility.await().atMost(Duration.ofSeconds(5)).untilAsserted(() ->
-                assertNotNull(isolationPolicy.getBookieMappingCache()
-                        .getIfCached(BookieRackAffinityMapping.BOOKIE_INFO_ROOT_PATH)));
 
         try {
             isolationPolicy
@@ -646,12 +617,10 @@ public class IsolatedBookieEnsemblePlacementPolicyTest {
         customMetadata.put(EnsemblePlacementPolicyConfig.ENSEMBLE_PLACEMENT_POLICY_CONFIG, policyConfig.encode());
 
         // do the test logic
-        IsolatedBookieEnsemblePlacementPolicy isolationPolicy = new IsolatedBookieEnsemblePlacementPolicy();
         ClientConfiguration bkClientConf = new ClientConfiguration();
         bkClientConf.setProperty(BookieRackAffinityMapping.METADATA_STORE_INSTANCE, store);
         bkClientConf.setProperty(IsolatedBookieEnsemblePlacementPolicy.ISOLATION_BOOKIE_GROUPS, primaryGroupName);
-        isolationPolicy.initialize(bkClientConf, Optional.empty(), timer, SettableFeatureProvider.DISABLE_ALL,
-            NullStatsLogger.INSTANCE, BookieSocketAddress.LEGACY_BOOKIEID_RESOLVER);
+        IsolatedBookieEnsemblePlacementPolicy isolationPolicy = createIsolationPolicy(bkClientConf);
         isolationPolicy.onClusterChanged(writableBookies, readOnlyBookies);
 
         // we assume we have an ensemble list which is consist with bookie1 and bookie3, and bookie3 is broken.
@@ -693,14 +662,12 @@ public class IsolatedBookieEnsemblePlacementPolicyTest {
         store.put(BookieRackAffinityMapping.BOOKIE_INFO_ROOT_PATH, jsonMapper.writeValueAsBytes(bookieMapping),
                 Optional.empty()).join();
 
-        IsolatedBookieEnsemblePlacementPolicy isolationPolicy = new IsolatedBookieEnsemblePlacementPolicy();
         ClientConfiguration bkClientConf = new ClientConfiguration();
         bkClientConf.setProperty(BookieRackAffinityMapping.METADATA_STORE_INSTANCE, store);
         bkClientConf.setProperty(IsolatedBookieEnsemblePlacementPolicy.ISOLATION_BOOKIE_GROUPS, defaultIsolatedGroup);
         bkClientConf.setProperty(IsolatedBookieEnsemblePlacementPolicy.SECONDARY_ISOLATION_BOOKIE_GROUPS,
                 defaultSecondaryIsolatedGroup);
-        isolationPolicy.initialize(bkClientConf, Optional.empty(), timer, SettableFeatureProvider.DISABLE_ALL,
-                NullStatsLogger.INSTANCE, BookieSocketAddress.LEGACY_BOOKIEID_RESOLVER);
+        IsolatedBookieEnsemblePlacementPolicy isolationPolicy = createIsolationPolicy(bkClientConf);
         isolationPolicy.onClusterChanged(writableBookies, readOnlyBookies);
 
         Map<String, Object> placementPolicyProperties = new HashMap<>();
@@ -745,22 +712,13 @@ public class IsolatedBookieEnsemblePlacementPolicyTest {
         store.put(BookieRackAffinityMapping.BOOKIE_INFO_ROOT_PATH, jsonMapper.writeValueAsBytes(bookieMapping),
                 Optional.empty()).join();
 
-        IsolatedBookieEnsemblePlacementPolicy isolationPolicy = new IsolatedBookieEnsemblePlacementPolicy();
         ClientConfiguration bkClientConf = new ClientConfiguration();
         bkClientConf.setProperty(BookieRackAffinityMapping.METADATA_STORE_INSTANCE, store);
         bkClientConf.setProperty(IsolatedBookieEnsemblePlacementPolicy.ISOLATION_BOOKIE_GROUPS, isolationGroup1);
         bkClientConf.setProperty(IsolatedBookieEnsemblePlacementPolicy.SECONDARY_ISOLATION_BOOKIE_GROUPS,
                 isolationGroup2);
-        isolationPolicy.initialize(bkClientConf, Optional.empty(), timer, SettableFeatureProvider.DISABLE_ALL,
-                NullStatsLogger.INSTANCE, BookieSocketAddress.LEGACY_BOOKIEID_RESOLVER);
+        IsolatedBookieEnsemblePlacementPolicy isolationPolicy = createIsolationPolicy(bkClientConf);
         isolationPolicy.onClusterChanged(writableBookies, readOnlyBookies);
-
-        // Wait for the async cache load triggered by initialize() to complete; otherwise
-        // getExcludedBookiesWithIsolationGroups returns an empty set when cachedRackConfiguration
-        // is still null. Same pattern used in testBookieInfoChange (#25473).
-        Awaitility.await().atMost(Duration.ofSeconds(5)).untilAsserted(() ->
-                assertNotNull(isolationPolicy.getBookieMappingCache()
-                        .getIfCached(BookieRackAffinityMapping.BOOKIE_INFO_ROOT_PATH)));
 
         /* Test common cases */
         MutablePair<Set<String>, Set<String>> groups = new MutablePair<>();
@@ -876,12 +834,10 @@ public class IsolatedBookieEnsemblePlacementPolicyTest {
         store.put(BookieRackAffinityMapping.BOOKIE_INFO_ROOT_PATH, jsonMapper.writeValueAsBytes(bookieMapping),
                 Optional.empty()).join();
 
-        IsolatedBookieEnsemblePlacementPolicy isolationPolicy = new IsolatedBookieEnsemblePlacementPolicy();
         ClientConfiguration bkClientConf = new ClientConfiguration();
         bkClientConf.setProperty(BookieRackAffinityMapping.METADATA_STORE_INSTANCE, store);
         bkClientConf.setProperty(IsolatedBookieEnsemblePlacementPolicy.ISOLATION_BOOKIE_GROUPS, "group1");
-        isolationPolicy.initialize(bkClientConf, Optional.empty(), timer, SettableFeatureProvider.DISABLE_ALL,
-                NullStatsLogger.INSTANCE, BookieSocketAddress.LEGACY_BOOKIEID_RESOLVER);
+        IsolatedBookieEnsemblePlacementPolicy isolationPolicy = createIsolationPolicy(bkClientConf);
         isolationPolicy.onClusterChanged(writableBookies, readOnlyBookies);
 
         // Use a policy class that does NOT match IsolatedBookieEnsemblePlacementPolicy.
@@ -932,12 +888,10 @@ public class IsolatedBookieEnsemblePlacementPolicyTest {
         store.put(BookieRackAffinityMapping.BOOKIE_INFO_ROOT_PATH, jsonMapper.writeValueAsBytes(bookieMapping),
                 Optional.empty()).join();
 
-        IsolatedBookieEnsemblePlacementPolicy isolationPolicy = new IsolatedBookieEnsemblePlacementPolicy();
         ClientConfiguration bkClientConf = new ClientConfiguration();
         bkClientConf.setProperty(BookieRackAffinityMapping.METADATA_STORE_INSTANCE, store);
         bkClientConf.setProperty(IsolatedBookieEnsemblePlacementPolicy.ISOLATION_BOOKIE_GROUPS, defaultGroup);
-        isolationPolicy.initialize(bkClientConf, Optional.empty(), timer, SettableFeatureProvider.DISABLE_ALL,
-                NullStatsLogger.INSTANCE, BookieSocketAddress.LEGACY_BOOKIEID_RESOLVER);
+        IsolatedBookieEnsemblePlacementPolicy isolationPolicy = createIsolationPolicy(bkClientConf);
         isolationPolicy.onClusterChanged(writableBookies, readOnlyBookies);
 
         // --- unit-level: getIsolationGroup should parse properties, not fall back to defaults ---
@@ -979,6 +933,20 @@ public class IsolatedBookieEnsemblePlacementPolicyTest {
                 .newEnsemble(2, 2, 2, Collections.emptyMap(), new HashSet<>()).getResult();
         assertTrue(bookieIdGroup1.containsAll(defaultEnsemble),
                 "default ensemble should come from " + defaultGroup + ", got " + defaultEnsemble);
+    }
+
+    /**
+     * Creates and initializes the policy under test, and waits until the rack configuration load started by
+     * {@code initialize} has been applied. That load is asynchronous, and until it completes
+     * {@code getExcludedBookiesWithIsolationGroups} finds a null {@code cachedRackConfiguration} and silently
+     * applies no isolation at all, so any placement assertion made before it completes is racy.
+     */
+    private IsolatedBookieEnsemblePlacementPolicy createIsolationPolicy(ClientConfiguration bkClientConf) {
+        IsolatedBookieEnsemblePlacementPolicy isolationPolicy = new IsolatedBookieEnsemblePlacementPolicy();
+        isolationPolicy.initialize(bkClientConf, Optional.empty(), timer, SettableFeatureProvider.DISABLE_ALL,
+                NullStatsLogger.INSTANCE, BookieSocketAddress.LEGACY_BOOKIEID_RESOLVER);
+        isolationPolicy.getInitialRackConfigurationLoadFuture().join();
+        return isolationPolicy;
     }
 
     // The policy gets the bookie info asynchronously before each query or update, when putting the bookie info into


### PR DESCRIPTION
### Motivation

`IsolatedBookieEnsemblePlacementPolicyTest` keeps flaking. It has already been patched five times, one test
method at a time — #25473, #25474, #25496, #25640, #25900 — and it is still failing. The most recent failure
is on `branch-4.2` CI, where `testNonRegionBookie` failed on both the initial run and the retry:

```
[ERROR] IsolatedBookieEnsemblePlacementPolicyTest.testNonRegionBookie:129 expected [false] but found [true]
```

i.e. `assertFalse(ensemble.contains(BOOKIE3))` — a bookie that is *not* in the isolation group ended up in the
ensemble. `master` carries the identical code, so the same latent race is here.

**Root cause.** `IsolatedBookieEnsemblePlacementPolicy.initialize()` kicks off a fire-and-forget load of the
bookie rack configuration:

```java
bookieMappingCache.get(BOOKIE_INFO_ROOT_PATH).thenAccept(opt -> opt.ifPresent(
        brc -> cachedRackConfiguration = brc))
```

and `getExcludedBookiesWithIsolationGroups()` degrades silently while that load is in flight:

```java
BookiesRackConfiguration allGroupsBookieMapping = cachedRackConfiguration;
if (allGroupsBookieMapping == null) {
    log.debug("The bookies rack config is not available at now.");
    return excludedBookies;   // empty -> nothing is excluded -> no isolation at all
}
```

Every test in the class calls `newEnsemble()` straight after `initialize()`. If the load has not completed,
no bookies are excluded and the rack-aware policy is free to pick any of the four writable bookies. Since
PIP-453 (#25187) moved metadata-store callbacks onto a dedicated executor, that window is wide enough to lose
on a loaded CI runner.

**The existing guards do not work.** Three tests carry this guard, added by the previous flake fixes:

```java
Awaitility.await().atMost(Duration.ofSeconds(5)).untilAsserted(() ->
        assertNotNull(isolationPolicy.getBookieMappingCache()
                .getIfCached(BookieRackAffinityMapping.BOOKIE_INFO_ROOT_PATH)));
```

`MetadataCache.getIfCached` returns `Optional<T>`, which is never `null`, so the condition is a tautology that
passes on the first poll. The guard only ever worked as an accidental `Thread.sleep` — Awaitility's default
100 ms poll delay. The remaining 11 test methods have no guard at all.

### Modifications

- `IsolatedBookieEnsemblePlacementPolicy` keeps a reference to the load chain it already creates, exposed as a
  `@VisibleForTesting` `initialRackConfigurationLoadFuture`. No behaviour change: the same chain is built, the
  same `exceptionally` handler applies, nothing new blocks or is retained.
- `IsolatedBookieEnsemblePlacementPolicyTest` routes all 14 policy creations through one `createIsolationPolicy()`
  helper that initializes the policy and then joins that future. Waiting on the *composed* future is what makes
  this airtight: completing the underlying cache future and running the `thenAccept` that assigns
  `cachedRackConfiguration` are two separate steps, so waiting on the cache entry alone still races.
- The three tautological `assertNotNull(...getIfCached(...))` guards are removed.

Future tests added to this class get the wait for free, which is the point — the per-test patching has not
converged in five attempts.

Not addressed here: the same window exists in production. Between BK client init and the first successful rack
config load, `getExcludedBookiesWithIsolationGroups()` applies no isolation at all and only says so at DEBUG
level, so ledgers created in that window can land on bookies outside the configured isolation group. That is a
behaviour change and belongs in its own PR.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as `IsolatedBookieEnsemblePlacementPolicyTest`.

Evidence that the diagnosis and the fix are correct, since the race is timing-dependent and does not reproduce
on a fast developer machine:

- With the metadata cache gated so the rack config load completes 300 ms late — exactly the CI condition — the
  un-waited path produced isolation violations in **17 of 20** rounds (the ensemble contained BOOKIE3/BOOKIE4);
  the waited path in **0 of 20**.
- Full class with `@Test(invocationCount = 10)`: 140 tests, 0 failures.
- `checkstyleMain`, `checkstyleTest` and `spotlessCheck` pass for `pulsar-broker-common`.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
