### PR TITLE
[improve][build] Upgrade Gradle to 9.7.1

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=84fbba45c7f4c64abc77460e1c00f541e9f960e3c7ed2538f1ede19eacd873ae
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
+distributionSha256Sum=acd53f1edaf02f1a8ff99879f8a34b302661a057d9b063ae9e35b552f804d20a
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 networkTimeout=10000
 retries=3
 retryBackOffMs=1000


### PR DESCRIPTION
### Motivation

Gradle [9.7.1](https://docs.gradle.org/9.7.1/release-notes.html) is a patch release that fixes six
regressions introduced in 9.7.0, the version this repository upgraded to in #26332.

The one that matters most for day-to-day development is
[gradle/gradle#38788](https://github.com/gradle/gradle/issues/38788): 9.7.0 broke the formatting of
test failure comparisons, which disabled the **"Click to see difference"** IDE support for failed
assertions. 9.7.1 restores it.

The other five: `BaseExecSpec` stream API conformance, ANTLR leaking onto the kapt compile classpath,
custom `Transformer` implementations working again, parent-first class resolution for `ant.taskdef`
with an explicit classpath, and the required argument order of `Option` annotations in the Kotlin DSL.

### Modifications

Bump `distributionUrl` and `distributionSha256Sum` in `gradle/wrapper/gradle-wrapper.properties` to
9.7.1. The checksum matches the published `gradle-9.7.1-bin.zip` SHA-256 (`acd53f1e…`).

`gradlew`, `gradlew.bat` and `gradle-wrapper.jar` need no regeneration: the published
`gradle-9.7.1-wrapper.jar` has the same SHA-256 (`7a9ce74c…`) as the 9.7.0 jar already checked in, and
`./gradlew wrapper --gradle-version 9.7.1` leaves all three files untouched. That task still rewrites
`retries`/`retryBackOffMs` to its own defaults, so those are kept at the values this repository uses
(`3` / `1000`).

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

`./gradlew spotlessCheck checkstyleMain checkstyleTest` passes locally on 9.7.1.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [x] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

Build tooling only: the Gradle wrapper, 9.7.0 → 9.7.1. No change to any shipped artifact.
