### PR TITLE
[improve][misc] PIP-472: Drop Jetty ee8 usage and adapt legacy javax.servlet additional servlets

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -384,6 +384,8 @@ The Apache Software License, Version 2.0
     - org.apache.bookkeeper-native-io-4.18.0.jar
     - org.apache.bookkeeper-native-library-common-4.18.0.jar
     - at.yawk.lz4-lz4-java-1.11.2.jar
+  * Apache Felix HTTP Wrappers
+    - org.apache.felix-org.apache.felix.http.wrappers-1.1.10.jar
   * Apache HTTP Client
     - org.apache.httpcomponents-httpclient-4.5.14.jar
     - org.apache.httpcomponents-httpcore-4.4.16.jar

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -158,12 +158,15 @@ jakarta-activation = "2.1.4"
 angus-activation = "2.0.3"
 jakarta-xml-bind = "4.0.5"
 jakarta-validation = "3.0.2"
-# javax-servlet (Servlet 4.0, ee8) is retained alongside jakarta-servlet (Servlet 6.0, ee10)
-# so that the AdditionalServlet plugin SPI keeps supporting legacy javax.servlet handlers (PIP-472).
-# Each is kept at the Servlet level its Jetty 12.1 environment implements: Jetty ee8 ships
-# jetty-servlet-api 4.0.x and Jetty ee10 pins jakarta.servlet-api 6.0.0.
+# Pulsar's web tier runs a single Jetty environment (ee10 / jakarta.servlet 6.0). javax-servlet is
+# retained only as the compile/runtime API of the legacy javax.servlet handlers that the
+# AdditionalServlet plugin SPI still accepts; those are adapted to jakarta.servlet by
+# felix-http-wrappers and registered in the ee10 environment like any other servlet (PIP-472).
+# Servlet 4.0 is a floor, not a preference: the wrappers reference Servlet 4.0 types such as
+# javax.servlet.http.PushBuilder, so a downgrade to 3.1 fails with NoClassDefFoundError on first use.
 javax-servlet = "4.0.1"
 jakarta-servlet = "6.0.0"
+felix-http-wrappers = "1.1.10"
 # Oxia / etcd
 oxia = "0.9.4"
 oxia-testcontainers = "0.7.4"
@@ -297,13 +300,12 @@ jetty-alpn-conscrypt-server = { module = "org.eclipse.jetty:jetty-alpn-conscrypt
 jetty-compression-server = { module = "org.eclipse.jetty.compression:jetty-compression-server", version.ref = "jetty" }
 jetty-compression-gzip = { module = "org.eclipse.jetty.compression:jetty-compression-gzip", version.ref = "jetty" }
 jetty-client = { module = "org.eclipse.jetty:jetty-client", version.ref = "jetty" }
-# jetty-ee8-* is retained for the AdditionalServlet legacy javax.servlet environment (PIP-472)
+# jetty-ee8-servlet is used only by the patched ZooKeeper admin server under jetty-upgrade/, which
+# implements ZooKeeper's own javax.servlet-based APIs and runs its own Jetty server. Pulsar's broker,
+# proxy and websocket Jetty wiring is ee10-only (PIP-472).
 jetty-ee8-servlet = { module = "org.eclipse.jetty.ee8:jetty-ee8-servlet", version.ref = "jetty" }
-jetty-ee8-servlets = { module = "org.eclipse.jetty.ee8:jetty-ee8-servlets", version.ref = "jetty" }
-jetty-ee8-proxy = { module = "org.eclipse.jetty.ee8:jetty-ee8-proxy", version.ref = "jetty" }
 jetty-websocket-jetty-api = { module = "org.eclipse.jetty.websocket:jetty-websocket-jetty-api", version.ref = "jetty" }
 jetty-websocket-jetty-client = { module = "org.eclipse.jetty.websocket:jetty-websocket-jetty-client", version.ref = "jetty" }
-jetty-ee8-websocket-jetty-server = { module = "org.eclipse.jetty.ee8.websocket:jetty-ee8-websocket-jetty-server", version.ref = "jetty" }
 # jetty-ee10-* is used by Pulsar's own broker/proxy/websocket Jetty wiring (jakarta.servlet, PIP-472)
 jetty-ee10-servlet = { module = "org.eclipse.jetty.ee10:jetty-ee10-servlet", version.ref = "jetty" }
 jetty-ee10-servlets = { module = "org.eclipse.jetty.ee10:jetty-ee10-servlets", version.ref = "jetty" }
@@ -421,6 +423,9 @@ angus-activation = { module = "org.eclipse.angus:angus-activation", version.ref 
 jakarta-xml-bind-api = { module = "jakarta.xml.bind:jakarta.xml.bind-api", version.ref = "jakarta-xml-bind" }
 javax-servlet-api = { module = "javax.servlet:javax.servlet-api", version.ref = "javax-servlet" }
 jakarta-servlet-api = { module = "jakarta.servlet:jakarta.servlet-api", version.ref = "jakarta-servlet" }
+# Adapters between javax.servlet and jakarta.servlet, used to run legacy javax.servlet
+# AdditionalServlet plugins inside Pulsar's jakarta.servlet Jetty environment (PIP-472)
+felix-http-wrappers = { module = "org.apache.felix:org.apache.felix.http.wrappers", version.ref = "felix-http-wrappers" }
 # javax.xml.bind:jaxb-api is required at runtime by third-party libraries that still reference the
 # legacy javax.xml.bind API (jclouds and Hadoop in the tiered-storage offloaders); Pulsar's own code
 # uses jakarta.xml.bind (PIP-472)

--- a/pip/pip-472.md
+++ b/pip/pip-472.md
@@ -38,7 +38,7 @@ Today the codebase imports `javax.*` from approximately 1,620 Java files. Removi
 | Package | Approx. files | Status |
 |---|---|---|
 | `javax.ws.rs` | 660 | Migrate to `jakarta.ws.rs` |
-| `javax.servlet` | 368 | Pulsar's own code migrates to `jakarta.servlet`; usage in the `AdditionalServlet` plugin SPI surface is intentionally retained on `javax.servlet` (see *High-Level Design — Phase 1*) |
+| `javax.servlet` | 368 | Pulsar's own code migrates to `jakarta.servlet`; the `AdditionalServlet` plugin SPI surface intentionally keeps accepting `javax.servlet` handlers, which Pulsar adapts to `jakarta.servlet` (see *High-Level Design — Phase 1*) |
 | `javax.annotation` (JSR 250 portion) | 48 | Migrate to `jakarta.annotation` |
 
 Pulsar's existing usage of `javax.security.*` (in `pulsar-broker-auth-sasl` and similar) is exclusively `javax.security.auth.callback`, `javax.security.auth.login`, `javax.security.auth.Subject`, and `javax.security.sasl.*` — all JDK-resident JAAS / SASL APIs that stay in `javax.*` and have no Jakarta counterpart. They are therefore out of scope.
@@ -62,8 +62,8 @@ A partial migration is already visible in git history (e.g. commits replacing `j
 ### In Scope
 
 - **Source code namespace migration** for the Jakarta-EE-derived `javax.*` packages used in Pulsar's own code (`javax.ws.rs`, `javax.annotation` JSR-250 portion, `javax.validation`, `javax.xml.bind`, `javax.activation`, `javax.inject` where used, `javax.websocket` where used). `javax.servlet` is intentionally retained in the `AdditionalServlet` plugin SPI surface (see *High-Level Design*) and therefore not eliminated codebase-wide. Approximate scope: ~1,100 files (1,620 total `javax.*` imports minus ~476 in JDK-resident `javax.*` packages that stay in `javax.*` forever, minus the `javax.servlet` files that remain because of the AdditionalServlet retention).
-- **Extend the `AdditionalServlet` SPI** so plugins can register `jakarta.servlet` handlers (preferred, routed to Jetty's ee10 environment) in addition to the existing `javax.servlet` registration path (legacy, routed to ee8). Both registration styles coexist; existing plugins keep working without recompilation.
-- **Dependency upgrades** in `gradle/libs.versions.toml` to Jakarta-namespace versions of every affected library (Jersey 2.42 → 3.1.10, Swagger Core 1.6.2 → 2.2.27, add `jetty-ee10-*` alongside the retained `jetty-ee8-*`, add `jakarta.servlet:jakarta.servlet-api:6.0.0` alongside the retained `javax.servlet:javax.servlet-api`, bump the `jakarta-*` API versions to their Jakarta EE 10 namespace versions, swap `jackson-jaxrs-json-provider` for `jackson-jakarta-rs-json-provider`).
+- **Extend the `AdditionalServlet` SPI** so plugins can register `jakarta.servlet` handlers (preferred, registered as they are) in addition to the existing `javax.servlet` registration path (legacy, adapted to `jakarta.servlet` before registration). Both registration styles coexist; existing plugins keep working without recompilation.
+- **Dependency upgrades** in `gradle/libs.versions.toml` to Jakarta-namespace versions of every affected library (Jersey 2.42 → 3.1.10, Swagger Core 1.6.2 → 2.2.27, replace `jetty-ee8-*` with `jetty-ee10-*` in Pulsar's web tier, add `jakarta.servlet:jakarta.servlet-api:6.0.0` alongside the retained `javax.servlet:javax.servlet-api`, add `org.apache.felix:org.apache.felix.http.wrappers` for the legacy `AdditionalServlet` adaptation, bump the `jakarta-*` API versions to their Jakarta EE 10 namespace versions, swap `jackson-jaxrs-json-provider` for `jackson-jakarta-rs-json-provider`).
 - **Shading and packaging cleanup** for shaded client/proxy/function JARs that currently include `javax.*` API classes (`pulsar-client-shaded`, `pulsar-client-admin-shaded`, `pulsar-client-all-shaded`, `pulsar-functions/localrun-shaded`, etc.).
 - **LICENSE and NOTICE updates** to reflect any artifact replacements.
 - **Migration guide** for plugin, connector, function, and embedding-API authors describing what changes they must make to recompile against Pulsar 5.0.
@@ -89,11 +89,15 @@ The migration is executed in four phases. Each phase is mergeable on its own; th
 - Add a CI lint that prevents new `javax.ws.rs`, `javax.servlet`, `javax.annotation` (JSR 250 portion), or `javax.validation` imports from being introduced after Phase 1 lands. The lint is feature-flagged so it can be enabled per-module as the migration progresses.
 - Inventory shaded client modules (`pulsar-client-shaded`, `pulsar-client-admin-shaded`, `pulsar-client-all-shaded`, `pulsar-functions/localrun-shaded`, `jclouds-shaded`, etc.) and document their current `javax.*` shading rules so Phase 3 has a checklist.
 
-### Phase 1 — Web stack migration with ee8/ee10 coexistence
+### Phase 1 — Web stack migration to a single ee10 environment
 
 The web stack has two interlocked layers, each with its own coexistence story:
 
-1. **Servlet container (Jetty 12).** Jetty 12 supports running multiple Servlet API generations side by side, each in its own *environment*. Pulsar's broker, proxy, and websocket components move from `jetty-ee8-*` (Servlet 4 / `javax.servlet`) to `jetty-ee10-*` (Servlet 6 / `jakarta.servlet`). The `jetty-ee8-*` artifacts are **retained** alongside ee10 so that both environments share the same Jetty 12 server instance and connector pool. The `AdditionalServlet` SPI (`org.apache.pulsar.broker.web.plugin.servlet.AdditionalServlet*`) is extended so that plugins can register **either** `jakarta.servlet` handlers (preferred, routed to the ee10 environment) or `javax.servlet` handlers (legacy path, routed to the ee8 environment); both styles can coexist within a single broker. This is the Jetty 12 design intent for migration scenarios and is what unblocks gradual ecosystem migration without breaking existing AdditionalServlet plugins.
+1. **Servlet container (Jetty 12).** Pulsar's broker, proxy, and websocket components move from `jetty-ee8-*` (Servlet 4 / `javax.servlet`) to `jetty-ee10-*` (Servlet 6 / `jakarta.servlet`), and the `jetty-ee8-*` modules are **dropped** from Pulsar's web tier. Pulsar runs a **single** Jetty environment.
+
+   Jetty 12 can run several Servlet API generations side by side, each in its own *environment*, and an earlier revision of this PIP proposed doing exactly that: keeping an ee8 environment alongside ee10 and routing legacy `javax.servlet` `AdditionalServlet` plugins into it. That does not work for Pulsar, because each Jetty environment owns its own servlet context, servlet handler and — crucially — its own **filter chain**. The broker and proxy filters (authentication, rate limiting, request-size limiting, listener-name tagging, broker interceptors) are `jakarta.servlet`-typed and can only be installed on ee10 contexts, so a servlet registered in an ee8 context would silently run outside the request pipeline every other servlet goes through: the `requiresAuthentication` argument handed to the registration call would have no effect at all. Splitting the web tier across two Jetty environments splits its request handling, which is not an acceptable trade for plugin compatibility.
+
+   Instead, the `AdditionalServlet` SPI (`org.apache.pulsar.broker.web.plugin.servlet.AdditionalServlet*`) is extended so that plugins can declare **either** `jakarta.servlet` handlers (preferred, registered as they are) or `javax.servlet` handlers (legacy). A legacy handler is adapted to `jakarta.servlet` with `org.apache.felix.http.jakartawrappers.ServletWrapper` from `org.apache.felix:org.apache.felix.http.wrappers` — a small Apache-licensed pair of `javax.servlet` ↔ `jakarta.servlet` adapter packages whose only dependencies are the two servlet APIs — and then registered through the ordinary ee10 path. Both styles coexist within a single broker, share one environment and one filter chain, and existing AdditionalServlet plugins keep working without recompilation. Only `javax.servlet:javax.servlet-api` stays on the classpath for them; no Jetty ee8 module does.
 
 2. **JAX-RS provider (Jersey).** Jersey 2 (`javax.ws.rs`) and Jersey 3 (`jakarta.ws.rs`) cannot share a single REST tier. The broker REST tier moves atomically to Jersey 3. Every JAX-RS resource class registered with the broker REST application — across `pulsar-broker`, `pulsar-broker-common`, `pulsar-client-admin`, `pulsar-websocket`, and `pulsar-proxy` — is updated in the same coordinated change to import `jakarta.ws.rs.*`. Modules outside the broker REST tier are unaffected by the Jersey switch and keep their `javax.*` imports until Phase 2.
 
@@ -108,22 +112,23 @@ In `gradle/libs.versions.toml`:
 | `jakarta-validation` | `2.0.2` | `3.0.2` | Jakarta EE 10 |
 | `jakarta-xml-bind` | `2.3.3` | `4.0.2` | Jakarta EE 10 |
 | `jakarta-activation` | `1.2.2` | `2.1.3` | Jakarta EE 10 |
-| `javax-servlet` | `3.1.0` | unchanged | **Retained** for the ee8 environment used by AdditionalServlet plugins |
+| `javax-servlet` | `3.1.0` | `4.0.1` | **Retained** as the API of legacy `javax.servlet` AdditionalServlet plugins; 4.0.1 is the Servlet level the Felix wrappers are built against |
 | *new* `jakarta-servlet` | — | `6.0.0` | Servlet 6 / Jakarta EE 10 |
 
 The PIP targets **Jakarta EE 10** consistently across these specs (rather than mixing in EE 11) because EE 10 has the broadest tooling and runtime support today and matches the maturity of the third-party libraries Pulsar consumes. EE 11 is a candidate for a future follow-up.
 
 Plus aliases:
 
-- **Add** `jetty-ee10-*` library aliases for every `jetty-ee8-*` artifact currently in use. The `jetty-ee8-*` aliases are retained alongside ee10 so AdditionalServlet plugins keep working. Pulsar's own broker/proxy/websocket Jetty wiring uses ee10.
+- **Add** `jetty-ee10-*` library aliases for every `jetty-ee8-*` artifact currently in use, and **remove** the `jetty-ee8-*` aliases used by Pulsar's web tier. (`jetty-ee8-servlet` stays in the catalog only for the patched ZooKeeper admin server under `jetty-upgrade/`, which implements ZooKeeper's own `javax.servlet`-based APIs and runs a separate Jetty server.) Pulsar's broker/proxy/websocket Jetty wiring is ee10-only.
 - **Replace** `jackson-jaxrs-json-provider` (`com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider`) with `jackson-jakarta-rs-json-provider` (`com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-json-provider`) at the existing Jackson 2.21.3 version (Jackson publishes both variants under the same release).
-- **Add** `jakarta.servlet:jakarta.servlet-api:6.0.0` as a new servlet-api alias **alongside** the retained `javax.servlet:javax.servlet-api:3.1.0`.
+- **Add** `jakarta.servlet:jakarta.servlet-api:6.0.0` as a new servlet-api alias **alongside** the retained `javax.servlet:javax.servlet-api`.
+- **Add** `org.apache.felix:org.apache.felix.http.wrappers`, the adapter used to present a legacy `javax.servlet` AdditionalServlet to Jetty as a `jakarta.servlet` one.
 
 Phase 1 lands as one coordinated PR that:
 
 - Updates `gradle/libs.versions.toml` per the table above.
-- Updates Jetty wiring in `WebService`, `ProxyServer`, and `WebSocketService` to start the ee10 environment alongside ee8.
-- Extends the `AdditionalServlet` SPI so plugins can register `jakarta.servlet` handlers in addition to existing `javax.servlet` handlers; existing plugin entry points stay binary-compatible.
+- Updates Jetty wiring in the broker's `WebService`, the proxy's `WebServer`, and the websocket component's `ProxyServer` to run the ee10 environment.
+- Extends the `AdditionalServlet` SPI so plugins can register `jakarta.servlet` handlers in addition to existing `javax.servlet` handlers, adapting the latter to `jakarta.servlet` at registration time; existing plugin entry points stay binary-compatible.
 - Migrates every JAX-RS resource class participating in the broker REST tier (~239 files: ~140 in `pulsar-broker` + 34 in `pulsar-broker-common` + 30 in `pulsar-client-admin` + 17 in `pulsar-websocket` + 18 in `pulsar-proxy`). The mechanical `javax.ws.rs.*` → `jakarta.ws.rs.*` and Swagger 1 → 2 annotation renames in those files are driven by OpenRewrite.
 
 Phase 1 is large but atomic — Jersey cannot be half-migrated.
@@ -147,7 +152,7 @@ Each PR:
 
 ### Phase 3 — Cleanup
 
-- Update shading rules: remove `javax.ws.rs`, `javax.annotation-api`, `javax.validation`, `javax.xml.bind`, `javax.activation` entries (all now Jakarta-namespaced); add equivalent `jakarta.*` entries where shading is still required. The `javax.servlet` shading rules remain because the ee8 environment is retained for `AdditionalServlet` plugin support.
+- Update shading rules: remove `javax.ws.rs`, `javax.annotation-api`, `javax.validation`, `javax.xml.bind`, `javax.activation` entries (all now Jakarta-namespaced); add equivalent `jakarta.*` entries where shading is still required. The `javax.servlet` shading rules remain because `javax.servlet` is retained for `AdditionalServlet` plugin support.
 - Update LICENSE and NOTICE files in shaded client distributions.
 - Remove now-unused exclusions (e.g. `Exclude javax.annotation` rules in build files).
 - Enable the codebase-wide Checkstyle import check.
@@ -161,9 +166,10 @@ Each PR:
 |---|---|---|---|
 | `org.glassfish.jersey.core:jersey-server` (and all `org.glassfish.jersey.*` artifacts) | 2.42 | 3.1.10 | Group ID unchanged; major bump moves namespace to `jakarta.ws.rs` |
 | `io.swagger:swagger-annotations`, `io.swagger:swagger-core` | 1.6.2 | — | **Replace with** `io.swagger.core.v3:swagger-annotations`, `io.swagger.core.v3:swagger-jaxrs2` at 2.2.27. Annotation package renames from `io.swagger.annotations.*` to `io.swagger.v3.oas.annotations.*` |
-| `org.eclipse.jetty.ee8:jetty-ee8-*` | 12.1.8 | unchanged | **Retained** alongside `jetty-ee10-*` to preserve `AdditionalServlet` plugin support |
+| `org.eclipse.jetty.ee8:jetty-ee8-*` | 12.1.8 | — | **Removed** from Pulsar's web tier; `jetty-ee8-servlet` stays only for the patched ZooKeeper admin server under `jetty-upgrade/` |
 | *new* `org.eclipse.jetty.ee10:jetty-ee10-*` | — | 12.1.8 | Pulsar's own broker/proxy/websocket Jetty wiring uses ee10 |
-| `javax.servlet:javax.servlet-api` | 3.1.0 | unchanged | **Retained** for the ee8 environment used by AdditionalServlet plugins |
+| `javax.servlet:javax.servlet-api` | 3.1.0 | 4.0.1 | **Retained** as the API of legacy `javax.servlet` AdditionalServlet plugins |
+| *new* `org.apache.felix:org.apache.felix.http.wrappers` | — | 1.1.10 | Adapts a legacy `javax.servlet` AdditionalServlet to `jakarta.servlet` so it can be registered in the ee10 environment |
 | *new* `jakarta.servlet:jakarta.servlet-api` | — | 6.0.0 | Servlet 6 / Jakarta EE 10 |
 | `jakarta.ws.rs:jakarta.ws.rs-api` | 2.1.6 | 3.1.0 | 2.1.x is Jakarta EE 8 (javax namespace); 3.1.x is Jakarta EE 10 (jakarta namespace) |
 | `jakarta.annotation:jakarta.annotation-api` | 1.3.5 | 2.1.1 | 2.x is Jakarta EE 10 namespace |
@@ -203,7 +209,7 @@ Shaded modules currently rewrite some `javax.*` classes into Pulsar's shaded nam
 
 Pulsar already runs Checkstyle in CI. The migration uses Checkstyle's `ImportControl` (or `IllegalImport`) module to prevent regressions, since extending an existing tool is cheaper than introducing a new Gradle plugin. The Jakarta-EE-spec packages below are added to the existing Checkstyle configuration and disallowed across the codebase, with two well-defined exceptions:
 
-- `javax.servlet` is allowed only in code paths that implement the `AdditionalServlet` SPI (where javax-servlet support is intentionally retained).
+- `javax.servlet` is allowed only in code paths that implement or adapt the `AdditionalServlet` SPI (where javax-servlet support is intentionally retained).
 - `javax.annotation.processing` is always allowed (it is a JDK package, not Jakarta EE).
 
 Disallowed packages for Pulsar's own code:
@@ -233,7 +239,7 @@ The migration's compile-time impact on downstream Java code is narrower than the
 
 **Unaffected — these continue to work without recompilation:**
 
-- **`AdditionalServlet` plugins**: existing plugins that register `javax.servlet` handlers continue to work unchanged — the SPI's `javax.servlet` registration path is retained and routed to Jetty's ee8 environment. New plugins (and existing plugins that want to migrate) can register `jakarta.servlet` handlers via the extended SPI; those go to the ee10 environment. Both styles coexist.
+- **`AdditionalServlet` plugins**: existing plugins that register `javax.servlet` handlers continue to work unchanged — the SPI's `javax.servlet` registration path is retained, and Pulsar adapts such a handler to `jakarta.servlet` before registering it. New plugins (and existing plugins that want to migrate) can register `jakarta.servlet` handlers via the extended SPI. Both styles coexist, in one Jetty environment, behind the same filter chain.
 - **Connectors and Functions**: NAR archives execute in isolated classloaders (`NarClassLoader`). The connector / function base contexts (`BaseContext`, `FunctionContext`, `SinkContext`, `SourceContext`) currently do not expose Jakarta-EE-spec types in their signatures, so existing 4.x NARs continue to work on a 5.0 broker as long as they don't directly call the affected Pulsar REST/auth SPIs. A connector / function NAR that internally uses `javax.ws.rs` for its own HTTP client is also unaffected, because nothing forces those NARs to share Pulsar's JAX-RS provider.
 
 **Wire protocol and REST API are unchanged.** Pulsar's binary protocol, REST API URLs, request bodies, response bodies, and status codes are identical before and after the migration. A 4.x client speaking to a 5.0 broker, or vice versa, behaves the same as it does today.
@@ -262,7 +268,7 @@ During the migration window, operators are advised to watch for any classpath er
 
 ## Security Considerations
 
-- Jersey 3.1 and Jetty 12 (with `ee10` modules) both receive active security maintenance; Jersey 2.x and Jetty's `ee8` family are increasingly only fixed for serious CVEs. Migration improves Pulsar's exposure to security fixes.
+- Jersey 3.1 and Jetty 12 (with `ee10` modules) both receive active security maintenance; Jersey 2.x and Jetty's `ee8` family are increasingly only fixed for serious CVEs. Migration improves Pulsar's exposure to security fixes, and dropping `jetty-ee8-*` from the web tier removes that family from Pulsar's request path altogether.
 - Swagger Core 2.x receives active maintenance; 1.6.x is end-of-life.
 - No new authentication, authorisation, or transport-security surfaces are introduced. JAAS (`javax.security.auth.*`) and JSSE (`javax.net.ssl`) remain on `javax.*` (they are JDK SPIs, not Jakarta EE).
 - Plugin authors recompiling for the new Pulsar 5.0 must use updated dependencies; the migration guide explicitly calls out that plugins compiled against the old `javax.*` namespace will not load on a 5.0 broker, which is the desired (failing-loud) behaviour rather than a silent classpath conflict.
@@ -308,7 +314,7 @@ Geo-replication runs broker-to-broker over Pulsar's binary protocol, which this 
 
 ## General Notes
 
-The migration is heavily mechanical — most of the source-code change is import-rename driven by an automated recipe — but the dependency-upgrade and JAX-RS namespace switch in Phase 1 require careful coordination because Jersey 2 and Jersey 3 cannot coexist in the same REST tier. Phase 1 should be executed by contributors familiar with Jersey, Jetty, and Swagger initialisation in `pulsar-broker`. The Jetty 12 ee8/ee10 dual-environment configuration that preserves the `AdditionalServlet` plugin SPI is the key architectural decision that lets Phase 1 land without forcing all third-party AdditionalServlet plugins to recompile in lockstep.
+The migration is heavily mechanical — most of the source-code change is import-rename driven by an automated recipe — but the dependency-upgrade and JAX-RS namespace switch in Phase 1 require careful coordination because Jersey 2 and Jersey 3 cannot coexist in the same REST tier. Phase 1 should be executed by contributors familiar with Jersey, Jetty, and Swagger initialisation in `pulsar-broker`. Adapting legacy `javax.servlet` AdditionalServlet plugins into the single ee10 environment is the key architectural decision that lets Phase 1 land without forcing all third-party AdditionalServlet plugins to recompile in lockstep, and without splitting the web tier's filter chain across two Jetty environments.
 
 ## Links
 

--- a/pulsar-broker-common/build.gradle.kts
+++ b/pulsar-broker-common/build.gradle.kts
@@ -38,6 +38,10 @@ dependencies {
     api(libs.simpleclient)
     implementation(libs.caffeine)
     api(libs.jakarta.servlet.api)
+    // Legacy javax.servlet AdditionalServlet plugins are adapted to jakarta.servlet by the Apache Felix
+    // wrappers so that they run in Pulsar's single jakarta.servlet Jetty environment (PIP-472)
+    implementation(libs.javax.servlet.api)
+    implementation(libs.felix.http.wrappers)
     api(libs.jakarta.ws.rs.api)
     implementation(libs.jjwt.impl)
     implementation(libs.jjwt.jackson)

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/web/plugin/servlet/AdditionalServlet.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/web/plugin/servlet/AdditionalServlet.java
@@ -29,10 +29,13 @@ public interface AdditionalServlet extends AutoCloseable {
     /**
      * The servlet implementation type enum.
      * <p>
-     * {@link AdditionalServletType#JAVAX_SERVLET} servlets implement {@code javax.servlet.Servlet} and are
-     * routed to Jetty's ee8 environment (legacy compatibility path). {@link AdditionalServletType#JAKARTA_SERVLET}
-     * servlets implement {@code jakarta.servlet.Servlet} and are routed to Jetty's ee10 environment (the preferred
-     * path going forward). Both styles can coexist within a single broker/proxy. See PIP-472.
+     * {@link AdditionalServletType#JAKARTA_SERVLET} servlets implement {@code jakarta.servlet.Servlet}, the
+     * servlet API of the Jetty environment the broker and the proxy run, and are the preferred style going
+     * forward. {@link AdditionalServletType#JAVAX_SERVLET} servlets implement the legacy
+     * {@code javax.servlet.Servlet} interface and are adapted to {@code jakarta.servlet.Servlet} before they are
+     * registered, so that plugins built against the {@code javax.servlet} API keep working without
+     * recompilation. Both styles can coexist within a single broker/proxy and both go through the same filter
+     * chain. See PIP-472.
      */
     enum AdditionalServletType {
         JAVAX_SERVLET,

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/web/plugin/servlet/AdditionalServletUtils.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/web/plugin/servlet/AdditionalServletUtils.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker.web.plugin.servlet;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import jakarta.servlet.Servlet;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.DirectoryStream;
@@ -28,6 +29,8 @@ import java.nio.file.Paths;
 import lombok.CustomLog;
 import lombok.experimental.UtilityClass;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.felix.http.jakartawrappers.ServletWrapper;
+import org.apache.pulsar.broker.web.plugin.servlet.AdditionalServlet.AdditionalServletType;
 import org.apache.pulsar.common.nar.NarClassLoader;
 import org.apache.pulsar.common.nar.NarClassLoaderBuilder;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
@@ -151,6 +154,42 @@ public class AdditionalServletUtils {
             rethrowIOException(t);
             return null;
         }
+    }
+
+    /**
+     * Adapts the servlet instance of an additional servlet to {@code jakarta.servlet.Servlet}, the servlet API
+     * of the single Jetty environment the broker and the proxy run.
+     *
+     * <p>Servlets declaring {@link AdditionalServletType#JAKARTA_SERVLET} are returned as they are. Servlets
+     * declaring {@link AdditionalServletType#JAVAX_SERVLET} implement the legacy {@code javax.servlet.Servlet}
+     * interface and are adapted with the Apache Felix {@link ServletWrapper}. Registering both flavours in the
+     * same environment is what lets every additional servlet go through the broker/proxy filter chain, which is
+     * {@code jakarta.servlet}-typed (PIP-472).
+     *
+     * @param additionalServlet the additional servlet whose servlet instance should be adapted
+     * @return the servlet instance as a {@code jakarta.servlet.Servlet}
+     * @throws IllegalArgumentException if the servlet instance doesn't implement the servlet interface required
+     *         by the {@link AdditionalServlet#getServletType() servlet type} the additional servlet declares
+     */
+    public Servlet toJakartaServlet(AdditionalServlet additionalServlet) {
+        AdditionalServletType servletType = additionalServlet.getServletType();
+        Object servletInstance = additionalServlet.getServletInstance();
+        switch (servletType) {
+            case JAVAX_SERVLET -> {
+                if (servletInstance instanceof javax.servlet.Servlet javaxServlet) {
+                    return new ServletWrapper(javaxServlet);
+                }
+            }
+            case JAKARTA_SERVLET -> {
+                if (servletInstance instanceof Servlet jakartaServlet) {
+                    return jakartaServlet;
+                }
+            }
+            default -> throw new IllegalArgumentException("Unsupported additional servlet type " + servletType);
+        }
+        throw new IllegalArgumentException("Additional servlet instance of type "
+                + (servletInstance == null ? "null" : servletInstance.getClass().getName())
+                + " doesn't implement the servlet interface required by the declared servlet type " + servletType);
     }
 
     private void rethrowIOException(Throwable cause)

--- a/pulsar-broker/build.gradle.kts
+++ b/pulsar-broker/build.gradle.kts
@@ -66,9 +66,6 @@ dependencies {
     implementation(libs.jetty.alpn.conscrypt.server)
     api(libs.jetty.ee10.servlet)
     implementation(libs.jetty.ee10.servlets)
-    // ee8 + javax.servlet retained for the legacy AdditionalServlet javax.servlet path (PIP-472)
-    api(libs.jetty.ee8.servlet)
-    implementation(libs.javax.servlet.api)
     implementation(libs.jersey.server)
     implementation(libs.jersey.container.servlet.core)
     implementation(libs.jersey.container.servlet)
@@ -128,6 +125,8 @@ dependencies {
     testImplementation(libs.asynchttpclient)
     testImplementation(libs.bcprov.jdk18on)
     testImplementation(libs.commons.math3)
+    // Tests register AdditionalServlet plugins written against the legacy javax.servlet API
+    testImplementation(libs.javax.servlet.api)
     testImplementation(libs.okhttp3)
     testImplementation(libs.vertx.core)
     testImplementation(libs.wiremock)

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -32,6 +32,7 @@ import io.netty.util.Timer;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder;
+import jakarta.servlet.Servlet;
 import jakarta.servlet.ServletException;
 import jakarta.ws.rs.core.Response;
 import java.io.IOException;
@@ -144,6 +145,7 @@ import org.apache.pulsar.broker.web.RestException;
 import org.apache.pulsar.broker.web.RestProducerContext;
 import org.apache.pulsar.broker.web.WebService;
 import org.apache.pulsar.broker.web.plugin.servlet.AdditionalServlet;
+import org.apache.pulsar.broker.web.plugin.servlet.AdditionalServletUtils;
 import org.apache.pulsar.broker.web.plugin.servlet.AdditionalServletWithClassLoader;
 import org.apache.pulsar.broker.web.plugin.servlet.AdditionalServletWithPulsarService;
 import org.apache.pulsar.broker.web.plugin.servlet.AdditionalServlets;
@@ -1302,80 +1304,31 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                 if (additionalServlet instanceof AdditionalServletWithPulsarService) {
                     ((AdditionalServletWithPulsarService) additionalServlet).setPulsarService(this);
                 }
-                switch (servletWithClassLoader.getServletType()) {
-                    case JAVAX_SERVLET -> {
-                        // Legacy javax.servlet handlers are routed to Jetty's ee8 environment (PIP-472).
-                        Object servletInstance = servletWithClassLoader.getServletInstance();
-                        if (!(servletInstance instanceof javax.servlet.Servlet)) {
-                            log.error()
-                                    .attr("servlet", servletWithClassLoader)
-                                    .attr("type", servletInstance.getClass().getName())
-                                    .attr("match", servletWithClassLoader.getServletType())
-                                    .log("AdditionalServletWithClassLoader has invalid servlet instance type which"
-                                            + " doesn't match . Skipping.");
-                            try {
-                                servletWithClassLoader.close();
-                            } catch (Exception e) {
-                                log.error()
-                                        .attr("servlet", servletWithClassLoader)
-                                        .exception(e)
-                                        .log("Failed to close servlet .");
-                            }
-                            continue;
-                        }
-                        org.eclipse.jetty.ee8.servlet.ServletHolder servletHolder =
-                                new org.eclipse.jetty.ee8.servlet.ServletHolder(
-                                        (javax.servlet.Servlet) servletInstance);
-                        webService.addServletEe8(servletWithClassLoader.getBasePath(), servletHolder,
-                                config.isAuthenticationEnabled(), attributeMap);
-                        log.info()
-                                .attr("basePath", servletWithClassLoader.getBasePath())
-                                .log("Broker add additional servlet basePath");
-                    }
-                    case JAKARTA_SERVLET -> {
-                        // jakarta.servlet handlers are routed to Jetty's ee10 environment (PIP-472).
-                        Object servletInstance = servletWithClassLoader.getServletInstance();
-                        if (!(servletInstance instanceof jakarta.servlet.Servlet)) {
-                            log.error()
-                                    .attr("servlet", servletWithClassLoader)
-                                    .attr("type", servletInstance.getClass().getName())
-                                    .attr("match", servletWithClassLoader.getServletType())
-                                    .log("AdditionalServletWithClassLoader has invalid servlet instance type which"
-                                            + " doesn't match . Skipping.");
-                            try {
-                                servletWithClassLoader.close();
-                            } catch (Exception e) {
-                                log.error()
-                                        .attr("servlet", servletWithClassLoader)
-                                        .exception(e)
-                                        .log("Failed to close servlet .");
-                            }
-                            continue;
-                        }
-                        ServletHolder servletHolder =
-                                new ServletHolder((jakarta.servlet.Servlet) servletInstance);
-                        webService.addServlet(servletWithClassLoader.getBasePath(), servletHolder,
-                                config.isAuthenticationEnabled(), attributeMap);
-                        log.info()
-                                .attr("basePath", servletWithClassLoader.getBasePath())
-                                .log("Broker add additional servlet basePath");
-                    }
-                    default -> {
+                // Legacy javax.servlet handlers are adapted to jakarta.servlet so that every additional servlet
+                // is registered in the same Jetty environment and goes through the broker filter chain (PIP-472).
+                Servlet servlet;
+                try {
+                    servlet = AdditionalServletUtils.toJakartaServlet(servletWithClassLoader);
+                } catch (IllegalArgumentException e) {
+                    log.error()
+                            .attr("servlet", servletWithClassLoader)
+                            .exception(e)
+                            .log("AdditionalServletWithClassLoader has an unusable servlet instance. Skipping.");
+                    try {
+                        servletWithClassLoader.close();
+                    } catch (Exception closeException) {
                         log.error()
                                 .attr("servlet", servletWithClassLoader)
-                                .attr("type", servletWithClassLoader.getServletType())
-                                .log("AdditionalServletWithClassLoader has unsupported servlet type . Skipping.");
-                        try {
-                            servletWithClassLoader.close();
-                        } catch (Exception e) {
-                            log.error()
-                                    .attr("servlet", servletWithClassLoader)
-                                    .exception(e)
-                                    .log("Failed to close servlet .");
-                        }
-                        continue;
+                                .exception(closeException)
+                                .log("Failed to close servlet .");
                     }
+                    continue;
                 }
+                webService.addServlet(servletWithClassLoader.getBasePath(), new ServletHolder(servlet),
+                        config.isAuthenticationEnabled(), attributeMap);
+                log.info()
+                        .attr("basePath", servletWithClassLoader.getBasePath())
+                        .log("Broker add additional servlet basePath");
             }
         }
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/WebService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/WebService.java
@@ -413,28 +413,6 @@ public class WebService implements AutoCloseable {
         handlers.add(servletContextHandler);
     }
 
-    /**
-     * Registers a legacy {@code javax.servlet}-based servlet in Jetty's ee8 environment. This path exists
-     * solely to keep existing {@code AdditionalServlet} plugins that report
-     * {@link org.apache.pulsar.broker.web.plugin.servlet.AdditionalServlet.AdditionalServletType#JAVAX_SERVLET}
-     * working without recompilation (PIP-472). Pulsar's own servlets and {@code jakarta.servlet} additional
-     * servlets use {@link #addServlet} (ee10). The broker filter chain is jakarta-typed (ee10) and is therefore
-     * not applied to the ee8 environment; legacy javax additional servlets run without the broker filter chain.
-     */
-    public void addServletEe8(String path, org.eclipse.jetty.ee8.servlet.ServletHolder servletHolder,
-                              boolean requiresAuthentication, Map<String, Object> attributeMap) {
-        org.eclipse.jetty.ee8.servlet.ServletContextHandler servletContextHandler =
-                new org.eclipse.jetty.ee8.servlet.ServletContextHandler(
-                        org.eclipse.jetty.ee8.servlet.ServletContextHandler.SESSIONS);
-        servletContextHandler.setContextPath(path);
-        servletContextHandler.addServlet(servletHolder, MATCH_ALL);
-        if (attributeMap != null) {
-            attributeMap.forEach(servletContextHandler::setAttribute);
-        }
-        // The ee8 ServletContextHandler.get() bridges the ee8 context to a core org.eclipse.jetty.server.Handler
-        handlers.add(servletContextHandler.get());
-    }
-
     public void addWebSocketServlet(String path, JettyWebSocketServlet webSocketServlet,
                                     Map<String, Object> attributeMap) {
         ServletContextHandler servletContextHandler = new ServletContextHandler(ServletContextHandler.SESSIONS);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/PrometheusMetricsTestUtil.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/PrometheusMetricsTestUtil.java
@@ -32,7 +32,7 @@ import java.util.concurrent.TimeoutException;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsGenerator;
 import org.apache.pulsar.broker.stats.prometheus.PrometheusRawMetricsProvider;
-import org.eclipse.jetty.ee8.nested.HttpOutput;
+import org.eclipse.jetty.ee10.servlet.HttpOutput;
 
 public class PrometheusMetricsTestUtil {
     public static void generate(PulsarService pulsar, boolean includeTopicMetrics, boolean includeConsumerMetrics,

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/BrokerAdditionalServletFilterChainTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/BrokerAdditionalServletFilterChainTest.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import com.google.common.collect.Sets;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import okhttp3.OkHttpClient;
+import okhttp3.Response;
+import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
+import org.apache.pulsar.broker.web.plugin.servlet.AdditionalServlet;
+import org.apache.pulsar.broker.web.plugin.servlet.AdditionalServletWithClassLoader;
+import org.apache.pulsar.broker.web.plugin.servlet.AdditionalServlets;
+import org.apache.pulsar.broker.web.plugin.servlet.LegacyJavaxAdditionalServlet;
+import org.apache.pulsar.common.configuration.PulsarConfiguration;
+import org.mockito.Mockito;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * Verifies that {@code AdditionalServlet} plugins are served by the broker's filter chain, whichever servlet
+ * API they are written against. Legacy {@code javax.servlet} plugins are adapted to {@code jakarta.servlet} and
+ * registered in the same Jetty environment as every other servlet, so the {@code AuthenticationFilter} the
+ * broker installs when authentication is enabled applies to them too (PIP-472).
+ */
+@Test(groups = "broker")
+public class BrokerAdditionalServletFilterChainTest extends MockedPulsarServiceBaseTest {
+
+    private static final String JAVAX_BASE_PATH = "/additional/servlet/javax";
+    private static final String JAKARTA_BASE_PATH = "/additional/servlet/jakarta";
+    private static final String PARAM_VALUE = "hello";
+
+    @Override
+    @BeforeClass
+    protected void setup() throws Exception {
+        conf.setAuthenticationEnabled(true);
+        conf.setAuthenticationProviders(
+                Sets.newHashSet("org.apache.pulsar.broker.auth.MockAuthenticationProvider"));
+        internalSetup();
+    }
+
+    @Override
+    @AfterClass(alwaysRun = true)
+    protected void cleanup() throws Exception {
+        internalCleanup();
+    }
+
+    @Override
+    protected void beforePulsarStart(PulsarService pulsar) throws Exception {
+        Map<String, AdditionalServletWithClassLoader> servlets = new HashMap<>();
+        servlets.put("javax-servlet", new AdditionalServletWithClassLoader(
+                new LegacyJavaxAdditionalServlet(JAVAX_BASE_PATH), null));
+        servlets.put("jakarta-servlet", new AdditionalServletWithClassLoader(
+                new JakartaAdditionalServlet(), null));
+
+        AdditionalServlets additionalServlets = Mockito.mock(AdditionalServlets.class);
+        Mockito.when(additionalServlets.getServlets()).thenReturn(servlets);
+        Mockito.when(pulsar.getBrokerAdditionalServlets()).thenReturn(additionalServlets);
+    }
+
+    @Test
+    public void testJavaxAdditionalServletGoesThroughTheFilterChain() throws Exception {
+        assertThat(statusOf(JAVAX_BASE_PATH, false))
+                .as("unauthenticated request to a javax.servlet additional servlet")
+                .isEqualTo(HttpServletResponse.SC_UNAUTHORIZED);
+
+        assertThat(bodyOf(JAVAX_BASE_PATH))
+                .isEqualTo(LegacyJavaxAdditionalServlet.expectedResponse(JAVAX_BASE_PATH, PARAM_VALUE));
+    }
+
+    @Test
+    public void testJakartaAdditionalServletGoesThroughTheFilterChain() throws Exception {
+        assertThat(statusOf(JAKARTA_BASE_PATH, false))
+                .as("unauthenticated request to a jakarta.servlet additional servlet")
+                .isEqualTo(HttpServletResponse.SC_UNAUTHORIZED);
+
+        assertThat(bodyOf(JAKARTA_BASE_PATH)).isEqualTo(PARAM_VALUE);
+    }
+
+    private int statusOf(String basePath, boolean authenticated) throws IOException {
+        try (Response response = get(basePath, authenticated)) {
+            return response.code();
+        }
+    }
+
+    private String bodyOf(String basePath) throws IOException {
+        try (Response response = get(basePath, true)) {
+            assertThat(response.code()).isEqualTo(HttpServletResponse.SC_OK);
+            return response.body().string().trim();
+        }
+    }
+
+    private Response get(String basePath, boolean authenticated) throws IOException {
+        okhttp3.Request.Builder request = new okhttp3.Request.Builder()
+                .get()
+                .url(pulsar.getWebServiceAddress() + basePath
+                        + "?" + LegacyJavaxAdditionalServlet.QUERY_PARAM + "=" + PARAM_VALUE);
+        if (authenticated) {
+            // MockAuthenticationProvider accepts a "<result>.<result>" principal in the mockuser header
+            request.header("mockuser", "pass.pass");
+        }
+        return new OkHttpClient().newCall(request.build()).execute();
+    }
+
+    /**
+     * An additional servlet written against the {@code jakarta.servlet} API, echoing back the query parameter.
+     */
+    private static class JakartaAdditionalServlet extends HttpServlet implements AdditionalServlet {
+
+        @Override
+        public void loadConfig(PulsarConfiguration pulsarConfiguration) {
+            // No config to load
+        }
+
+        @Override
+        public String getBasePath() {
+            return JAKARTA_BASE_PATH;
+        }
+
+        @Override
+        public AdditionalServletType getServletType() {
+            return AdditionalServletType.JAKARTA_SERVLET;
+        }
+
+        @Override
+        public Object getServletInstance() {
+            return this;
+        }
+
+        @Override
+        public void close() {
+            // Nothing to close
+        }
+
+        @Override
+        protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+            byte[] body = request.getParameter(LegacyJavaxAdditionalServlet.QUERY_PARAM)
+                    .getBytes(StandardCharsets.UTF_8);
+            response.setContentType("text/plain");
+            response.setContentLength(body.length);
+            response.getOutputStream().write(body);
+            response.getOutputStream().flush();
+        }
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/BrokerAdditionalServletFilterChainTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/BrokerAdditionalServletFilterChainTest.java
@@ -20,21 +20,17 @@ package org.apache.pulsar.broker;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import com.google.common.collect.Sets;
-import jakarta.servlet.http.HttpServlet;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import okhttp3.OkHttpClient;
 import okhttp3.Response;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
-import org.apache.pulsar.broker.web.plugin.servlet.AdditionalServlet;
 import org.apache.pulsar.broker.web.plugin.servlet.AdditionalServletWithClassLoader;
 import org.apache.pulsar.broker.web.plugin.servlet.AdditionalServlets;
+import org.apache.pulsar.broker.web.plugin.servlet.JakartaAdditionalServlet;
 import org.apache.pulsar.broker.web.plugin.servlet.LegacyJavaxAdditionalServlet;
-import org.apache.pulsar.common.configuration.PulsarConfiguration;
 import org.mockito.Mockito;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -53,6 +49,8 @@ public class BrokerAdditionalServletFilterChainTest extends MockedPulsarServiceB
     private static final String JAKARTA_BASE_PATH = "/additional/servlet/jakarta";
     private static final String PARAM_VALUE = "hello";
 
+    private OkHttpClient httpClient;
+
     @Override
     @BeforeClass
     protected void setup() throws Exception {
@@ -60,11 +58,17 @@ public class BrokerAdditionalServletFilterChainTest extends MockedPulsarServiceB
         conf.setAuthenticationProviders(
                 Sets.newHashSet("org.apache.pulsar.broker.auth.MockAuthenticationProvider"));
         internalSetup();
+        httpClient = new OkHttpClient();
     }
 
     @Override
     @AfterClass(alwaysRun = true)
     protected void cleanup() throws Exception {
+        if (httpClient != null) {
+            httpClient.dispatcher().executorService().shutdown();
+            httpClient.connectionPool().evictAll();
+            httpClient = null;
+        }
         internalCleanup();
     }
 
@@ -74,7 +78,7 @@ public class BrokerAdditionalServletFilterChainTest extends MockedPulsarServiceB
         servlets.put("javax-servlet", new AdditionalServletWithClassLoader(
                 new LegacyJavaxAdditionalServlet(JAVAX_BASE_PATH), null));
         servlets.put("jakarta-servlet", new AdditionalServletWithClassLoader(
-                new JakartaAdditionalServlet(), null));
+                new JakartaAdditionalServlet(JAKARTA_BASE_PATH), null));
 
         AdditionalServlets additionalServlets = Mockito.mock(AdditionalServlets.class);
         Mockito.when(additionalServlets.getServlets()).thenReturn(servlets);
@@ -97,7 +101,8 @@ public class BrokerAdditionalServletFilterChainTest extends MockedPulsarServiceB
                 .as("unauthenticated request to a jakarta.servlet additional servlet")
                 .isEqualTo(HttpServletResponse.SC_UNAUTHORIZED);
 
-        assertThat(bodyOf(JAKARTA_BASE_PATH)).isEqualTo(PARAM_VALUE);
+        assertThat(bodyOf(JAKARTA_BASE_PATH))
+                .isEqualTo(JakartaAdditionalServlet.expectedResponse(JAKARTA_BASE_PATH, PARAM_VALUE));
     }
 
     private int statusOf(String basePath, boolean authenticated) throws IOException {
@@ -122,47 +127,6 @@ public class BrokerAdditionalServletFilterChainTest extends MockedPulsarServiceB
             // MockAuthenticationProvider accepts a "<result>.<result>" principal in the mockuser header
             request.header("mockuser", "pass.pass");
         }
-        return new OkHttpClient().newCall(request.build()).execute();
-    }
-
-    /**
-     * An additional servlet written against the {@code jakarta.servlet} API, echoing back the query parameter.
-     */
-    private static class JakartaAdditionalServlet extends HttpServlet implements AdditionalServlet {
-
-        @Override
-        public void loadConfig(PulsarConfiguration pulsarConfiguration) {
-            // No config to load
-        }
-
-        @Override
-        public String getBasePath() {
-            return JAKARTA_BASE_PATH;
-        }
-
-        @Override
-        public AdditionalServletType getServletType() {
-            return AdditionalServletType.JAKARTA_SERVLET;
-        }
-
-        @Override
-        public Object getServletInstance() {
-            return this;
-        }
-
-        @Override
-        public void close() {
-            // Nothing to close
-        }
-
-        @Override
-        protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-            byte[] body = request.getParameter(LegacyJavaxAdditionalServlet.QUERY_PARAM)
-                    .getBytes(StandardCharsets.UTF_8);
-            response.setContentType("text/plain");
-            response.setContentLength(body.length);
-            response.getOutputStream().write(body);
-            response.getOutputStream().flush();
-        }
+        return httpClient.newCall(request.build()).execute();
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/BrokerAdditionalServletTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/BrokerAdditionalServletTest.java
@@ -36,6 +36,7 @@ import org.apache.pulsar.broker.web.plugin.servlet.AdditionalServlet;
 import org.apache.pulsar.broker.web.plugin.servlet.AdditionalServletWithClassLoader;
 import org.apache.pulsar.broker.web.plugin.servlet.AdditionalServletWithPulsarService;
 import org.apache.pulsar.broker.web.plugin.servlet.AdditionalServlets;
+import org.apache.pulsar.broker.web.plugin.servlet.LegacyJavaxAdditionalServlet;
 import org.apache.pulsar.common.configuration.PulsarConfiguration;
 import org.mockito.Mockito;
 import org.testng.Assert;
@@ -49,6 +50,7 @@ public class BrokerAdditionalServletTest extends MockedPulsarServiceBaseTest {
 
     private static final String BASE_PATH = "/additional/servlet";
     private static final String WITH_PULSAR_SERVICE_BASE_PATH = "/additional/servlet/with/pulsar/service";
+    private static final String JAVAX_BASE_PATH = "/additional/servlet/javax";
     private static final String QUERY_PARAM = "param";
 
     @Override
@@ -117,6 +119,8 @@ public class BrokerAdditionalServletTest extends MockedPulsarServiceBaseTest {
         map.put("broker-additional-servlet", new AdditionalServletWithClassLoader(brokerAdditionalServlet, null));
         map.put("broker-additional-servlet-with-pulsar-service", new
                 AdditionalServletWithClassLoader(brokerAdditionalServletWithPulsarService, null));
+        map.put("broker-additional-servlet-javax", new AdditionalServletWithClassLoader(
+                new LegacyJavaxAdditionalServlet(JAVAX_BASE_PATH), null));
         Mockito.when(brokerAdditionalServlets.getServlets()).thenReturn(map);
 
         Mockito.when(pulsar.getBrokerAdditionalServlets()).thenReturn(brokerAdditionalServlets);
@@ -134,6 +138,14 @@ public class BrokerAdditionalServletTest extends MockedPulsarServiceBaseTest {
         String withPulsarServiceParamValue = PulsarService.class.getName();
         String withPulsarServiceResponse = httpGet("http://localhost:" + httpPort + WITH_PULSAR_SERVICE_BASE_PATH);
         Assert.assertEquals(withPulsarServiceParamValue, withPulsarServiceResponse);
+
+        // A servlet written against the legacy javax.servlet API is adapted to jakarta.servlet and serves
+        // requests through the same Jetty environment as the jakarta.servlet ones
+        String javaxParamValue = "value - " + RandomUtils.nextInt();
+        String javaxResponse = httpGet("http://localhost:" + httpPort + JAVAX_BASE_PATH
+                + "?" + QUERY_PARAM + "=" + javaxParamValue);
+        Assert.assertEquals(javaxResponse.trim(),
+                LegacyJavaxAdditionalServlet.expectedResponse(JAVAX_BASE_PATH, javaxParamValue));
     }
 
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/web/plugin/servlet/JakartaAdditionalServlet.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/web/plugin/servlet/JakartaAdditionalServlet.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.web.plugin.servlet;
+
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.apache.pulsar.common.configuration.PulsarConfiguration;
+
+/**
+ * An {@link AdditionalServlet} written against the {@code jakarta.servlet} API, the counterpart of
+ * {@link LegacyJavaxAdditionalServlet}. The two echo back the same parts of the request, so that a test can
+ * assert the adapted legacy servlet observes exactly what a native one does.
+ */
+public class JakartaAdditionalServlet extends HttpServlet implements AdditionalServlet {
+
+    private final String basePath;
+
+    public JakartaAdditionalServlet(String basePath) {
+        this.basePath = basePath;
+    }
+
+    /**
+     * Builds the response body this servlet answers a {@code GET basePath?param=<paramValue>} with. The request
+     * URI carries a trailing slash because Jetty redirects a bare context path to its canonical form.
+     */
+    public static String expectedResponse(String basePath, String paramValue) {
+        return paramValue + "|" + basePath + "/|GET";
+    }
+
+    @Override
+    public void loadConfig(PulsarConfiguration pulsarConfiguration) {
+        // No config to load
+    }
+
+    @Override
+    public String getBasePath() {
+        return basePath;
+    }
+
+    @Override
+    public AdditionalServletType getServletType() {
+        return AdditionalServletType.JAKARTA_SERVLET;
+    }
+
+    @Override
+    public Object getServletInstance() {
+        return this;
+    }
+
+    @Override
+    public void close() {
+        // Nothing to close
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        byte[] body = (request.getParameter(LegacyJavaxAdditionalServlet.QUERY_PARAM) + "|"
+                + request.getRequestURI() + "|" + request.getMethod()).getBytes(StandardCharsets.UTF_8);
+        response.setContentType("text/plain");
+        response.setContentLength(body.length);
+        ServletOutputStream outputStream = response.getOutputStream();
+        outputStream.write(body);
+        outputStream.flush();
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/web/plugin/servlet/LegacyJavaxAdditionalServlet.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/web/plugin/servlet/LegacyJavaxAdditionalServlet.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.web.plugin.servlet;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.apache.pulsar.common.configuration.PulsarConfiguration;
+
+/**
+ * An {@link AdditionalServlet} written against the legacy {@code javax.servlet} API, the way existing
+ * third-party plugins are, so that tests can exercise the adaptation to {@code jakarta.servlet} that the
+ * broker and the proxy perform before registering such a servlet (PIP-472).
+ *
+ * <p>The response echoes back parts of the request the plugin observes through the javax API, so that a test
+ * can tell an adapted request apart from an empty or mistranslated one.
+ */
+public class LegacyJavaxAdditionalServlet extends HttpServlet implements AdditionalServlet {
+
+    public static final String QUERY_PARAM = "param";
+
+    private final String basePath;
+
+    public LegacyJavaxAdditionalServlet(String basePath) {
+        this.basePath = basePath;
+    }
+
+    /**
+     * Builds the response body this servlet answers a {@code GET basePath?param=<paramValue>} with. The request
+     * URI carries a trailing slash because Jetty redirects a bare context path to its canonical form.
+     */
+    public static String expectedResponse(String basePath, String paramValue) {
+        return paramValue + "|" + basePath + "/|GET";
+    }
+
+    @Override
+    public void loadConfig(PulsarConfiguration pulsarConfiguration) {
+        // No config to load
+    }
+
+    @Override
+    public String getBasePath() {
+        return basePath;
+    }
+
+    @Override
+    public AdditionalServletType getServletType() {
+        return AdditionalServletType.JAVAX_SERVLET;
+    }
+
+    @Override
+    public Object getServletInstance() {
+        return this;
+    }
+
+    @Override
+    public void close() {
+        // Nothing to close
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        byte[] body = (request.getParameter(QUERY_PARAM) + "|" + request.getRequestURI() + "|" + request.getMethod())
+                .getBytes(StandardCharsets.UTF_8);
+        response.setContentType("text/plain");
+        response.setContentLength(body.length);
+        ServletOutputStream outputStream = response.getOutputStream();
+        outputStream.write(body);
+        outputStream.flush();
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MockBrokerService.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MockBrokerService.java
@@ -28,13 +28,13 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.concurrent.ThreadFactory;
 import java.util.regex.Pattern;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import lombok.CustomLog;
 import org.apache.pulsar.client.api.MockBrokerServiceHooks.CommandAckHook;
 import org.apache.pulsar.client.api.MockBrokerServiceHooks.CommandCloseConsumerHook;
@@ -71,9 +71,8 @@ import org.apache.pulsar.common.protocol.FrameDecoderUtil;
 import org.apache.pulsar.common.protocol.PulsarDecoder;
 import org.apache.pulsar.common.protocol.schema.SchemaVersion;
 import org.apache.pulsar.common.util.netty.EventLoopUtil;
-import org.eclipse.jetty.ee8.nested.AbstractHandler;
-import org.eclipse.jetty.ee8.nested.ContextHandler;
-import org.eclipse.jetty.ee8.nested.Request;
+import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee10.servlet.ServletHolder;
 import org.eclipse.jetty.server.Server;
 
 /**
@@ -83,7 +82,7 @@ import org.eclipse.jetty.server.Server;
 public class MockBrokerService {
     private LookupData lookupData;
 
-    private class GenericResponseHandler extends AbstractHandler {
+    private class GenericResponseServlet extends HttpServlet {
         private final ObjectMapper objectMapper = new ObjectMapper();
         private final String lookupURI = "/lookup/v2/topic/persistent";
         private final String partitionMetadataURI = "/admin/v2/persistent";
@@ -95,20 +94,20 @@ public class MockBrokerService {
         private final Pattern multiPartPattern = Pattern.compile(".*/multi-part-.*");
 
         @Override
-        public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response)
-                throws IOException, ServletException {
+        protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException {
             String responseString;
-            log.info().attr("httpRequest", baseRequest.getRequestURI()).log("Received HTTP request");
-            if (baseRequest.getRequestURI().startsWith(lookupURI)) {
+            String requestURI = request.getRequestURI();
+            log.info().attr("httpRequest", requestURI).log("Received HTTP request");
+            if (requestURI.startsWith(lookupURI)) {
                 response.setContentType("application/json;charset=utf-8");
                 response.setStatus(HttpServletResponse.SC_OK);
                 responseString = objectMapper.writeValueAsString(lookupData);
-            } else if (baseRequest.getRequestURI().startsWith(partitionMetadataURI)) {
+            } else if (requestURI.startsWith(partitionMetadataURI)) {
                 response.setContentType("application/json;charset=utf-8");
                 response.setStatus(HttpServletResponse.SC_OK);
-                if (singlePartPattern.matcher(baseRequest.getRequestURI()).matches()) {
+                if (singlePartPattern.matcher(requestURI).matches()) {
                     responseString = objectMapper.writeValueAsString(singlePartitionedTopicMetadata);
-                } else if (multiPartPattern.matcher(baseRequest.getRequestURI()).matches()) {
+                } else if (multiPartPattern.matcher(requestURI).matches()) {
                     responseString = objectMapper.writeValueAsString(multiPartitionedTopicMetadata);
                 } else {
                     responseString = objectMapper.writeValueAsString(nonPartitionedTopicMetadata);
@@ -118,7 +117,6 @@ public class MockBrokerService {
                 response.setStatus(HttpServletResponse.SC_NOT_FOUND);
                 responseString = "URI NOT DEFINED";
             }
-            baseRequest.setHandled(true);
             response.getWriter().println(responseString);
             log.info().attr("sentResponse", responseString).log("Sent response");
         }
@@ -296,7 +294,10 @@ public class MockBrokerService {
 
     public MockBrokerService() {
         server = new Server(0);
-        server.setHandler(new ContextHandler("/", new GenericResponseHandler()));
+        ServletContextHandler context = new ServletContextHandler();
+        context.setContextPath("/");
+        context.addServlet(new ServletHolder(new GenericResponseServlet()), "/*");
+        server.setHandler(context);
     }
 
     public void start() {

--- a/pulsar-proxy/build.gradle.kts
+++ b/pulsar-proxy/build.gradle.kts
@@ -43,9 +43,6 @@ dependencies {
     implementation(libs.jetty.ee10.servlets)
     implementation(libs.jetty.ee10.proxy)
     implementation(libs.jetty.ee10.websocket.jetty.server)
-    // ee8 + javax.servlet retained for the legacy AdditionalServlet javax.servlet path (PIP-472)
-    api(libs.jetty.ee8.servlet)
-    implementation(libs.javax.servlet.api)
     implementation(libs.jersey.server)
     implementation(libs.jersey.container.servlet.core)
     implementation(libs.jersey.container.servlet)
@@ -87,6 +84,8 @@ dependencies {
     testImplementation(libs.jetty.websocket.jetty.client)
     testImplementation(libs.jjwt.api)
     testImplementation(libs.jjwt.impl)
+    // Tests register AdditionalServlet plugins written against the legacy javax.servlet API
+    testImplementation(libs.javax.servlet.api)
     testImplementation(libs.okhttp3)
     testImplementation(libs.testcontainers)
     // PIP-478: assert the proxy's TLS factory emits pulsar.tls.reload through the wired OpenTelemetry root.

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyServiceStarter.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyServiceStarter.java
@@ -29,6 +29,7 @@ import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.Gauge;
 import io.prometheus.client.Gauge.Child;
 import io.prometheus.client.hotspot.DefaultExports;
+import jakarta.servlet.Servlet;
 import java.io.IOException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -46,6 +47,7 @@ import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.authentication.AuthenticationService;
 import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsServlet;
+import org.apache.pulsar.broker.web.plugin.servlet.AdditionalServletUtils;
 import org.apache.pulsar.broker.web.plugin.servlet.AdditionalServletWithClassLoader;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.AuthenticationFactory;
@@ -417,80 +419,31 @@ public class ProxyServiceStarter {
                     service.getProxyAdditionalServlets().getServlets().values();
             for (AdditionalServletWithClassLoader servletWithClassLoader : additionalServletCollection) {
                 servletWithClassLoader.loadConfig(config);
-                switch (servletWithClassLoader.getServletType()) {
-                    case JAVAX_SERVLET -> {
-                        // Legacy javax.servlet handlers are routed to Jetty's ee8 environment (PIP-472).
-                        Object servletInstance = servletWithClassLoader.getServletInstance();
-                        if (!(servletInstance instanceof javax.servlet.Servlet)) {
-                            log.error()
-                                    .attr("servletWithClassLoader", servletWithClassLoader)
-                                    .attr("servletInstance", servletInstance.getClass().getName())
-                                    .attr("servletWithClassLoader", servletWithClassLoader.getServletType())
-                                    .log("AdditionalServletWithClassLoader has invalid"
-                                            + " servlet instance type. Skipping.");
-                            try {
-                                servletWithClassLoader.close();
-                            } catch (Exception e) {
-                                log.error()
-                                        .attr("servletWithClassLoader", servletWithClassLoader)
-                                        .exception(e)
-                                        .log("Failed to close servlet");
-                            }
-                            continue;
-                        }
-                        org.eclipse.jetty.ee8.servlet.ServletHolder additionalServletHolder =
-                                new org.eclipse.jetty.ee8.servlet.ServletHolder(
-                                        (javax.servlet.Servlet) servletInstance);
-                        server.addServletEe8(servletWithClassLoader.getBasePath(), additionalServletHolder,
-                                Collections.emptyList(), config.isAuthenticationEnabled());
-                        log.info()
-                                .attr("servletWithClassLoader", servletWithClassLoader.getBasePath())
-                                .log("proxy add additional servlet basePath");
-                    }
-                    case JAKARTA_SERVLET -> {
-                        // jakarta.servlet handlers are routed to Jetty's ee10 environment (PIP-472).
-                        Object servletInstance = servletWithClassLoader.getServletInstance();
-                        if (!(servletInstance instanceof jakarta.servlet.Servlet)) {
-                            log.error()
-                                    .attr("servletWithClassLoader", servletWithClassLoader)
-                                    .attr("servletInstance", servletInstance.getClass().getName())
-                                    .attr("servletWithClassLoader", servletWithClassLoader.getServletType())
-                                    .log("AdditionalServletWithClassLoader has invalid"
-                                            + " servlet instance type. Skipping.");
-                            try {
-                                servletWithClassLoader.close();
-                            } catch (Exception e) {
-                                log.error()
-                                        .attr("servletWithClassLoader", servletWithClassLoader)
-                                        .exception(e)
-                                        .log("Failed to close servlet");
-                            }
-                            continue;
-                        }
-                        ServletHolder additionalServletHolder =
-                                new ServletHolder((jakarta.servlet.Servlet) servletInstance);
-                        server.addServlet(servletWithClassLoader.getBasePath(), additionalServletHolder,
-                                Collections.emptyList(), config.isAuthenticationEnabled());
-                        log.info()
-                                .attr("servletWithClassLoader", servletWithClassLoader.getBasePath())
-                                .log("proxy add additional servlet basePath");
-                    }
-                    default -> {
+                // Legacy javax.servlet handlers are adapted to jakarta.servlet so that every additional servlet
+                // is registered in the same Jetty environment and goes through the proxy filter chain (PIP-472).
+                Servlet servlet;
+                try {
+                    servlet = AdditionalServletUtils.toJakartaServlet(servletWithClassLoader);
+                } catch (IllegalArgumentException e) {
+                    log.error()
+                            .attr("servletWithClassLoader", servletWithClassLoader)
+                            .exception(e)
+                            .log("AdditionalServletWithClassLoader has an unusable servlet instance. Skipping.");
+                    try {
+                        servletWithClassLoader.close();
+                    } catch (Exception closeException) {
                         log.error()
                                 .attr("servletWithClassLoader", servletWithClassLoader)
-                                .attr("servletWithClassLoader", servletWithClassLoader.getServletType())
-                                .log("AdditionalServletWithClassLoader has unsupported servlet type . Skipping");
-                        try {
-                            servletWithClassLoader.close();
-                        } catch (Exception e) {
-                            log.error()
-                                    .attr("servletWithClassLoader", servletWithClassLoader)
-                                    .exception(e)
-                                    .log("Failed to close servlet");
-                        }
-                        continue;
+                                .exception(closeException)
+                                .log("Failed to close servlet");
                     }
+                    continue;
                 }
+                server.addServlet(servletWithClassLoader.getBasePath(), new ServletHolder(servlet),
+                        Collections.emptyList(), config.isAuthenticationEnabled());
+                log.info()
+                        .attr("servletWithClassLoader", servletWithClassLoader.getBasePath())
+                        .log("proxy add additional servlet basePath");
             }
         }
 

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/WebServer.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/WebServer.java
@@ -271,32 +271,6 @@ public class WebServer {
         return context;
     }
 
-    /**
-     * Registers a legacy {@code javax.servlet}-based servlet in Jetty's ee8 environment, used to keep existing
-     * {@code AdditionalServlet} plugins reporting {@code JAVAX_SERVLET} working without recompilation (PIP-472).
-     * The proxy filter chain is jakarta-typed (ee10) and is therefore not applied to the ee8 environment.
-     */
-    public void addServletEe8(String basePath, org.eclipse.jetty.ee8.servlet.ServletHolder servletHolder,
-                              List<Pair<String, Object>> attributes, boolean requireAuthentication) {
-        Optional<String> existingPath = servletPaths.stream().filter(p -> p.startsWith(basePath)).findFirst();
-        if (existingPath.isPresent()) {
-            throw new IllegalArgumentException(
-                    String.format("Cannot add servlet at %s, path %s already exists", basePath, existingPath.get()));
-        }
-        servletPaths.add(basePath);
-
-        org.eclipse.jetty.ee8.servlet.ServletContextHandler context =
-                new org.eclipse.jetty.ee8.servlet.ServletContextHandler(
-                        org.eclipse.jetty.ee8.servlet.ServletContextHandler.SESSIONS);
-        context.setContextPath(basePath);
-        context.addServlet(servletHolder, MATCH_ALL);
-        for (Pair<String, Object> attribute : attributes) {
-            context.setAttribute(attribute.getLeft(), attribute.getRight());
-        }
-        // The ee8 ServletContextHandler.get() bridges the ee8 context to a core org.eclipse.jetty.server.Handler
-        handlers.add(context.get());
-    }
-
     private static void popularServletParams(ServletHolder servletHolder, ProxyConfiguration config) {
         int requestBufferSize = -1;
         try {

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyAdditionalServletFilterChainTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyAdditionalServletFilterChainTest.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.proxy.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import com.google.common.collect.Sets;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import lombok.CustomLog;
+import okhttp3.OkHttpClient;
+import okhttp3.Response;
+import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
+import org.apache.pulsar.broker.authentication.AuthenticationService;
+import org.apache.pulsar.broker.web.plugin.servlet.AdditionalServletWithClassLoader;
+import org.apache.pulsar.broker.web.plugin.servlet.AdditionalServlets;
+import org.apache.pulsar.broker.web.plugin.servlet.LegacyJavaxAdditionalServlet;
+import org.apache.pulsar.client.api.Authentication;
+import org.apache.pulsar.client.api.AuthenticationFactory;
+import org.apache.pulsar.common.configuration.PulsarConfigurationLoader;
+import org.apache.pulsar.metadata.impl.ZKMetadataStore;
+import org.mockito.Mockito;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * Verifies that {@code AdditionalServlet} plugins are served by the proxy's filter chain, whichever servlet API
+ * they are written against. A legacy {@code javax.servlet} plugin is adapted to {@code jakarta.servlet} and
+ * registered in the same Jetty environment as every other servlet, so the {@code AuthenticationFilter} the
+ * proxy installs when authentication is enabled applies to it too (PIP-472).
+ */
+@CustomLog
+public class ProxyAdditionalServletFilterChainTest extends MockedPulsarServiceBaseTest {
+
+    private static final String JAVAX_BASE_PATH = "/metrics/javax";
+    private static final String PARAM_VALUE = "hello";
+
+    private final ProxyConfiguration proxyConfig = new ProxyConfiguration();
+    private ProxyService proxyService;
+    private WebServer proxyWebServer;
+    private Authentication proxyClientAuthentication;
+
+    @Override
+    @BeforeClass
+    protected void setup() throws Exception {
+        internalSetup();
+
+        proxyConfig.setServicePort(Optional.of(0));
+        proxyConfig.setBrokerProxyAllowedTargetPorts("*");
+        proxyConfig.setWebServicePort(Optional.of(0));
+        proxyConfig.setMetadataStoreUrl(DUMMY_VALUE);
+        proxyConfig.setConfigurationMetadataStoreUrl(GLOBAL_DUMMY_VALUE);
+        proxyConfig.setClusterName(configClusterName);
+        proxyConfig.setAuthenticationEnabled(true);
+        proxyConfig.setAuthenticationProviders(
+                Sets.newHashSet("org.apache.pulsar.broker.auth.MockAuthenticationProvider"));
+
+        proxyClientAuthentication = AuthenticationFactory.create(proxyConfig.getBrokerClientAuthenticationPlugin(),
+                proxyConfig.getBrokerClientAuthenticationParameters());
+        proxyClientAuthentication.start();
+
+        proxyService = Mockito.spy(new ProxyService(proxyConfig,
+                new AuthenticationService(PulsarConfigurationLoader.convertFrom(proxyConfig)),
+                proxyClientAuthentication));
+        doReturn(registerCloseable(new ZKMetadataStore(mockZooKeeper))).when(proxyService).createLocalMetadataStore();
+        doReturn(registerCloseable(new ZKMetadataStore(mockZooKeeperGlobal))).when(proxyService)
+                .createConfigurationMetadataStore();
+        proxyService.start();
+
+        AdditionalServlets additionalServlets = Mockito.mock(AdditionalServlets.class);
+        Map<String, AdditionalServletWithClassLoader> servlets = new HashMap<>();
+        servlets.put("javax-proxy-servlet", new AdditionalServletWithClassLoader(
+                new LegacyJavaxAdditionalServlet(JAVAX_BASE_PATH), null));
+        Mockito.when(additionalServlets.getServlets()).thenReturn(servlets);
+        Mockito.when(proxyService.getProxyAdditionalServlets()).thenReturn(additionalServlets);
+
+        proxyWebServer = new WebServer(proxyConfig,
+                new AuthenticationService(PulsarConfigurationLoader.convertFrom(proxyConfig)));
+        ProxyServiceStarter.addWebServerHandlers(proxyWebServer, proxyConfig, proxyService, null,
+                proxyClientAuthentication);
+        proxyWebServer.start();
+    }
+
+    @Override
+    @AfterClass(alwaysRun = true)
+    protected void cleanup() throws Exception {
+        internalCleanup();
+        if (proxyService != null) {
+            proxyService.close();
+        }
+        if (proxyWebServer != null) {
+            proxyWebServer.stop();
+        }
+        if (proxyClientAuthentication != null) {
+            proxyClientAuthentication.close();
+        }
+    }
+
+    @Test
+    public void testJavaxAdditionalServletGoesThroughTheFilterChain() throws Exception {
+        try (Response unauthenticated = get(false)) {
+            assertThat(unauthenticated.code())
+                    .as("unauthenticated request to a javax.servlet additional servlet")
+                    .isEqualTo(HttpServletResponse.SC_UNAUTHORIZED);
+        }
+
+        try (Response authenticated = get(true)) {
+            assertThat(authenticated.code()).isEqualTo(HttpServletResponse.SC_OK);
+            assertThat(authenticated.body().string().trim())
+                    .isEqualTo(LegacyJavaxAdditionalServlet.expectedResponse(JAVAX_BASE_PATH, PARAM_VALUE));
+        }
+    }
+
+    private Response get(boolean authenticated) throws IOException {
+        okhttp3.Request.Builder request = new okhttp3.Request.Builder()
+                .get()
+                .url("http://localhost:" + proxyWebServer.getListenPortHTTP().get() + JAVAX_BASE_PATH
+                        + "?" + LegacyJavaxAdditionalServlet.QUERY_PARAM + "=" + PARAM_VALUE);
+        if (authenticated) {
+            // MockAuthenticationProvider accepts a "<result>.<result>" principal in the mockuser header
+            request.header("mockuser", "pass.pass");
+        }
+        return new OkHttpClient().newCall(request.build()).execute();
+    }
+}

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyAdditionalServletFilterChainTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyAdditionalServletFilterChainTest.java
@@ -33,6 +33,7 @@ import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.broker.authentication.AuthenticationService;
 import org.apache.pulsar.broker.web.plugin.servlet.AdditionalServletWithClassLoader;
 import org.apache.pulsar.broker.web.plugin.servlet.AdditionalServlets;
+import org.apache.pulsar.broker.web.plugin.servlet.JakartaAdditionalServlet;
 import org.apache.pulsar.broker.web.plugin.servlet.LegacyJavaxAdditionalServlet;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.AuthenticationFactory;
@@ -45,20 +46,22 @@ import org.testng.annotations.Test;
 
 /**
  * Verifies that {@code AdditionalServlet} plugins are served by the proxy's filter chain, whichever servlet API
- * they are written against. A legacy {@code javax.servlet} plugin is adapted to {@code jakarta.servlet} and
+ * they are written against. Legacy {@code javax.servlet} plugins are adapted to {@code jakarta.servlet} and
  * registered in the same Jetty environment as every other servlet, so the {@code AuthenticationFilter} the
- * proxy installs when authentication is enabled applies to it too (PIP-472).
+ * proxy installs when authentication is enabled applies to them too (PIP-472).
  */
 @CustomLog
 public class ProxyAdditionalServletFilterChainTest extends MockedPulsarServiceBaseTest {
 
     private static final String JAVAX_BASE_PATH = "/metrics/javax";
+    private static final String JAKARTA_BASE_PATH = "/metrics/jakarta";
     private static final String PARAM_VALUE = "hello";
 
     private final ProxyConfiguration proxyConfig = new ProxyConfiguration();
     private ProxyService proxyService;
     private WebServer proxyWebServer;
     private Authentication proxyClientAuthentication;
+    private OkHttpClient httpClient;
 
     @Override
     @BeforeClass
@@ -91,6 +94,8 @@ public class ProxyAdditionalServletFilterChainTest extends MockedPulsarServiceBa
         Map<String, AdditionalServletWithClassLoader> servlets = new HashMap<>();
         servlets.put("javax-proxy-servlet", new AdditionalServletWithClassLoader(
                 new LegacyJavaxAdditionalServlet(JAVAX_BASE_PATH), null));
+        servlets.put("jakarta-proxy-servlet", new AdditionalServletWithClassLoader(
+                new JakartaAdditionalServlet(JAKARTA_BASE_PATH), null));
         Mockito.when(additionalServlets.getServlets()).thenReturn(servlets);
         Mockito.when(proxyService.getProxyAdditionalServlets()).thenReturn(additionalServlets);
 
@@ -99,11 +104,18 @@ public class ProxyAdditionalServletFilterChainTest extends MockedPulsarServiceBa
         ProxyServiceStarter.addWebServerHandlers(proxyWebServer, proxyConfig, proxyService, null,
                 proxyClientAuthentication);
         proxyWebServer.start();
+
+        httpClient = new OkHttpClient();
     }
 
     @Override
     @AfterClass(alwaysRun = true)
     protected void cleanup() throws Exception {
+        if (httpClient != null) {
+            httpClient.dispatcher().executorService().shutdown();
+            httpClient.connectionPool().evictAll();
+            httpClient = null;
+        }
         internalCleanup();
         if (proxyService != null) {
             proxyService.close();
@@ -118,28 +130,46 @@ public class ProxyAdditionalServletFilterChainTest extends MockedPulsarServiceBa
 
     @Test
     public void testJavaxAdditionalServletGoesThroughTheFilterChain() throws Exception {
-        try (Response unauthenticated = get(false)) {
-            assertThat(unauthenticated.code())
-                    .as("unauthenticated request to a javax.servlet additional servlet")
-                    .isEqualTo(HttpServletResponse.SC_UNAUTHORIZED);
-        }
+        assertThat(statusOf(JAVAX_BASE_PATH, false))
+                .as("unauthenticated request to a javax.servlet additional servlet")
+                .isEqualTo(HttpServletResponse.SC_UNAUTHORIZED);
 
-        try (Response authenticated = get(true)) {
-            assertThat(authenticated.code()).isEqualTo(HttpServletResponse.SC_OK);
-            assertThat(authenticated.body().string().trim())
-                    .isEqualTo(LegacyJavaxAdditionalServlet.expectedResponse(JAVAX_BASE_PATH, PARAM_VALUE));
+        assertThat(bodyOf(JAVAX_BASE_PATH))
+                .isEqualTo(LegacyJavaxAdditionalServlet.expectedResponse(JAVAX_BASE_PATH, PARAM_VALUE));
+    }
+
+    @Test
+    public void testJakartaAdditionalServletGoesThroughTheFilterChain() throws Exception {
+        assertThat(statusOf(JAKARTA_BASE_PATH, false))
+                .as("unauthenticated request to a jakarta.servlet additional servlet")
+                .isEqualTo(HttpServletResponse.SC_UNAUTHORIZED);
+
+        assertThat(bodyOf(JAKARTA_BASE_PATH))
+                .isEqualTo(JakartaAdditionalServlet.expectedResponse(JAKARTA_BASE_PATH, PARAM_VALUE));
+    }
+
+    private int statusOf(String basePath, boolean authenticated) throws IOException {
+        try (Response response = get(basePath, authenticated)) {
+            return response.code();
         }
     }
 
-    private Response get(boolean authenticated) throws IOException {
+    private String bodyOf(String basePath) throws IOException {
+        try (Response response = get(basePath, true)) {
+            assertThat(response.code()).isEqualTo(HttpServletResponse.SC_OK);
+            return response.body().string().trim();
+        }
+    }
+
+    private Response get(String basePath, boolean authenticated) throws IOException {
         okhttp3.Request.Builder request = new okhttp3.Request.Builder()
                 .get()
-                .url("http://localhost:" + proxyWebServer.getListenPortHTTP().get() + JAVAX_BASE_PATH
+                .url("http://localhost:" + proxyWebServer.getListenPortHTTP().get() + basePath
                         + "?" + LegacyJavaxAdditionalServlet.QUERY_PARAM + "=" + PARAM_VALUE);
         if (authenticated) {
             // MockAuthenticationProvider accepts a "<result>.<result>" principal in the mockuser header
             request.header("mockuser", "pass.pass");
         }
-        return new OkHttpClient().newCall(request.build()).execute();
+        return httpClient.newCall(request.build()).execute();
     }
 }

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyAdditionalServletTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyAdditionalServletTest.java
@@ -44,6 +44,7 @@ import org.apache.pulsar.broker.authentication.AuthenticationService;
 import org.apache.pulsar.broker.web.plugin.servlet.AdditionalServlet;
 import org.apache.pulsar.broker.web.plugin.servlet.AdditionalServletWithClassLoader;
 import org.apache.pulsar.broker.web.plugin.servlet.AdditionalServlets;
+import org.apache.pulsar.broker.web.plugin.servlet.LegacyJavaxAdditionalServlet;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.AuthenticationFactory;
 import org.apache.pulsar.common.configuration.PulsarConfigurationLoader;
@@ -59,6 +60,7 @@ import org.testng.annotations.Test;
 public class ProxyAdditionalServletTest extends MockedPulsarServiceBaseTest {
 
     private static final String BASE_PATH = "/metrics/broker";
+    private static final String JAVAX_BASE_PATH = "/metrics/javax";
     private static final String QUERY_PARAM = "param";
 
     private ProxyService proxyService;
@@ -188,6 +190,8 @@ public class ProxyAdditionalServletTest extends MockedPulsarServiceBaseTest {
         AdditionalServlets proxyAdditionalServlets = Mockito.mock(AdditionalServlets.class);
         Map<String, AdditionalServletWithClassLoader> map = new HashMap<>();
         map.put("prometheus-proxy-servlet", new AdditionalServletWithClassLoader(proxyAdditionalServlet, null));
+        map.put("javax-proxy-servlet", new AdditionalServletWithClassLoader(
+                new LegacyJavaxAdditionalServlet(JAVAX_BASE_PATH), null));
         Mockito.when(proxyAdditionalServlets.getServlets()).thenReturn(map);
 
         Mockito.when(proxyService.getProxyAdditionalServlets()).thenReturn(proxyAdditionalServlets);
@@ -219,6 +223,16 @@ public class ProxyAdditionalServletTest extends MockedPulsarServiceBaseTest {
         Assert.assertEquals(response, paramValue);
         String headerKey = "header1";
         Assert.assertEquals(headers.get(headerKey), responseHeaders.get(headerKey));
+
+        // A servlet written against the legacy javax.servlet API is adapted to jakarta.servlet and serves
+        // requests through the same Jetty environment, and therefore the same filters, as the jakarta ones
+        String javaxParamValue = "value - " + RandomUtils.nextInt();
+        final Map<String, String> javaxHeaders = new HashMap<>();
+        String javaxResponse = httpGet("http://localhost:" + httpPort + JAVAX_BASE_PATH
+                + "?" + QUERY_PARAM + "=" + javaxParamValue, javaxHeaders);
+        Assert.assertEquals(javaxResponse.trim(),
+                LegacyJavaxAdditionalServlet.expectedResponse(JAVAX_BASE_PATH, javaxParamValue));
+        Assert.assertEquals(javaxHeaders.get(headerKey), responseHeaders.get(headerKey));
     }
 
     String httpGet(String url, Map<String, String> headers) throws IOException {


### PR DESCRIPTION
PIP: [PIP-472](https://github.com/apache/pulsar/blob/master/pip/pip-472.md) (#25700), follow-up to #25912

### Motivation

PIP-472 (#25912) moved Pulsar's web tier from Jetty's `ee8` environment (`javax.servlet`) to `ee10`
(`jakarta.servlet`). To keep `AdditionalServlet` plugins that are written against `javax.servlet`
working without recompilation, it kept a **second** Jetty environment — `ee8` — alive inside the
same Jetty `Server` and registered those plugins there, via `WebService.addServletEe8` (broker) and
`WebServer.addServletEe8` (proxy).

Combining both environments in one Jetty instance does not work the way that design assumed. A
Jetty environment owns its own servlet context, servlet handler and — crucially — its own **filter
chain**; the two are not shared. Pulsar's broker and proxy filters are `jakarta.servlet`-typed and
can therefore only be installed on `ee10` contexts, so a servlet registered in the `ee8` environment
ran outside the request pipeline that every other servlet goes through. Concretely, an
`AdditionalServlet` reporting `AdditionalServletType.JAVAX_SERVLET` was served without:

| | broker | proxy |
|---|---|---|
| `RateLimitingFilter` | ✗ | ✗ |
| `AuthenticationFilter` (so the `requiresAuthentication` / `isAuthenticationEnabled` argument passed to `addServletEe8` had no effect) | ✗ | ✗ |
| `WaitUntilPulsarServiceIsReadyForIncomingRequestsFilter`, `AddListenerAttributeFilter` | ✗ | — |
| `PreInterceptFilter` / `ProcessHandlerFilter` / `ResponseHandlerFilter` (broker interceptors) | ✗ | — |
| `DisableDebugHttpMethodFilter`, `MaxRequestSizeFilter` | ✗ | — |
| `CustomHeaderFilter` (`proxyHttpResponseHeadersJson`) | — | ✗ |
| `setDecodeAmbiguousURIs(true)` | ✗ | ✗ |
| `popularServletParams(...)` (request buffer size) | — | ✗ |

Keeping the two environments would mean maintaining two parallel, differently-typed filter chains
for the rest of PIP-472's lifetime. Running one environment and adapting the legacy servlets into it
is simpler and gives every additional servlet the same request pipeline.

### Modifications

- **Drop Jetty's `ee8` API from Pulsar's web tier.** `WebService.addServletEe8` and
  `WebServer.addServletEe8` are deleted (both were introduced by #25912 and have never been in a
  release), and `api(libs.jetty.ee8.servlet)` is removed from `pulsar-broker` and `pulsar-proxy`.
- **Adapt legacy `javax.servlet` additional servlets instead.** A new
  `AdditionalServletUtils.toJakartaServlet(AdditionalServlet)` in `pulsar-broker-common` returns a
  `JAKARTA_SERVLET` instance as it is, and wraps a `JAVAX_SERVLET` instance in
  `org.apache.felix.http.jakartawrappers.ServletWrapper` from
  `org.apache.felix:org.apache.felix.http.wrappers:1.1.10` (Apache-2.0; ~91 KB; its only dependencies
  are the two servlet APIs, both already on the classpath). Both flavours are then registered through
  the ordinary `addServlet` path.
- **Collapse the duplicated registration branches** in `PulsarService.addBrokerAdditionalServlets`
  and `ProxyServiceStarter.addWebServerHandlers`: the `JAVAX_SERVLET` / `JAKARTA_SERVLET` switch and
  its duplicated `instanceof`-check-log-close-skip blocks become one call. Behaviour on a mismatched
  servlet instance is unchanged (log an error, close the servlet, skip it).
- **Version catalog**: add `felix-http-wrappers`; drop the `jetty-ee8-servlets`, `jetty-ee8-proxy`
  and `jetty-ee8-websocket-jetty-server` aliases, which no build file referenced. `jetty-ee8-servlet`
  stays for `jetty-upgrade/`'s patched ZooKeeper admin server, which implements ZooKeeper's own
  `javax.servlet`-based APIs and runs a separate Jetty server. `javax.servlet:javax.servlet-api:4.0.1`
  stays as the API of legacy plugins (4.0 is a floor, not a preference: the Felix wrappers reference
  Servlet 4.0 types such as `javax.servlet.http.PushBuilder`), and moves to `pulsar-broker-common`
  alongside the Felix dependency.
- **Test-only `ee8` leftovers**: `MockBrokerService` moves from `org.eclipse.jetty.ee8.nested.*` to an
  `ee10` `ServletContextHandler` with a `jakarta.servlet` `HttpServlet`, and
  `PrometheusMetricsTestUtil` now imports `org.eclipse.jetty.ee10.servlet.HttpOutput`, matching
  `PulsarPrometheusMetricsServlet`. After this PR no Pulsar source outside `jetty-upgrade/` references
  a Jetty `ee8` class.
- **`pip/pip-472.md`** is amended in place to describe the single-environment design, why the
  `ee8`/`ee10` coexistence was replaced, and the added/removed dependencies.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- New `BrokerAdditionalServletFilterChainTest` and `ProxyAdditionalServletFilterChainTest` register a
  `javax.servlet` additional servlet with authentication enabled and assert that an unauthenticated
  request is rejected with `401` while an authenticated one gets `200` and the expected body. Both
  fail on the pre-change code (verified locally: `expected: 401 but was: 200` for the `javax` case;
  the `jakarta` case passes on both sides, so the test is specific to the environment split).
- `BrokerAdditionalServletTest` and `ProxyAdditionalServletTest` gained a legacy `javax.servlet`
  additional servlet next to the existing `jakarta.servlet` one. The shared
  `LegacyJavaxAdditionalServlet` fixture echoes the query parameter, request URI and method it
  observes through the `javax` API, so a mistranslated request is visible; the proxy test also asserts
  the `CustomHeaderFilter` response header now reaches the `javax` servlet.
- The existing container-based `TestAdditionalServlets` covers the real NAR path — `RandomAdditionalServlet`
  is a `javax.servlet` `AdditionalServlet` loaded through `NarClassLoader` from `/pulsar/examples`.
  Ran locally against a freshly built image: `testBrokerAdditionalServlet` and
  `testProxyAdditionalServlet` both pass.
- `./gradlew quickCheck`, `./gradlew sanityCheck`, `./gradlew :distribution:pulsar-server-distribution:checkBinaryLicense`
  and `./gradlew :distribution:pulsar-shell-distribution:checkBinaryLicense` all pass. The `jetty-ee8-*`
  and `jetty-servlet-api` entries stay in `LICENSE.bin.txt` because the patched ZooKeeper admin server
  still brings them into `lib/`.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [x] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

Adds `org.apache.felix:org.apache.felix.http.wrappers:1.1.10` (Apache-2.0) to `pulsar-broker-common`
and removes `org.eclipse.jetty.ee8:jetty-ee8-servlet` from `pulsar-broker` and `pulsar-proxy`.

The `AdditionalServlet` SPI itself is unchanged: plugins reporting `JAVAX_SERVLET` and plugins
reporting `JAKARTA_SERVLET` both keep working, without recompilation. `addServletEe8` is removed, but
it only ever existed on master (5.0.0-M1-SNAPSHOT) and is not part of any release.
