### PR TITLE
[improve][build] Allow building with Java 26

### DIFF
--- a/.github/workflows/pulsar-ci-flaky.yaml
+++ b/.github/workflows/pulsar-ci-flaky.yaml
@@ -44,6 +44,7 @@ on:
         options:
           - '25'
           - '21'
+          - '26'
         default: '25'
       trace_test_resource_cleanup:
         description: 'Collect thread & heap information before exiting a test JVM. When set to "on", thread dump and heap histogram will be collected. When set to "full", a heap dump will also be collected.'

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -39,6 +39,7 @@ on:
         options:
           - '25'
           - '21'
+          - '26'
         default: '25'
       trace_test_resource_cleanup:
         description: 'Collect thread & heap information before exiting a test JVM. When set to "on", thread dump and heap histogram will be collected. When set to "full", a heap dump will also be collected.'

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -92,7 +92,7 @@ concurrency model.
 ## Build infrastructure
 
 Apache Pulsar uses a **Gradle** build (migrated from Maven via PIP-463; some older tooling and docs
-elsewhere still reference Maven). The wrapper `./gradlew` requires **JDK 21 or 25** (bytecode targets
+elsewhere still reference Maven). The wrapper `./gradlew` requires **JDK 21, 25 or 26** (bytecode targets
 Java 17). See [`CONTRIBUTING.md` → Building](CONTRIBUTING.md#building) for the build and lint commands.
 
 - `settings.gradle.kts` — all modules, organized in dependency tiers (Tier 0 has no internal deps,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ workflow (build, test, PR, CI). For the big-picture module map and the Gradle bu
 
 ## Building
 
-**JDK 21 or 25** is required to build `master` (bytecode targets Java 17; `-PskipJavaVersionCheck`
+**JDK 21, 25 or 26** is required to build `master` (bytecode targets Java 17; `-PskipJavaVersionCheck`
 bypasses the check); `zip` is also needed. Use the bundled wrapper `./gradlew` (Linux/macOS) or
 `gradlew.bat` (Windows) — no separate Gradle install. See the
 [build-tooling setup guide](https://pulsar.apache.org/contribute/setup-buildtools/) and the

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ for the Gradle build infrastructure and how to change build files.
 
     | Pulsar Version   |                                   JDK Version                                    |
     |------------------|:--------------------------------------------------------------------------------:|
-    | master           | [JDK 21](https://adoptium.net/en-GB/temurin/releases?version=21&os=any&arch=any) or [JDK 25](https://adoptium.net/en-GB/temurin/releases?version=25&os=any&arch=any) |
+    | master           | [JDK 21](https://adoptium.net/en-GB/temurin/releases?version=21&os=any&arch=any), [JDK 25](https://adoptium.net/en-GB/temurin/releases?version=25&os=any&arch=any) or [JDK 26](https://adoptium.net/en-GB/temurin/releases?version=26&os=any&arch=any) |
     | 4.0+             | [JDK 21](https://adoptium.net/en-GB/temurin/releases?version=21&os=any&arch=any) |
     | 2.11 +           | [JDK 17](https://adoptium.net/en-GB/temurin/releases?version=17&os=any&arch=any) |
     | 2.8 / 2.9 / 2.10 | [JDK 11](https://adoptium.net/en-GB/temurin/releases?version=11&os=any&arch=any) |

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -37,7 +37,7 @@ dependencyResolutionManagement {
         }
     }
 
-    // override docker-jdk version with -PdockerJavaVersion=21|25
+    // override docker-jdk version with -PdockerJavaVersion=21|25|26
     val overrideDockerJavaVersion = settings.providers.gradleProperty("dockerJavaVersion")
     if (overrideDockerJavaVersion.isPresent) {
         versionCatalogs {
@@ -50,11 +50,13 @@ dependencyResolutionManagement {
 
 rootProject.name = "pulsar"
 
-// Running this build requires Java 21 or 25. Version check can be skipped with -PskipJavaVersionCheck parameter.
+// Running this build requires Java 21, 25 or 26. Version check can be skipped with -PskipJavaVersionCheck parameter.
 val javaVersion = providers.provider { JavaVersion.current() }
-val statisfiedJavaVersion = javaVersion.map { it == JavaVersion.VERSION_21 || it == JavaVersion.VERSION_25 }
+val statisfiedJavaVersion = javaVersion.map {
+    it == JavaVersion.VERSION_21 || it == JavaVersion.VERSION_25 || it == JavaVersion.VERSION_26
+}
 require(providers.gradleProperty("skipJavaVersionCheck").isPresent || statisfiedJavaVersion.get()) {
-    "This build requires Java 21 or 25, but is running on Java ${javaVersion.get()}. Pass -PskipJavaVersionCheck to skip this check."
+    "This build requires Java 21, 25 or 26, but is running on Java ${javaVersion.get()}. Pass -PskipJavaVersionCheck to skip this check."
 }
 
 // ──────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
### Motivation

The Gradle build's JDK gate in `settings.gradle.kts` only accepts Java 21 or 25, so running `./gradlew` on a Java 26 JDK fails immediately unless `-PskipJavaVersionCheck` is passed. With the check skipped, the codebase already compiles cleanly on 26: `./gradlew sanityCheck` (checkstyle, spotless, Apache RAT, and main + test compilation of every module) passes, and unit tests run on the 26 JVM. No toolchain bumps (Gradle 9.7.1, Lombok, checkstyle, spotless) were needed.

### Modifications

- `settings.gradle.kts`: accept Java 26 in the JDK version check; update the error message and the `dockerJavaVersion` override comment.
- `CONTRIBUTING.md`, `ARCHITECTURE.md`, `README.md`: document Java 26 as a supported build JDK for `master`.
- `pulsar-ci.yaml`, `pulsar-ci-flaky.yaml`: add `26` as a `workflow_dispatch` choice for `jdk_major_version` so CI can be run on Java 26 on demand. Defaults, scheduled runs, and the shade matrix are unchanged.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

Verified locally:
- `./gradlew sanityCheck` passes on JDK 26.0.1 (all spotless/checkstyle tasks executed fresh on the 26 JVM, not from cache).
- `./gradlew help` succeeds on JDK 26 and JDK 21 without `-PskipJavaVersionCheck`; JDK 17 is still rejected with the updated message.
- `:pulsar-common:test --tests org.apache.pulsar.common.naming.TopicNameTest` runs on the JDK 26 JVM (18 tests, 0 failures), exercising the Java 24+ `--enable-native-access` test JVM flag.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
