### PR TITLE
[test][broker] Reproduce shared topic permission deletion

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorUsingGlobalZKTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorUsingGlobalZKTest.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.broker.service;
 
 import static org.apache.pulsar.broker.service.TopicPoliciesService.GetType.GLOBAL_ONLY;
 import static org.apache.pulsar.broker.service.TopicPoliciesService.GetType.LOCAL_ONLY;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -28,6 +29,7 @@ import static org.testng.Assert.fail;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -51,6 +53,7 @@ import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.policies.data.AuthAction;
 import org.apache.pulsar.common.policies.data.AutoFailoverPolicyData;
 import org.apache.pulsar.common.policies.data.AutoFailoverPolicyType;
 import org.apache.pulsar.common.policies.data.AutoTopicCreationOverride;
@@ -118,6 +121,27 @@ public class OneWayReplicatorUsingGlobalZKTest extends OneWayReplicatorTest {
     @Test(dataProvider = "isPartitioned")
     public void testReplicatorCreateTopic(boolean isPartitioned) throws Exception {
         super.testReplicatorCreateTopic(isPartitioned);
+    }
+
+    @Test
+    public void testDeletingTopicOnOneClusterKeepsSharedTopicPermissions() throws Exception {
+        String topic = BrokerTestUtil.newUniqueName("persistent://" + replicatedNamespace + "/topic-permissions-");
+        String role = "test-role";
+        Set<AuthAction> permissions = EnumSet.of(AuthAction.produce, AuthAction.consume);
+
+        admin1.topics().createNonPartitionedTopic(topic);
+        admin2.topics().createNonPartitionedTopic(topic);
+        try {
+            admin2.topics().grantPermission(topic, role, permissions);
+            assertThat(admin1.topics().getPermissions(topic)).containsEntry(role, permissions);
+
+            admin2.topics().delete(topic, true);
+
+            assertThat(admin1.topics().getStats(topic)).isNotNull();
+            assertThat(admin1.topics().getPermissions(topic)).containsEntry(role, permissions);
+        } finally {
+            admin1.topics().delete(topic, true);
+        }
     }
 
     @Override


### PR DESCRIPTION
## Motivation

In a multi-cluster deployment with separate local metadata stores and a shared configuration metadata store, topic-level permissions are shared even though topic lifecycles remain local. Deleting a topic in one cluster currently removes the shared permission entry while the same-named topic remains available in another cluster.

This draft adds a deterministic regression reproducer before the behavior is corrected.

## Modifications

- Add a two-broker integration test using the existing shared-configuration-store fixture.
- Create the same topic in both clusters, grant topic-level permissions through one cluster, and verify they are visible through the other.
- Delete the topic from one cluster, verify the peer topic still exists, and assert that its permissions remain.

## Testing

- `gradle :pulsar-broker:checkstyleTest` passes.
- `gradle :pulsar-broker:test --tests "org.apache.pulsar.broker.service.OneWayReplicatorUsingGlobalZKTest.testDeletingTopicOnOneClusterKeepsSharedTopicPermissions" -PtestRetryCount=0` reproduces the issue: the peer topic remains, but its permissions are `{}`.