### PR TITLE
[fix][client] Commit ByteBufPair frames as a single outbound pipeline entry

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/ByteBufPair.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/ByteBufPair.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.common.protocol;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
@@ -152,16 +153,25 @@ public final class ByteBufPair extends AbstractReferenceCounted {
     @SuppressWarnings("checkstyle:JavadocType")
     public static class Encoder extends ChannelOutboundHandlerAdapter {
         @Override
-        public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+        public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
             if (msg instanceof ByteBufPair) {
                 ByteBufPair b = (ByteBufPair) msg;
-
-                // Write each buffer individually on the socket. The retain() here is needed to preserve the fact that
-                // ByteBuf are automatically released after a write. If the ByteBufPair ref count is increased and it
-                // gets written multiple times, the individual buffers refcount should be reflected as well.
+                CompositeByteBuf frame = null;
                 try {
-                    ctx.write(b.getFirst().retainedDuplicate(), ctx.voidPromise());
-                    ctx.write(b.getSecond().retainedDuplicate(), promise);
+                    ByteBuf first = b.getFirst();
+                    ByteBuf second = b.getSecond();
+                    // Commit the whole frame as a single pipeline entry: two separate writes allowed
+                    // a failure in between to enqueue only the header half and desynchronize the peer's
+                    // frame parser. The retain() gives the composite independent component claims, so
+                    // writing a pair the caller has retained again (resend) keeps working.
+                    frame = Unpooled.compositeBuffer(2);
+                    frame.addComponent(true, first.retain());
+                    frame.addComponent(true, second.retain());
+                    ctx.write(frame, promise);
+                    frame = null;
+                } catch (Throwable t) {
+                    ReferenceCountUtil.safeRelease(frame);
+                    promise.tryFailure(t);
                 } finally {
                     ReferenceCountUtil.safeRelease(b);
                 }
@@ -175,16 +185,21 @@ public final class ByteBufPair extends AbstractReferenceCounted {
     @SuppressWarnings("checkstyle:JavadocType")
     public static class CopyingEncoder extends ChannelOutboundHandlerAdapter {
         @Override
-        public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+        public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
             if (msg instanceof ByteBufPair) {
                 ByteBufPair b = (ByteBufPair) msg;
-
-                // Some handlers in the pipeline will modify the bytebufs passed in to them (i.e. SslHandler).
-                // For these handlers, we need to pass a copy of the buffers as the source buffers may be cached
-                // for multiple requests.
+                CompositeByteBuf frame = null;
                 try {
-                    ctx.write(b.getFirst().copy(), ctx.voidPromise());
-                    ctx.write(b.getSecond().copy(), promise);
+                    ByteBuf first = b.getFirst();
+                    ByteBuf second = b.getSecond();
+                    frame = Unpooled.compositeBuffer(2);
+                    frame.addComponent(true, first.copy());
+                    frame.addComponent(true, second.copy());
+                    ctx.write(frame, promise);
+                    frame = null;
+                } catch (Throwable t) {
+                    ReferenceCountUtil.safeRelease(frame);
+                    promise.tryFailure(t);
                 } finally {
                     ReferenceCountUtil.safeRelease(b);
                 }

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/protocol/ByteBufPairTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/protocol/ByteBufPairTest.java
@@ -20,13 +20,29 @@ package org.apache.pulsar.common.protocol;
 
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.DefaultChannelPromise;
+import io.netty.channel.VoidChannelPromise;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.util.IllegalReferenceCountException;
+import io.netty.util.concurrent.ImmediateEventExecutor;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
+import org.mockito.MockedStatic;
 import org.testng.annotations.Test;
 
 public class ByteBufPairTest {
@@ -93,5 +109,166 @@ public class ByteBufPairTest {
         assertEquals(b2.refCnt(), 0);
         assertEquals(new String(ByteBufUtil.getBytes(coalesced)), "helloworld");
         coalesced.release();
+    }
+
+    /**
+     * A frame must reach the outbound pipeline as a single message, not as a
+     * header entry followed by a payload entry.
+     */
+    @Test
+    public void testEncoderCommitsFrameAsSingleMessage() {
+        EmbeddedChannel channel = new EmbeddedChannel(ByteBufPair.ENCODER);
+        ByteBuf b1 = Unpooled.wrappedBuffer("hello".getBytes());
+        ByteBuf b2 = Unpooled.wrappedBuffer("world".getBytes());
+        ByteBufPair buf = ByteBufPair.get(b1, b2);
+
+        channel.writeOutbound(buf);
+
+        ByteBuf frame = channel.readOutbound();
+        assertNotNull(frame);
+        assertEquals(frame.readableBytes(), 10);
+        assertEquals(new String(ByteBufUtil.getBytes(frame)), "helloworld");
+        assertNull(channel.readOutbound());
+        frame.release();
+        channel.finishAndReleaseAll();
+    }
+
+    /** Same as above for the copying encoder used on the TLS path. */
+    @Test
+    public void testCopyingEncoderCommitsFrameAsSingleMessage() {
+        EmbeddedChannel channel = new EmbeddedChannel(ByteBufPair.COPYING_ENCODER);
+        ByteBuf b1 = Unpooled.wrappedBuffer("hello".getBytes());
+        ByteBuf b2 = Unpooled.wrappedBuffer("world".getBytes());
+        ByteBufPair buf = ByteBufPair.get(b1, b2);
+
+        channel.writeOutbound(buf);
+
+        ByteBuf frame = channel.readOutbound();
+        assertNotNull(frame);
+        assertEquals(new String(ByteBufUtil.getBytes(frame)), "helloworld");
+        assertNull(channel.readOutbound());
+        assertEquals(buf.refCnt(), 0);
+        assertEquals(b1.refCnt(), 0);
+        assertEquals(b2.refCnt(), 0);
+        frame.release();
+        channel.finishAndReleaseAll();
+    }
+
+    /**
+     * The same pair can be written multiple times, as a resend after reconnect does.
+     */
+    @Test
+    public void testEncoderSupportsMultipleWritesOfSamePair() {
+        EmbeddedChannel channelA = new EmbeddedChannel(ByteBufPair.ENCODER);
+        EmbeddedChannel channelB = new EmbeddedChannel(ByteBufPair.ENCODER);
+        ByteBuf b1 = Unpooled.wrappedBuffer("hello".getBytes());
+        ByteBuf b2 = Unpooled.wrappedBuffer("world".getBytes());
+        ByteBufPair buf = ByteBufPair.get(b1, b2);
+
+        // Each write takes its own pair claim first, as ProducerImpl does (op.cmd.retain()).
+        buf.retain();
+        channelA.writeOutbound(buf);
+        buf.retain();
+        channelB.writeOutbound(buf);
+
+        ByteBuf frameA = channelA.readOutbound();
+        ByteBuf frameB = channelB.readOutbound();
+        assertEquals(new String(ByteBufUtil.getBytes(frameA)), "helloworld");
+        assertEquals(new String(ByteBufUtil.getBytes(frameB)), "helloworld");
+        frameA.release();
+        frameB.release();
+
+        assertEquals(buf.refCnt(), 1);
+        buf.release();
+        assertEquals(buf.refCnt(), 0);
+        assertEquals(b1.refCnt(), 0);
+        assertEquals(b2.refCnt(), 0);
+        channelA.finishAndReleaseAll();
+        channelB.finishAndReleaseAll();
+    }
+
+    /**
+     * If one pair's component is concurrently released (as the send-timeout disposal can do
+     * during a reconnect window), every entry that still reaches the wire must be a complete
+     * frame — a header-only entry would desynchronize every frame after it.
+     */
+    @Test
+    public void testEncoderFailedBuildKeepsStreamAligned() {
+        EmbeddedChannel channel = new EmbeddedChannel(ByteBufPair.ENCODER);
+        ByteBufPair good = ByteBufPair.get(Unpooled.wrappedBuffer("good1".getBytes()),
+                Unpooled.wrappedBuffer("good2".getBytes()));
+        ByteBuf bad2 = Unpooled.wrappedBuffer("payload".getBytes());
+        ByteBufPair bad = ByteBufPair.get(Unpooled.wrappedBuffer("head!".getBytes()), bad2);
+        ByteBufPair good3 = ByteBufPair.get(Unpooled.wrappedBuffer("good3".getBytes()),
+                Unpooled.wrappedBuffer("good4".getBytes()));
+        bad2.release();
+
+        for (ByteBufPair p : Arrays.asList(good, bad, good3)) {
+            try {
+                channel.writeOutbound(p);
+            } catch (IllegalReferenceCountException acceptable) {
+                // a failed write is acceptable here, a partial entry is not
+            }
+        }
+
+        List<String> frames = new ArrayList<>();
+        ByteBuf frame;
+        while ((frame = channel.readOutbound()) != null) {
+            frames.add(new String(ByteBufUtil.getBytes(frame)));
+            frame.release();
+        }
+        assertEquals(frames, Arrays.asList("good1good2", "good3good4"));
+        channel.finishAndReleaseAll();
+    }
+
+    @Test
+    public void testEncoderFailedBuildCommitsNothing() {
+        ByteBuf bad1 = Unpooled.wrappedBuffer("head!".getBytes());
+        ByteBuf bad2 = Unpooled.wrappedBuffer("payload".getBytes());
+        ByteBufPair bad = ByteBufPair.get(bad1, bad2);
+        // Simulate the concurrent release of the second component before the encoder takes its claim.
+        bad2.release();
+        assertEquals(bad2.refCnt(), 0);
+
+        ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+        DefaultChannelPromise promise = new DefaultChannelPromise(
+                channelMock(), ImmediateEventExecutor.INSTANCE);
+
+        bad.retain();
+        ByteBufPair.ENCODER.write(ctx, bad, promise);
+
+        verify(ctx, never()).write(any(), any());
+        assertTrue(promise.isDone() && !promise.isSuccess(), "the write promise must be failed");
+        // the composite returned the first component's claim; the finally block consumed the write claim
+        assertEquals(bad1.refCnt(), 1);
+        assertEquals(bad.refCnt(), 1);
+    }
+
+    @Test
+    public void testEncoderAllocationFailureFailsWriteAndReleasesPair() {
+        ByteBuf b1 = Unpooled.wrappedBuffer("hello".getBytes());
+        ByteBuf b2 = Unpooled.wrappedBuffer("world".getBytes());
+        ByteBufPair buf = ByteBufPair.get(b1, b2);
+        ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+        DefaultChannelPromise promise = new DefaultChannelPromise(
+                channelMock(), ImmediateEventExecutor.INSTANCE);
+
+        try (MockedStatic<Unpooled> pooled = mockStatic(Unpooled.class)) {
+            pooled.when(() -> Unpooled.compositeBuffer(2)).thenThrow(new OutOfMemoryError("test"));
+            ByteBufPair.ENCODER.write(ctx, buf, promise);
+        }
+
+        verify(ctx, never()).write(any(), any());
+        assertTrue(promise.isDone() && !promise.isSuccess(), "the write promise must be failed");
+        assertEquals(buf.refCnt(), 0);
+        assertEquals(b1.refCnt(), 0);
+        assertEquals(b2.refCnt(), 0);
+    }
+
+    private static Channel channelMock() {
+        Channel channel = mock(Channel.class);
+        when(channel.eventLoop()).thenReturn(new EmbeddedChannel().eventLoop());
+        when(channel.voidPromise()).thenReturn(new VoidChannelPromise(channel, true));
+        return channel;
     }
 }


### PR DESCRIPTION
### Motivation

`ByteBufPair.Encoder` — the outbound encoder that both the client and broker `PulsarChannelInitializer` install for the binary protocol — serialized each frame as **two independent pipeline writes**: the header half with the void promise, then the payload half carrying the real write promise. The two entries share no failure domain.

If anything fails after the header half is enqueued but before the payload half is claimed — most notably when the send-timeout path concurrently releases the pair's buffers while the frame is being written on the event loop — a **header-only entry is committed to the channel outbound buffer and reaches the wire**. (In `ProducerImpl`, the `cnx == null` reconnect-window branch of `failPendingMessages` disposes in-flight ops on the timer thread, which can race the write of the same op on the connection's event loop.)

The consequence is severe: the peer's `LengthFieldBasedFrameDecoder` permanently loses frame sync on that connection, and the broker rejects everything that follows:

```
ERROR org.apache.pulsar.broker.service.Producer - [...] Failed to verify checksum
WARN  org.apache.pulsar.broker.service.ServerCnx - [...] Got exception io.netty.handler.codec.TooLongFrameException: Adjusted frame length exceeds 5253120: 1515870814 - discarded
```

(`1515870814` is `0x5A5A5A5A` — the broker read *message payload bytes* as the frame length, i.e. the stream was already misaligned mid-payload.) The connection is then closed and all in-flight messages on it are lost.

This is a long-lived latent defect that only surfaces under a specific conjunction of conditions, which is why intermittent reports with this exact signature have historically been attributed to the network layer or intermediaries (e.g. #21557):

- batching with a short `sendTimeout` (e.g. 3s);
- a connection drop / reconnect window (broker or proxy restart, cluster churn);
- sender-thread stalls — e.g. a tight `-XX:MaxDirectMemorySize` makes `Bits.reserveMemory` block the allocating thread for seconds near the cap — aging messages past the timeout exactly while their writes are queued on the event loop.

### Modifications

- `Encoder` and `CopyingEncoder` now build each frame as a single `CompositeByteBuf` (component claims taken via `retain()` in `Encoder`, copies in `CopyingEncoder`) and commit it with one `ctx.write()` carrying the real promise: a frame reaches the outbound buffer whole or not at all.
- Any failure during frame construction releases the composite (the composite allocation itself is inside the protected region), fails the write promise, and commits nothing.
- The pair keeps its original component claims, so writing a pair under an extra claim (resend after reconnect) keeps working.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

`ByteBufPairTest` now covers:

- a frame is committed as a **single** outbound message (both encoders, including the TLS copying encoder);
- the same pair can be written again under an extra claim (resend semantics, mirroring `op.cmd.retain()`);
- when a pair's component is concurrently released, only complete frames reach the wire — `testEncoderFailedBuildKeepsStreamAligned` is the minimal deterministic repro: on the previous two-write encoder it fails with a header-only `"head!"` entry committed between the good frames;
- a failed build fails the write promise and commits nothing;
- the composite allocation failure path releases the pair and fails the write.

End-to-end reproduction (how the defect was confirmed and the patch validated):

1. standalone broker + Pulsar proxy as **separate** docker containers (hard socket kill on proxy restart);
2. producer with `batchingMaxMessages=1000`, `batchingMaxBytes=128KB`, `batchingMaxPublishDelay=1ms`, `sendTimeout(3, SECONDS)`, no compression, 4 threads x 8KB payloads, client JVM `-XX:MaxDirectMemorySize=48m`, connecting through the proxy;
3. `docker restart` the proxy **during active traffic** (twice per 50s round);
4. check the broker log for `Failed to verify checksum` / `TooLongFrameException` / `unknown tag type`.

Results: the unmodified `master` client corrupted the stream in round 2 of this harness with the exact signature quoted above; with this patch, 34 rounds (~770k messages) produced **zero** corrupt entries — the client-side send errors after each restart were transient and always recovered.

### Does this pull request potentially affect one of the following parts:

- Dependencies (does it pull in a new dependency?):  no
- The public API:  no
- The schema registry:  no
- The default values of configurations:  no
- The wire protocol:  no — the byte stream is unchanged, only the atomicity of committing it
- The rest endpoints:  no
- The admin cli options:  no
- Anything that affects deployment:  no

### Documentation

- [x] `no-doc` needed (internal fix, no user-facing behavior or configuration change)