### PR TITLE
[improve][test] Cover reverse equality for topic message IDs

### DIFF
--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MessageIdCompareToTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MessageIdCompareToTest.java
@@ -180,7 +180,7 @@ public class MessageIdCompareToTest  {
         assertTrue(topicMessageId1.compareTo(messageIdImpl1) < 0, "Expected to be less than");
         assertTrue(topicMessageId2.compareTo(messageIdImpl1) < 0, "Expected to be less than");
         assertTrue(topicMessageId2.compareTo(messageIdImpl2) < 0, "Expected to be less than");
-        assertTrue(topicMessageId2.compareTo(messageIdImpl2) < 0, "Expected to be less than");
+        assertEquals(topicMessageId2.compareTo(messageIdImpl3), 0, "Expected to be equal");
     }
 
     @SuppressWarnings("deprecation")


### PR DESCRIPTION
### Motivation

`testBatchMessageIdImplCompareToTopicMessageId` repeated the same reverse-order assertion, leaving the corresponding equality case unchecked.

### Modifications

Replace the duplicate assertion with a reverse comparison between the topic message ID and the equivalent batch message ID (`batchIndex = -1`).

### Verifying this change

- `git diff --check`
- Not run: `./gradlew :pulsar-client-original:test -PtestRetryCount=0 --tests org.apache.pulsar.client.impl.MessageIdCompareToTest` could not start because this environment has no Java runtime.\n\n### Does this pull request potentially affect one of the following parts:\n\n- [ ] Dependencies (add or upgrade a dependency)\n- [ ] The public API\n- [ ] The schema\n- [ ] The default values of configurations\n- [ ] The threading model\n- [ ] The binary protocol\n- [ ] The REST endpoints\n- [ ] The admin CLI options\n- [ ] The metrics\n- [ ] Anything that affects deployment