### PR TITLE
[fix][broker] Bound the topic deletion retries triggered by a replication cluster removal

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -348,6 +348,15 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
     private final CompletableFuture<Void> initialReplicationCheck = new CompletableFuture<>();
     private final AtomicBoolean initialReplicationCheckInitialized = new AtomicBoolean(false);
 
+    /**
+     * Set while a deletion triggered by {@link #removeTopicIfLocalClusterNotAllowed()} is in progress, and while
+     * a failed one is waiting to be retried. Every failure path of {@link #delete} un-fences the topic, and
+     * un-fencing runs {@link #checkReplication()} again, which would start the same deletion again straight away.
+     * Without this guard, a deletion that keeps failing is retried in a tight loop for as long as the local
+     * cluster stays out of the replication clusters.
+     */
+    private final AtomicBoolean clusterRemovalDeletionInProgress = new AtomicBoolean(false);
+
     /***
      * We use 3 futures to prevent a new closing if there is an in-progress deletion or closing.  We make Pulsar return
      * the in-progress one when it is called the second time.
@@ -1637,6 +1646,9 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                     new CloseFutures(new CompletableFuture<>(), new CompletableFuture<>(), new CompletableFuture<>());
 
             AtomicBoolean alreadyUnFenced = new AtomicBoolean();
+            // The outer whenComplete below sees the same failure the inner handlers already reported, so it only
+            // logs the ones they did not.
+            AtomicBoolean deleteFailureLogged = new AtomicBoolean();
             CompletableFuture<Void> res = getBrokerService().getPulsar().getPulsarResources().getNamespaceResources()
                         .getPartitionedTopicResources().runWithMarkDeleteAsync(TopicName.get(topic), () -> {
                 CompletableFuture<Void> deleteFuture = new CompletableFuture<>();
@@ -1675,6 +1687,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                                 .thenCompose(ignore -> transactionBufferCleanupAndClose())
                                 .whenComplete((v, ex) -> {
                                     if (ex != null) {
+                                        deleteFailureLogged.set(true);
                                         log.error().exception(ex).log("Error deleting topic");
                                         alreadyUnFenced.set(true);
                                         unfenceTopicToResume();
@@ -1685,6 +1698,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
                                     FutureUtil.waitForAll(subsDeleteFutures).whenComplete((f, e) -> {
                                         if (e != null) {
+                                            deleteFailureLogged.set(true);
                                             log.error().exception(e).log("Error deleting topic");
                                             alreadyUnFenced.set(true);
                                             unfenceTopicToResume();
@@ -1716,6 +1730,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                                                                 .log("Topic is already deleted");
                                                         deleteLedgerComplete(ctx);
                                                     } else {
+                                                        deleteFailureLogged.set(true);
                                                         log.error()
                                                                 .exception(exception)
                                                                 .log("Error deleting topic");
@@ -1743,7 +1758,9 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                 return deleteFuture;
                 }).whenComplete((value, ex) -> {
                     if (ex != null) {
-                        log.error().exception(ex).log("Error deleting topic");
+                        if (!deleteFailureLogged.get()) {
+                            log.error().exception(ex).log("Error deleting topic");
+                        }
                         if (!alreadyUnFenced.get()) {
                             unfenceTopicToResume();
                         }
@@ -2250,15 +2267,74 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
     protected CompletableFuture<Boolean> removeTopicIfLocalClusterNotAllowed() {
         final String localCluster = brokerService.pulsar().getConfiguration().getClusterName();
         return checkAllowedCluster(localCluster).thenCompose(isAllowed -> {
-            if (!isAllowed) {
-                // if local cluster is removed from global namespace cluster-list : then delete topic forcefully
-                // because pulsar doesn't serve global topic without local repl-cluster configured.
-                return deleteForcefully().thenCompose(ignore -> {
-                    return deleteSchemaAndPoliciesIfClusterRemoved().thenApply(__ -> true);
-                });
+            if (isAllowed) {
+                return CompletableFuture.completedFuture(false);
             }
-            return CompletableFuture.completedFuture(false);
+            // if local cluster is removed from global namespace cluster-list : then delete topic forcefully
+            // because pulsar doesn't serve global topic without local repl-cluster configured.
+            if (!clusterRemovalDeletionInProgress.compareAndSet(false, true)) {
+                // A deletion is already in progress, or a failed one is waiting to be retried. Report the topic
+                // as removed so the caller does not start replicators for a topic that is being deleted.
+                return CompletableFuture.completedFuture(true);
+            }
+            return deleteForcefully()
+                    .thenCompose(ignore -> deleteSchemaAndPoliciesIfClusterRemoved())
+                    .thenApply(__ -> true)
+                    .whenComplete((__, ex) -> {
+                        if (ex != null) {
+                            scheduleClusterRemovalDeletionRetry();
+                        }
+                    });
         });
+    }
+
+    /**
+     * Schedules another attempt at the deletion triggered by the local cluster removal, so one that failed for a
+     * transient reason is still retried, at a bounded rate instead of in a tight loop. Must only be called while
+     * {@link #clusterRemovalDeletionInProgress} is set, which is what keeps a re-entrant check from starting a
+     * deletion of its own before the delay elapses.
+     */
+    private void scheduleClusterRemovalDeletionRetry() {
+        try {
+            brokerService.executor().schedule(this::retryClusterRemovalDeletion,
+                    getClusterRemovalDeletionRetryDelaySeconds(), SECONDS);
+        } catch (RejectedExecutionException e) {
+            // The broker is shutting down, so there is nothing left to retry.
+            clusterRemovalDeletionInProgress.set(false);
+        }
+    }
+
+    private void retryClusterRemovalDeletion() {
+        clusterRemovalDeletionInProgress.set(false);
+        if (isClosed()) {
+            return;
+        }
+        try {
+            checkReplication().exceptionally(ex -> {
+                rescheduleClusterRemovalDeletionAfterFailedCheck();
+                return null;
+            });
+        } catch (Throwable t) {
+            // checkReplication is overridable, so an implementation can fail before returning its future.
+            rescheduleClusterRemovalDeletionAfterFailedCheck();
+        }
+    }
+
+    /**
+     * Handles a replication check that failed before it could start a deletion, for instance because reading the
+     * namespace policies failed: nothing downstream scheduled the next attempt, so it has to be scheduled here. A
+     * failure of the deletion itself has already scheduled one and left {@link #clusterRemovalDeletionInProgress}
+     * set, which is what the compareAndSet detects, so the two paths never schedule competing retries.
+     */
+    private void rescheduleClusterRemovalDeletionAfterFailedCheck() {
+        if (clusterRemovalDeletionInProgress.compareAndSet(false, true)) {
+            scheduleClusterRemovalDeletionRetry();
+        }
+    }
+
+    @VisibleForTesting
+    long getClusterRemovalDeletionRetryDelaySeconds() {
+        return POLICY_UPDATE_FAILURE_RETRY_TIME_SECONDS;
     }
 
     protected CompletableFuture<Boolean> checkAllowedCluster(String localCluster) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicProtectedMethodsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicProtectedMethodsTest.java
@@ -18,9 +18,17 @@
  */
 package org.apache.pulsar.broker.service.persistent;
 
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
+import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import lombok.CustomLog;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl;
@@ -29,6 +37,7 @@ import org.apache.pulsar.broker.BrokerTestUtil;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.ProducerConsumerBase;
+import org.apache.pulsar.client.api.PulsarClientException;
 import org.awaitility.Awaitility;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -153,6 +162,99 @@ public class PersistentTopicProtectedMethodsTest extends ProducerConsumerBase {
 
         p1.close();
         c1.close();
+        admin.topics().delete(tp, false);
+    }
+
+    /***
+     * When the local cluster is removed from the replication clusters, checkReplication deletes the topic through
+     * removeTopicIfLocalClusterNotAllowed. Every failure path of PersistentTopic.delete un-fences the topic, and
+     * un-fencing runs checkReplication again, so a deletion that keeps failing must not be restarted every time
+     * the previous attempt reports its failure: that is an unbounded hot loop for as long as the local cluster
+     * stays out of the replication clusters. Retrying is only allowed again after a delay.
+     */
+    @Test
+    public void testClusterRemovalDeletionIsNotRetriedInALoop() throws Exception {
+        final String tp = BrokerTestUtil.newUniqueName("public/default/tp");
+        admin.topics().createNonPartitionedTopic(tp);
+        PersistentTopic persistentTopic = (PersistentTopic) pulsar.getBrokerService().getTopic(tp, false).join().get();
+
+        PersistentTopic spyTopic = spy(persistentTopic);
+        CompletableFuture<Void> firstDeletion = new CompletableFuture<>();
+        AtomicInteger deletions = new AtomicInteger();
+        doReturn(CompletableFuture.completedFuture(false)).when(spyTopic).checkAllowedCluster(anyString());
+        doAnswer(invocation -> deletions.incrementAndGet() == 1
+                ? firstDeletion : CompletableFuture.completedFuture(null))
+                .when(spyTopic).deleteForcefully();
+        // The scheduled retry is covered by testClusterRemovalDeletionIsRetriedWhenTheReplicationCheckFails.
+        // Push it beyond the lifetime of this test so none of the assertions below can race the timer.
+        doReturn(TimeUnit.HOURS.toSeconds(1)).when(spyTopic).getClusterRemovalDeletionRetryDelaySeconds();
+
+        // The first check starts the deletion.
+        CompletableFuture<Boolean> firstCheck = spyTopic.removeTopicIfLocalClusterNotAllowed();
+        assertFalse(firstCheck.isDone(), "The deletion is still in progress");
+
+        // A concurrent check must not start a second deletion, and must report the topic as being removed so the
+        // caller does not start replicators for it. checkAllowedCluster is stubbed with an already completed
+        // future, so deleteForcefully has been called by the time the check returns.
+        CompletableFuture<Boolean> concurrentCheck = spyTopic.removeTopicIfLocalClusterNotAllowed();
+        assertEquals(deletions.get(), 1);
+        assertTrue(concurrentCheck.get(5, TimeUnit.SECONDS));
+
+        // The deletion fails. This is what un-fences the topic and runs checkReplication again in production, so
+        // the check that immediately follows the failure must not start yet another deletion.
+        firstDeletion.completeExceptionally(
+                new PulsarClientException.AlreadyClosedException("Producer already closed"));
+        assertTrue(firstCheck.isCompletedExceptionally(), "The failure is still reported to the caller");
+        CompletableFuture<Boolean> checkAfterFailure = spyTopic.removeTopicIfLocalClusterNotAllowed();
+        assertEquals(deletions.get(), 1, "The failed deletion must not be restarted immediately");
+        assertTrue(checkAfterFailure.get(5, TimeUnit.SECONDS));
+
+        admin.topics().delete(tp, false);
+    }
+
+    /***
+     * A scheduled retry of the deletion goes through checkReplication, which can fail before it reaches the
+     * deletion at all, for example when reading the namespace policies fails. Nothing downstream schedules the
+     * next attempt in that case, so the retry has to be rescheduled by the check itself; otherwise the topic is
+     * left undeleted until an unrelated event happens to run another replication check. checkReplication is
+     * overridable through TopicFactory, so it can also fail synchronously, before returning its future.
+     */
+    @Test
+    public void testClusterRemovalDeletionIsRetriedWhenTheReplicationCheckFails() throws Exception {
+        final String tp = BrokerTestUtil.newUniqueName("public/default/tp");
+        admin.topics().createNonPartitionedTopic(tp);
+        PersistentTopic persistentTopic = (PersistentTopic) pulsar.getBrokerService().getTopic(tp, false).join().get();
+
+        PersistentTopic spyTopic = spy(persistentTopic);
+        AtomicInteger clusterChecks = new AtomicInteger();
+        AtomicInteger deletions = new AtomicInteger();
+        // Checks 2 and 3 are the ones the scheduled retries run. Fail both before they can start a deletion, the
+        // first synchronously and the second by returning a failed future.
+        doAnswer(invocation -> {
+            switch (clusterChecks.incrementAndGet()) {
+                case 2: throw new RuntimeException("mocked synchronous policy read failure");
+                case 3: return CompletableFuture.failedFuture(new RuntimeException("mocked policy read failure"));
+                default: return CompletableFuture.completedFuture(false);
+            }
+        }).when(spyTopic).checkAllowedCluster(anyString());
+        doAnswer(invocation -> deletions.incrementAndGet() == 1
+                ? CompletableFuture.failedFuture(
+                        new PulsarClientException.AlreadyClosedException("Producer already closed"))
+                : CompletableFuture.completedFuture(null))
+                .when(spyTopic).deleteForcefully();
+        doReturn(1L).when(spyTopic).getClusterRemovalDeletionRetryDelaySeconds();
+
+        // Check 1: the deletion is started and fails, so a retry is scheduled.
+        CompletableFuture<Boolean> firstCheck = spyTopic.removeTopicIfLocalClusterNotAllowed();
+        assertTrue(firstCheck.isCompletedExceptionally());
+        assertEquals(deletions.get(), 1);
+
+        // Checks 2 and 3 run from the scheduled retries and fail before starting a deletion. Check 4 must
+        // therefore still happen, and its deletion succeeds.
+        Awaitility.await().atMost(Duration.ofSeconds(60))
+                .untilAsserted(() -> assertEquals(deletions.get(), 2));
+        assertEquals(clusterChecks.get(), 4);
+
         admin.topics().delete(tp, false);
     }
 }


### PR DESCRIPTION
### Motivation

When the local cluster is removed from a namespace's `replication_clusters`,
`PersistentTopic#checkReplication()` calls `removeTopicIfLocalClusterNotAllowed()`, which calls
`deleteForcefully()`. That is documented, intended behaviour.

If that deletion **fails**, the broker retries it in an unbounded hot loop:

```
checkReplication()
  → removeTopicIfLocalClusterNotAllowed()                    (logs "Local cluster ... is not part of
                                                               global namespace repl list ...")
  → deleteForcefully() → delete(false, false, true)
  → ... some step of delete() fails
  → whenComplete: log.error("Error deleting topic"); unfenceTopicToResume();
  → unfenceTopicToResume() clears isFenced AND isClosingOrDeleting, then calls
    unfenceReplicatorsToResume() → checkReplication()        ← back to the top, immediately
```

Two things make it non-terminating:

* **The one re-entrancy guard is defeated, not absent.** `delete()` starts with
  `if (isClosingOrDeleting) { ... return failedFuture(new TopicFencedException(...)); }`, but
  `unfenceTopicToResume()` clears that exact flag before re-entering. In the incident below,
  `"Topic is already being closed or deleted"` appears **0 times** across ~29,700 re-entrant
  `delete()` calls.
* **The failure is never observed.** `unfenceReplicatorsToResume()` is `void` and discards
  `checkReplication()`'s future, so the existing 60 s backoff in
  `checkReplicationAndRetryOnFailure()` is never entered either — `"Policies update failed"` and
  `"scheduled retry"` also appear **0 times**.

So for as long as the local cluster stays out of the replication clusters and the deletion keeps
failing, the broker re-runs the entire deletion as fast as its executors allow.

Observed in production on Pulsar 4.2.4, in a 12.7-second broker log fragment:

| count | line |
|---:|---|
| 59,430 | `ERROR PersistentTopic - [<topic>] Error deleting topic` |
| 29,715 | `INFO BrokerService - Successfully delete authentication policies for topic <topic>` |
| 29,714 | `WARN PersistentTopic - Local cluster <local> is not part of global namespace repl list [<remote>] and allowed list []` |
| 29,710 | `INFO AbstractReplicator - [<topic> \| <local>-><remote>] Skip current termination since other thread is doing termination, state : Terminated` |
| 41 | *everything else in the entire file* |

109 topics, ~29,700 deletion attempts in 12.7 s (~26/s per topic), 2.2 M log lines / 239 MB
(~19 MB/s), and every one of the broker's ordered-executor threads saturated with work that could
never succeed. The topic-executor pool also carries topic-policy application, message TTL expiry and,
per `ServiceConfiguration`, *"load/unload bundle, update managedLedgerConfig, update
topic/subscription/replicator message dispatch rate, do leader election etc."* — so the whole broker
degrades. `/status.html` kept answering `200` in `0 ms` throughout, so a Kubernetes liveness probe
would not catch it.

In that incident the deletions failed in `transactionBufferCleanupAndClose()`, which is fixed
separately (see below). But the loop is a defect on its own: **any** persistent failure of `delete()`
reaches it.

Note the two `log.error("Error deleting topic")` per attempt — the inner handler logs the failure and
the outer `whenComplete` logs the very same `Throwable` again, doubling the volume of the worst case.

#### Relation to previous fixes

The transaction-buffer failure that triggered this loop has been narrowed three times — **#24648**
(guard for "the snapshot topic no longer exists"), **#25073** (*"Infinitely failed to delete topic if
the first time failed and enabled transaction"*) and **#25114** (the same trigger on the unsubscribe
path). Each removes one way of reaching the loop; the loop itself was never bounded, so the next
unhandled failure re-opens it. #25073 in particular names the symptom, but its `ClosedAndCleared`
latch is only armed on the success path, so it cannot help when the cleanup itself is what fails.

The remaining transaction-buffer variant is fixed in a companion PR,
*"[fix][txn] Do not fail topic deletion when the aborted txn snapshot cannot be cleared"*. The two
changes are independent and either one alone stops this incident; both are worth having.

Provenance of the cycle: `unfenceTopicToResume()`-on-delete-failure came from **#19129**
(*"Topic could be in fenced state forever if deletion fails"*). The edge that closed the cycle came
from **#21948**, which added `unfenceReplicatorsToResume()` and its `checkReplication()` call; that PR
touched only replicator classes and has no cluster-removal test.

### Modifications

1. **Bound the retries.** `removeTopicIfLocalClusterNotAllowed()` now CASes a new
   `clusterRemovalDeletionInProgress` flag before calling `deleteForcefully()`, and reports the topic
   as removed (`true`) when the CAS fails, so a re-entrant check does not start a second deletion and
   the caller does not start replicators for a topic that is being deleted.

   The guard is placed at the deletion's origin rather than in `unfenceReplicatorsToResume()` on
   purpose: un-fencing also exists to resume replicators after a *transient* close failure, which
   `OneWayReplicatorTest#testUnFenceTopicToReuse` pins, and that path must keep working.

2. **Keep retrying, at a bounded rate.** On failure the flag is re-armed after
   `POLICY_UPDATE_FAILURE_RETRY_TIME_SECONDS` (60 s, the constant this class already uses for the
   equivalent purpose) and the replication check runs again, so a deletion that failed for a transient
   reason is still retried — roughly once a minute instead of ~26 times a second.

   The retry also has to survive a replication check that fails *before* it can start a deletion (for
   instance when reading the namespace policies fails): nothing downstream would schedule the next
   attempt in that case, so `retryClusterRemovalDeletion()` reschedules it itself. `checkReplication()`
   is overridable through `TopicFactory`, so both an exceptional future and a synchronous throw are
   handled. The reschedule is guarded by the same CAS, so a failure originating in the deletion — which
   has already scheduled a retry and left the flag set — never produces a second, competing chain.

3. **Stop logging every deletion failure twice.** A `deleteFailureLogged` flag lets the outer
   `whenComplete` in `delete()` skip a failure an inner handler has already reported, while still
   logging the ones it has not (for example a failure of `runWithMarkDeleteAsync` itself).

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

* `PersistentTopicProtectedMethodsTest#testClusterRemovalDeletionIsNotRetriedInALoop` — a re-entrant
  check while a deletion is in flight, and one immediately after it fails, must not start another
  deletion. Without the change it fails with
  `TooManyActualInvocations: persistentTopic.deleteForcefully(); Wanted 1 time ... But was 2 times`.
* `PersistentTopicProtectedMethodsTest#testClusterRemovalDeletionIsRetriedWhenTheReplicationCheckFails`
  — the deletion is still retried after the delay, including when the intervening replication checks
  fail synchronously and asynchronously before reaching a deletion.
* Both tests were mutation-checked: disabling the CAS guard fails the first; removing either the
  synchronous or the asynchronous reschedule fails the second.
* `OneWayReplicatorTest` (52 tests, includes `testUnFenceTopicToReuse`),
  `OneWayReplicatorUsingGlobalZKTest` (24 tests, includes `testRemoveCluster`) and
  `ReplicatorRemoveClusterTest` (`testRemoveClusterFromNamespace`) all pass — the actual
  cluster-removal deletion still works.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
