### PR TITLE
[fix][sec][branch-4.x] Upgrade vertx to 4.5.32

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -509,11 +509,11 @@ The Apache Software License, Version 2.0
   * JCTools - Java Concurrency Tools for the JVM
     - org.jctools-jctools-core-4.0.5.jar
   * Vertx
-    - io.vertx-vertx-auth-common-4.5.28.jar
-    - io.vertx-vertx-bridge-common-4.5.28.jar
-    - io.vertx-vertx-core-4.5.28.jar
-    - io.vertx-vertx-web-4.5.28.jar
-    - io.vertx-vertx-web-common-4.5.28.jar
+    - io.vertx-vertx-auth-common-4.5.32.jar
+    - io.vertx-vertx-bridge-common-4.5.32.jar
+    - io.vertx-vertx-core-4.5.32.jar
+    - io.vertx-vertx-web-4.5.32.jar
+    - io.vertx-vertx-web-common-4.5.32.jar
   * Apache ZooKeeper
     - org.apache.zookeeper-zookeeper-jute-3.9.5.jar
   * Snappy Java

--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,7 @@ flexible messaging model and an intuitive client API.</description>
     <jersey.version>2.42</jersey.version>
     <athenz.version>1.10.62</athenz.version>
     <prometheus.version>0.16.0</prometheus.version>
-    <vertx.version>4.5.28</vertx.version>
+    <vertx.version>4.5.32</vertx.version>
     <rocksdb.version>7.9.2</rocksdb.version>
     <slf4j.version>2.0.18</slf4j.version>
     <commons.collections4.version>4.5.0</commons.collections4.version>


### PR DESCRIPTION
### Motivation

Vert.x 4.5.28 is currently used in branch-4.2. Versions 4.5.29 - 4.5.32 contain security and robustness fixes, both directly in Vert.x and in its transitive dependencies. Upgrading keeps the shipped Vert.x (used by the BookKeeper HTTP server and jetcd) free of known vulnerable versions.

Notable changes picked up by this upgrade:

- **4.5.29**: vertx-web [response not ended on edge error cases](https://github.com/vert-x3/vertx-web/issues/2908); transitive Netty 4.1.136.Final and Jackson 2.21.5 bumps
- **4.5.30**: the [default HTTP client redirect handler now removes sensitive headers on cross-origin redirects by default](https://github.com/eclipse-vertx/vert.x/issues/6243), plus [WebClient HTTP state management improvements](https://github.com/vert-x3/vertx-web/issues/2931)
- **4.5.31**: [JDK PQC availability detection](https://github.com/eclipse-vertx/vert.x/pull/6245)
- **4.5.32**: transitive [Netty 4.1.137](https://github.com/vert-x3/vertx-dependencies/pull/293) bump; vertx-json-schema [recursive `$ref` fix](https://github.com/eclipse-vertx/vertx-json-schema/issues/141)

Release notes:
- https://github.com/vert-x3/wiki/wiki/4.5.29-Release-Notes
- https://github.com/vert-x3/wiki/wiki/4.5.30-Release-Notes
- https://github.com/vert-x3/wiki/wiki/4.5.31-Release-Notes
- https://github.com/vert-x3/wiki/wiki/4.5.32-Release-Notes

### Modifications

- Bump `vertx.version` from `4.5.28` to `4.5.32` in the root `pom.xml`
- Update the Vert.x jar names in `distribution/server/src/assemble/LICENSE.bin.txt`

This is a patch-level upgrade within the Vert.x 4.5.x line, so no source changes are required.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [x] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

- [ ] `doc`
- [ ] `doc-required`
- [x] `doc-not-needed`
- [ ] `doc-complete`
