### PR TITLE
[improve][build] Upgrade lightproto to 0.8.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -168,7 +168,7 @@ jakarta-servlet = "6.0.0"
 oxia = "0.9.4"
 oxia-testcontainers = "0.7.4"
 # Build plugins
-lightproto = "0.7.3"
+lightproto = "0.8.1"
 graalvm-buildtools = "1.1.9"
 errorprone = "2.50.0"
 spotbugs = "4.10.3"


### PR DESCRIPTION
### Motivation

Supersedes #26256, which bumped LightProto to 0.8.0 and failed CI: `ProxyPatternConsumerBackPressureMultipleConsumersTest` ran out of heap. That exposed two regressions in the 0.8.0 generated code, both fixed in [LightProto v0.8.1](https://github.com/streamnative/lightproto/releases/tag/v0.8.1):

* **Large messages serialized to direct buffers allocated a full-size heap array per write** (streamnative/lightproto#20). 0.8.0 composed every message in a heap `byte[]` scratch before copying it into the target buffer; above 1 MiB the scratch was never retained, so every ~4.6 MB `CommandGetTopicsOfNamespaceResponse` cost a fresh multi-MB (G1 humongous) allocation — invisible to the broker's and proxy's `AsyncDualMemoryLimiter`, which accounts these responses as direct memory. 0.8.1 writes messages above 512 bytes in place through the direct buffer's NIO view: no scratch array, no copy, no allocation at any size.
* **Reused message instances retained the previous message's data after `clear()`** (streamnative/lightproto#19). 0.8.0's O(1) `clear()` only reset counts and presence bits, so the per-connection `BaseCommand` in `PulsarDecoder` kept the last topic list (~4.6 MB) alive on every connection that had ever received one. 0.8.1 releases those references for messages above 64 KiB.

With 0.8.1 the test passes locally (500/500 requests, free-heap floor >50 MB, where 0.8.0 ran out of heap at 275/500).

The performance gains that motivated the upgrade are retained. Measured on Pulsar's protocol messages against 0.7.3 (JDK 26, interleaved A/B, time per operation):

| | v0.7.3 | v0.8.1 | Δ |
|---|---|---|---|
| `BaseCommand` serialize | 52.3 ns | 23.0 ns | **−56%** |
| `MessageMetadata` serialize | 81.2 ns | 70.4 ns | −13% |
| `BaseCommand` deserialize | 28.5 ns | 21.9 ns | **−23%** |
| `MessageMetadata` deserialize | 72.5 ns | 43.0 ns | **−41%** |
| 4.6 MB topic-list response serialize | 175 µs | 166 µs | −5% (0 B allocated) |

Main changes in the generated code since 0.7.3: O(1) `clear()` with presence-guarded getters, presence-bit-driven traversal for union-like messages such as `BaseCommand`, array/NIO-view serialization with no `sun.misc.Unsafe` in the hot loops (JDK 24+ taxes each call), unchecked Netty reads for 64-bit varints.

### Modifications

* Bump `lightproto` from 0.7.3 to 0.8.1 in `gradle/libs.versions.toml`; all modules applying the plugin pick it up via the version catalog.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

`ProxyPatternConsumerBackPressureMultipleConsumersTest` (the test that OOMed on 0.8.0) passes locally on this branch with the released 0.8.1 artifacts.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [x] Dependencies (add or upgrade a dependency): `io.streamnative.lightproto` 0.7.3 → 0.8.1 (code generator and Gradle plugin; the generated protocol classes change, the wire format does not)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
