### PR TITLE
[fix][txn] Do not fail topic deletion when the aborted txn snapshot cannot be cleared

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
@@ -676,7 +676,20 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
         if (checkIfClosedAndCleared()) {
             return CompletableFuture.completedFuture(null);
         }
-        return snapshotAbortedTxnProcessor.clearAbortedTxnSnapshot().thenCompose(__ -> closeAsync())
+        // Removing the aborted txn snapshot is best-effort. It writes a tombstone to the
+        // __transaction_buffer_snapshot system topic of this namespace, which can fail permanently, for
+        // instance when the snapshot topic itself is gone or its producer has been closed. The topic must
+        // stay deletable in that case: callers such as PersistentTopic#checkReplication treat a failed
+        // deletion as retriable and would otherwise retry it forever. Failing here would also skip
+        // closeAsync() and leak the snapshot writer reference.
+        return snapshotAbortedTxnProcessor.clearAbortedTxnSnapshot()
+            .exceptionally(ex -> {
+                log.warn().exception(ex)
+                        .log("Failed to delete the aborted transaction snapshot, closing the transaction "
+                                + "buffer anyway. A stale snapshot entry may be left behind.");
+                return null;
+            })
+            .thenCompose(__ -> closeAsync())
             .thenAccept(__ -> {
                 changeToClosedAndClearedState();
             });

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBufferRecoveryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBufferRecoveryTest.java
@@ -18,12 +18,17 @@
  */
 package org.apache.pulsar.broker.transaction.buffer.impl;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
 import lombok.Cleanup;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.PositionFactory;
@@ -33,6 +38,7 @@ import org.apache.pulsar.broker.transaction.buffer.AbortedTxnProcessor;
 import org.apache.pulsar.broker.transaction.buffer.TransactionBufferProvider;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.ProducerConsumerBase;
+import org.apache.pulsar.client.api.PulsarClientException;
 import org.awaitility.Awaitility;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -137,6 +143,48 @@ public class TopicTransactionBufferRecoveryTest extends ProducerConsumerBase {
                             persistentTopic.getManagedLedger().getLastConfirmedEntry()));
             assertEquals(persistentTopic.getLastMaxReadPositionMovedForwardTimestamp(), 0L,
                     "Recovery of an idle topic should not move the max read position forward");
+        } finally {
+            pulsar.setTransactionBufferProvider(originalProvider);
+        }
+    }
+
+    /**
+     * Deleting the aborted txn snapshot writes a tombstone to the namespace's __transaction_buffer_snapshot
+     * system topic, which can fail permanently. Topic deletion must not depend on it: a caller that treats the
+     * failure as retriable, such as PersistentTopic#checkReplication after the local cluster has been removed
+     * from the namespace replication clusters, would otherwise retry the deletion forever. The transaction
+     * buffer must still be closed so the snapshot writer reference isn't leaked.
+     */
+    @Test
+    public void testTopicDeletionSucceedsWhenClearingAbortedTxnSnapshotFails() throws Exception {
+        String tpName = BrokerTestUtil.newUniqueName("persistent://public/default/tp-tb-clear-snapshot-fails");
+        AtomicReference<AbortedTxnProcessor> processorRef = new AtomicReference<>();
+        TransactionBufferProvider originalProvider = pulsar.getTransactionBufferProvider();
+        pulsar.setTransactionBufferProvider(originTopic -> {
+            AbortedTxnProcessor processor = mock(AbortedTxnProcessor.class);
+            when(processor.recoverFromSnapshot()).thenReturn(CompletableFuture.completedFuture(null));
+            when(processor.takeAbortedTxnsSnapshot(any()))
+                    .thenReturn(CompletableFuture.completedFuture(null));
+            when(processor.closeAsync()).thenReturn(CompletableFuture.completedFuture(null));
+            when(processor.clearAbortedTxnSnapshot()).thenReturn(CompletableFuture.failedFuture(
+                    new PulsarClientException.AlreadyClosedException("Producer already closed")));
+            processorRef.set(processor);
+            return new TopicTransactionBuffer(
+                    (PersistentTopic) originTopic, processor, AbortedTxnProcessor.SnapshotType.Single);
+        });
+        try {
+            Producer<byte[]> producer = pulsarClient.newProducer().topic(tpName).create();
+            producer.send("msg".getBytes(StandardCharsets.UTF_8));
+            producer.close();
+            AbortedTxnProcessor processor = processorRef.get();
+            assertNotNull(processor, "The test transaction buffer provider should have been used");
+
+            admin.topics().delete(tpName, true);
+
+            assertFalse(pulsar.getBrokerService().getTopicIfExists(tpName).get().isPresent(),
+                    "The topic should have been deleted despite the failing aborted txn snapshot cleanup");
+            verify(processor).clearAbortedTxnSnapshot();
+            verify(processor).closeAsync();
         } finally {
             pulsar.setTransactionBufferProvider(originalProvider);
         }


### PR DESCRIPTION
### Motivation

Deleting a topic ends in `PersistentTopic#transactionBufferCleanupAndClose()`, which calls
`TopicTransactionBuffer#clearSnapshotAndClose()`. That method first removes the topic's aborted
transaction snapshot — a tombstone written to the namespace's `__transaction_buffer_snapshot`
system topic — and only then closes the transaction buffer:

```java
return snapshotAbortedTxnProcessor.clearAbortedTxnSnapshot().thenCompose(__ -> closeAsync())
    .thenAccept(__ -> {
        changeToClosedAndClearedState();
    });
```

If that tombstone cannot be written, the whole topic deletion fails. That is a bad trade: the
topic's data is about to be removed anyway, and the caller has no way to make the write succeed.
Three consequences follow, all of them worse than a stale snapshot entry:

1. **The topic cannot be deleted at all**, and callers that treat a failed deletion as retriable
   retry it in a tight loop. `PersistentTopic#checkReplication()` is one such caller: when the
   local cluster is removed from a namespace's `replication_clusters`, it calls
   `removeTopicIfLocalClusterNotAllowed()` → `deleteForcefully()`. Every failure path of
   `delete()` un-fences the topic, un-fencing calls `checkReplication()` again, and the cycle
   restarts immediately. (That loop is a separate defect and is addressed in a separate PR; this
   PR removes the condition that makes it non-terminating.)
2. **`closeAsync()` is never reached**, because it is chained after the failing call. The
   `AbortedTxnProcessor`'s reference to the shared snapshot writer is therefore never released.
3. **`changeToClosedAndClearedState()` is never reached** either, so the
   `checkIfClosedAndCleared()` short-circuit at the top of the method can never arm and every
   retry re-runs the whole sequence.

This was observed in production on Pulsar 4.2.4. After the local cluster was removed from several
namespaces' replication clusters, the broker attempted to delete the affected topics and every
attempt failed with:

```
ERROR org.apache.pulsar.broker.service.persistent.PersistentTopic - [<topic>] Error deleting topic
java.util.concurrent.CompletionException: org.apache.pulsar.client.api.PulsarClientException$AlreadyClosedException: Producer already closed
	at o.a.p.b.transaction.buffer.impl.SingleSnapshotAbortedTxnProcessorImpl.clearAbortedTxnSnapshot(SingleSnapshotAbortedTxnProcessorImpl.java:119)
	at o.a.p.b.transaction.buffer.impl.TopicTransactionBuffer.clearSnapshotAndClose(TopicTransactionBuffer.java:662)
	at o.a.p.b.service.persistent.PersistentTopic.transactionBufferCleanupAndClose(PersistentTopic.java:4789)
	at o.a.p.b.service.persistent.PersistentTopic.lambda$delete$39(PersistentTopic.java:1585)
	...
Caused by: org.apache.pulsar.client.api.PulsarClientException$AlreadyClosedException: Producer already closed
	at o.a.p.client.impl.ProducerImpl.isValidProducerState(ProducerImpl.java:1083)
	at o.a.p.client.impl.ProducerImpl.sendAsync(ProducerImpl.java:553)
	...
	at o.a.p.b.systopic.TransactionBufferSnapshotBaseSystemTopicClient$TransactionBufferSnapshotWriter.deleteAsync(TransactionBufferSnapshotBaseSystemTopicClient.java:101)
	at o.a.p.b.transaction.buffer.impl.SingleSnapshotAbortedTxnProcessorImpl.lambda$clearAbortedTxnSnapshot$2(SingleSnapshotAbortedTxnProcessorImpl.java:124)
```

The producer to the namespace's `__transaction_buffer_snapshot` topic was permanently closed, and
it is never re-created: `SingleSnapshotAbortedTxnProcessorImpl#takeSnapshotWriter` is a `final`
field assigned once in the constructor, and `ReferenceCountedWriter#getFuture()` returns the same
already-completed future for the lifetime of that writer. So the failure was permanent, and every
affected topic was retried thousands of times per minute, producing tens of thousands of identical
stack traces per second.

#### Relation to previous fixes

The same failure mode has been narrowed down three times already, but each fix covers a different
variant:

* **#24648** added the `NamespaceEventsSystemTopicFactory#checkSystemTopicExists` guard to
  `clearAbortedTxnSnapshot()`, for the case where the snapshot topic itself no longer exists. In
  the scenario above that check returns **true** — the frames at
  `SingleSnapshotAbortedTxnProcessorImpl.java:121`/`:124` are inside the `if (exists)` branch — so
  the guard does not apply. The failure is a purely local producer-state check in
  `ProducerImpl#isValidProducerState`.
* **#25073** added the `ClosedAndCleared` state so a topic deletion that failed once is not
  repeated from scratch. As shown above, that latch is only armed on the success path, so it
  cannot arm when `clearAbortedTxnSnapshot()` is what fails.
* **#25114** fixed the same trigger on the unsubscribe path.

This PR closes the remaining variant, and does it once for every `AbortedTxnProcessor`
implementation rather than per failure mode.

### Modifications

Make removing the aborted transaction snapshot **best-effort** in
`TopicTransactionBuffer#clearSnapshotAndClose()`: a failure is logged at `WARN` and the transaction
buffer is still closed and still transitions to the `ClosedAndCleared` state, so topic deletion can
complete.

The handling is placed in `TopicTransactionBuffer` rather than in one processor, so it covers both
`SingleSnapshotAbortedTxnProcessorImpl` and `SnapshotSegmentAbortedTxnProcessorImpl`.

`clearSnapshot()` — the variant that does not close the buffer, used by the admin API — is
deliberately left unchanged and still propagates its failure.

Consequence, stated explicitly: when the tombstone cannot be written, a stale entry is left in
`persistent://<namespace>/__transaction_buffer_snapshot`. It is keyed by the full topic name and is
only read again by `AbortedTxnProcessor#recoverFromSnapshot()` if a topic with the identical name
is later created in the same namespace; aborted transactions restored from it are then discarded by
`trimExpiredAbortedTxns()`. This window already exists today for any broker that crashes between
deleting the topic's ledger and writing the tombstone, so the change does not introduce a new
class of orphan — it trades an unrecoverable, undeletable topic for a recoverable stale key.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

* Added `TopicTransactionBufferRecoveryTest#testTopicDeletionSucceedsWhenClearingAbortedTxnSnapshotFails`,
  which installs a `TransactionBufferProvider` whose `AbortedTxnProcessor#clearAbortedTxnSnapshot()`
  fails with `AlreadyClosedException("Producer already closed")`, and then asserts that
  `admin.topics().delete(topic, true)` succeeds, that the topic is gone, and that `closeAsync()` was
  still called on the processor so the snapshot writer reference is released.
* Without the production change the new test fails with exactly the symptom reported above —
  `PulsarAdminException$ServerSideErrorException: ... Message: Producer already closed`.
* `TopicTransactionBufferRecoveryTest` and `TransactionBufferCloseTest` pass.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
