### PR TITLE
[fix][sec][branch-4.x] Upgrade lz4-java to 1.11.2

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -383,7 +383,7 @@ The Apache Software License, Version 2.0
     - org.apache.bookkeeper-bookkeeper-slogger-api-4.17.4.jar
     - org.apache.bookkeeper-bookkeeper-slogger-slf4j-4.17.4.jar
     - org.apache.bookkeeper-native-io-4.17.4.jar
-    - at.yawk.lz4-lz4-java-1.11.1.jar
+    - at.yawk.lz4-lz4-java-1.11.2.jar
   * Apache HTTP Client
     - org.apache.httpcomponents-httpclient-4.5.14.jar
     - org.apache.httpcomponents-httpcore-4.4.16.jar

--- a/pom.xml
+++ b/pom.xml
@@ -375,7 +375,7 @@ flexible messaging model and an intuitive client API.</description>
     <commons-beanutils.version>1.11.0</commons-beanutils.version>
     <commons-configuration2.version>2.15.1</commons-configuration2.version>
     <mina-core.version>2.1.10</mina-core.version>
-    <lz4java.version>1.11.1</lz4java.version>
+    <lz4java.version>1.11.2</lz4java.version>
     <jsr305.version>3.0.2</jsr305.version>
   </properties>
 


### PR DESCRIPTION
### Motivation

lz4-java 1.11.2 is a security-only release that fixes two unvalidated-allocation
(CWE-789) issues, both moderate, both CVSS 5.3
(`CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L`), both affecting
`at.yawk.lz4:lz4-java <= 1.11.1`:

- [GHSA-6cx8-rjf8-pr8g](https://github.com/yawkat/lz4-java/security/advisories/GHSA-6cx8-rjf8-pr8g) —
  `LZ4DecompressorWithLength.decompress(byte[], int)` reads the 4-byte little-endian
  decompressed-length header via `getDecompressedLength()` and passes it straight to
  `LZ4FastDecompressor.decompress(byte[], int, int)`, which does `new byte[destLen]`
  before reading a single byte of payload. `getDecompressedLength()` performs no
  validation at all — no bound against `src.length`, no ceiling, no rejection of
  negatives — so a 5-byte input can force up to a 2 GiB allocation per call.
  `LZ4SafeDecompressor.decompress(byte[], int, int, int)` has the same shape via
  `maxDestLen`.
- [GHSA-4v53-57pg-c464](https://github.com/yawkat/lz4-java/security/advisories/GHSA-4v53-57pg-c464) —
  `LZ4BlockInputStream.refill()` grows its compressed-input buffer to the
  attacker-controlled `compressedLen` taken from the legacy `LZ4Block` header before
  reading the payload, so a header-only input can trigger a near-2 GiB allocation.

Neither advisory has a CVE assigned; both are repository-level advisories published
2026-08-06 and are only reachable through
`/repos/yawkat/lz4-java/security-advisories`, not the global advisory database.

**Exposure in Pulsar is limited, but the vulnerable jar does ship.** Pulsar's own LZ4
codec (`CompressionCodecLZ4`) uses aircompressor, not lz4-java, and no Pulsar
production code calls the affected decompressor APIs — `pulsar-common` declares
lz4-java at `test` scope only, for the `CompressionCodecLZ4JNI` reference codec.
However `at.yawk.lz4:lz4-java` reaches the server distribution transitively via
BookKeeper's `distributedlog-common`, so `lib/at.yawk.lz4-lz4-java-1.11.1.jar` is
bundled in the release tarball and is reported by dependency scanners.

`master` is already on 1.11.2 (`gradle/libs.versions.toml`); this is the branch-4.x
port. `branch-4.0` is also on 1.11.1 and takes the same patch.

### Modifications

- `pom.xml` — bump `lz4java.version` from `1.11.1` to `1.11.2`. The
  `dependencyManagement` entry for `at.yawk.lz4:lz4-java` uses this property, so it also
  pins the transitive BookKeeper/distributedlog resolution.
- `distribution/server/src/assemble/LICENSE.bin.txt` — update the bundled jar name to
  `at.yawk.lz4-lz4-java-1.11.2.jar`.

Upstream 1.11.2 is a security patch plus 23 Renovate dependency/plugin updates
([v1.11.1...v1.11.2](https://github.com/yawkat/lz4-java/compare/v1.11.1...v1.11.2)).

One upstream behaviour change is worth calling out: per GHSA-4v53-57pg-c464, 1.11.2
now rejects LZ4 blocks whose compressed length exceeds the uncompressed length. A
canonical `LZ4BlockOutputStream` never emits such a block — it writes
`COMPRESSION_METHOD_RAW` instead — so this only rejects non-canonical input. The new
`acceptOversizedBlocks` flag restores the old behaviour but reintroduces the DoS
vector. Pulsar does not use `LZ4BlockInputStream`/`LZ4BlockOutputStream`, so this does
not affect Pulsar's on-the-wire format.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a dependency upgrade without new test coverage; it is covered by
existing tests.

Verified locally:

- The jar contents are unchanged in shape between 1.11.1 and 1.11.2: the set of
  `.class` and bundled native library (`.so`/`.dylib`/`.dll`) entries is **identical**,
  and the set of artifacts referenced by the published POM is **identical** — no public
  API change, no new transitive dependency.
- The new version resolves everywhere it is used:

```
$ mvn -ntp dependency:tree -pl pulsar-common,pulsar-functions/worker,pulsar-package-management/bookkeeper-storage -Dincludes=at.yawk.lz4:lz4-java
[INFO] Building Pulsar Common 4.2.5-SNAPSHOT                              [1/3]
[INFO] \- at.yawk.lz4:lz4-java:jar:1.11.2:test
[INFO] Building Pulsar Functions :: Worker 4.2.5-SNAPSHOT                 [2/3]
[INFO]          \- at.yawk.lz4:lz4-java:jar:1.11.2:compile
[INFO] Building Apache Pulsar :: Package Management :: BookKeeper Storage 4.2.5-SNAPSHOT [3/3]
[INFO]          \- at.yawk.lz4:lz4-java:jar:1.11.2:compile
[INFO] BUILD SUCCESS
```

- The downloaded `lz4-java-1.11.2.jar` SHA-1 matches the checksum published on Maven
  Central.
- The updated `LICENSE.bin.txt` entry is validated in CI by
  `src/check-binary-license.sh` against the assembled server tarball.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [x] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
