### PR TITLE
[fix][fn] Return descriptive errors for unknown JSON properties

### DIFF
--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/Resources.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/Resources.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.functions.worker.rest;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import org.apache.pulsar.broker.web.UnrecognizedPropertyExceptionMapper;
 import org.apache.pulsar.functions.worker.rest.api.FunctionsMetricsResource;
 import org.apache.pulsar.functions.worker.rest.api.v2.FunctionsApiV2Resource;
 import org.apache.pulsar.functions.worker.rest.api.v2.WorkerApiV2Resource;
@@ -43,6 +44,7 @@ public final class Resources {
                         FunctionsApiV2Resource.class,
                         WorkerApiV2Resource.class,
                         WorkerStatsApiV2Resource.class,
+                        UnrecognizedPropertyExceptionMapper.class,
                         MultiPartFeature.class
                 ));
     }
@@ -52,6 +54,7 @@ public final class Resources {
         return new HashSet<>(
                 Arrays.asList(
                         MultiPartFeature.class,
+                        UnrecognizedPropertyExceptionMapper.class,
                         SourcesApiV3Resource.class,
                         SourceApiV3Resource.class,
                         SinksApiV3Resource.class,

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/ResourcesTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/ResourcesTest.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.functions.worker.rest;
+
+import static org.testng.Assert.assertTrue;
+import org.apache.pulsar.broker.web.UnrecognizedPropertyExceptionMapper;
+import org.testng.annotations.Test;
+
+public class ResourcesTest {
+
+    @Test
+    public void testJsonExceptionMapperIsRegisteredForApiResources() {
+        assertTrue(Resources.getApiV2Resources().contains(UnrecognizedPropertyExceptionMapper.class));
+        assertTrue(Resources.getApiV3Resources().contains(UnrecognizedPropertyExceptionMapper.class));
+    }
+}


### PR DESCRIPTION
Fixes #18253

### Motivation

The Functions Worker APIs return a generic HTTP 400 response when a multipart JSON configuration contains an unknown property. Pulsar already has an `UnrecognizedPropertyExceptionMapper` that produces a descriptive error, but the Functions Worker resource configurations do not register it.

### Modifications

- Register `UnrecognizedPropertyExceptionMapper` for the Functions Worker V2 APIs.
- Register `UnrecognizedPropertyExceptionMapper` for the Functions Worker V3 APIs.
- Add a regression test covering both resource sets.

### Verifying this change

This change added tests and can be verified as follows:

- `./gradlew :pulsar-functions:pulsar-functions-worker:test --tests "org.apache.pulsar.functions.worker.rest.ResourcesTest" -PtestRetryCount=0`
- `./gradlew :pulsar-functions:pulsar-functions-worker:checkstyleMain :pulsar-functions:pulsar-functions-worker:checkstyleTest`

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [x] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment