### PR TITLE
[fix][sec][branch-4.x] Upgrade Thrift to 0.24.0

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -433,7 +433,7 @@ The Apache Software License, Version 2.0
  * SnakeYaml -- org.yaml-snakeyaml-2.0.jar
  * RocksDB - org.rocksdb-rocksdbjni-7.9.2.jar
  * Google Error Prone Annotations - com.google.errorprone-error_prone_annotations-2.45.0.jar
- * Apache Thrift - org.apache.thrift-libthrift-0.23.0.jar
+ * Apache Thrift - org.apache.thrift-libthrift-0.24.0.jar
  * OkHttp3
      - com.squareup.okhttp3-logging-interceptor-5.3.2.jar
      - com.squareup.okhttp3-okhttp-5.3.2.jar

--- a/pom.xml
+++ b/pom.xml
@@ -303,7 +303,7 @@ flexible messaging model and an intuitive client API.</description>
     <ant.version>1.10.12</ant.version>
     <seancfoley.ipaddress.version>5.5.0</seancfoley.ipaddress.version>
     <disruptor.version>3.4.3</disruptor.version>
-    <thrift.version>0.23.0</thrift.version>
+    <thrift.version>0.24.0</thrift.version>
 
     <!-- zstd-jni is only used for testcase,
     the core logic is switched to java implementation of zstd in org.apache.commons:commons-compress -->
@@ -1352,7 +1352,7 @@ flexible messaging model and an intuitive client API.</description>
         </exclusions>
       </dependency>
       <!-- libthrift is a transitive dependency of distributedlog-core.
-      libthrift 0.23.0 upgraded to jakarta.* and HttpComponents 5 deps for its HTTP/servlet
+      libthrift 0.23.0 and later upgraded to jakarta.* and HttpComponents 5 deps for its HTTP/servlet
       transports, which distributedlog-core does not use (only TJSON/TMemory serialization is needed). !-->
       <dependency>
         <groupId>org.apache.thrift</groupId>


### PR DESCRIPTION
Fixes #26297

### Motivation

Apache Thrift is reported to be affected by multiple CVEs in the 4.x release lines:

- CVE-2026-55971
- CVE-2026-48144
- CVE-2026-58023
- CVE-2026-58662
- CVE-2026-45112
- CVE-2026-43871

`libthrift` reaches Pulsar as a transitive dependency of `distributedlog-core` (used by `pulsar-package-management/bookkeeper-storage` and `pulsar-functions/worker`), so the shaded server distribution ships the jar and dependency scanners flag it.

Apache Thrift 0.24.0 is the latest release and addresses these reports, so upgrading is the straightforward mitigation.

### Modifications

- Bump `thrift.version` from `0.23.0` to `0.24.0` in the root `pom.xml`.
- Update the `libthrift` jar entry in `distribution/server/src/assemble/LICENSE.bin.txt` accordingly.
- Reword the adjacent comment to `libthrift 0.23.0 and later` since the exclusion rationale applies to 0.24.0 as well.

The existing exclusions for the jakarta.* / HttpComponents 5 HTTP and servlet transports are unchanged and remain effective: the `libthrift` POM is byte-for-byte identical between 0.23.0 and 0.24.0 apart from the `<version>` element, so the dependency tree shape is the same. Verified with:

```
$ mvn -ntp dependency:tree -pl pulsar-package-management/bookkeeper-storage -Dincludes=org.apache.thrift
[INFO]    \- org.apache.thrift:libthrift:jar:0.24.0:compile
[INFO] BUILD SUCCESS
```

`libthrift` resolves as a leaf, confirming none of the excluded transitives leak back in.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

Pulsar does not compile against Thrift APIs directly; only `distributedlog-core`'s TJSON/TMemory serialization uses it. The binary license check in the distribution build validates the updated `LICENSE.bin.txt` entry.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [x] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
