### PR TITLE
[improve][broker] Avoid iterator allocation in BrokerInterceptors hot paths and restore configured ordering

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/intercept/BrokerInterceptors.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/intercept/BrokerInterceptors.java
@@ -25,6 +25,7 @@ import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
 import java.io.IOException;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import lombok.CustomLog;
 import org.apache.bookkeeper.mledger.Entry;
@@ -46,10 +47,12 @@ import org.apache.pulsar.common.intercept.InterceptException;
 @CustomLog
 public class BrokerInterceptors implements BrokerInterceptor {
 
-    private final Map<String, BrokerInterceptorWithClassLoader> interceptors;
+    // Interceptors in configured order. An array is used because iterating it does not allocate an iterator,
+    // unlike Map.values(), which matters on the per-message hot paths (onMessagePublish, beforeSendMessage, ...).
+    private final BrokerInterceptorWithClassLoader[] interceptors;
 
     public BrokerInterceptors(Map<String, BrokerInterceptorWithClassLoader> interceptors) {
-        this.interceptors = interceptors;
+        this.interceptors = interceptors.values().toArray(new BrokerInterceptorWithClassLoader[0]);
     }
 
     /**
@@ -94,7 +97,7 @@ public class BrokerInterceptors implements BrokerInterceptor {
         });
 
         if (!orderedInterceptorMap.isEmpty()) {
-            return new BrokerInterceptors(Map.copyOf(orderedInterceptorMap));
+            return new BrokerInterceptors(orderedInterceptorMap);
         } else {
             return null;
         }
@@ -105,7 +108,7 @@ public class BrokerInterceptors implements BrokerInterceptor {
                                  ByteBuf headersAndPayload,
                                  Topic.PublishContext publishContext) {
         if (interceptorsEnabled()) {
-            for (BrokerInterceptorWithClassLoader value : interceptors.values()) {
+            for (BrokerInterceptorWithClassLoader value : interceptors) {
                 value.onMessagePublish(producer, headersAndPayload, publishContext);
             }
         }
@@ -118,7 +121,7 @@ public class BrokerInterceptors implements BrokerInterceptor {
                                   long[] ackSet,
                                   MessageMetadata msgMetadata) {
         if (interceptorsEnabled()) {
-            for (BrokerInterceptorWithClassLoader value : interceptors.values()) {
+            for (BrokerInterceptorWithClassLoader value : interceptors) {
                 value.beforeSendMessage(subscription, entry, ackSet, msgMetadata);
             }
         }
@@ -131,7 +134,7 @@ public class BrokerInterceptors implements BrokerInterceptor {
                                   MessageMetadata msgMetadata,
                                   Consumer consumer) {
         if (interceptorsEnabled()) {
-            for (BrokerInterceptorWithClassLoader value : interceptors.values()) {
+            for (BrokerInterceptorWithClassLoader value : interceptors) {
                 value.beforeSendMessage(subscription, entry, ackSet, msgMetadata, consumer);
             }
         }
@@ -142,7 +145,7 @@ public class BrokerInterceptors implements BrokerInterceptor {
                                  Consumer consumer,
                                  Map<String, String> metadata) {
         if (interceptorsEnabled()) {
-            for (BrokerInterceptorWithClassLoader value : interceptors.values()) {
+            for (BrokerInterceptorWithClassLoader value : interceptors) {
                 value.consumerCreated(
                         cnx,
                         consumer,
@@ -156,7 +159,7 @@ public class BrokerInterceptors implements BrokerInterceptor {
                                Consumer consumer,
                                Map<String, String> metadata) {
         if (interceptorsEnabled()) {
-            for (BrokerInterceptorWithClassLoader value : interceptors.values()) {
+            for (BrokerInterceptorWithClassLoader value : interceptors) {
                 value.consumerClosed(cnx, consumer, metadata);
             }
         }
@@ -166,7 +169,7 @@ public class BrokerInterceptors implements BrokerInterceptor {
     public void producerCreated(ServerCnx cnx, Producer producer,
                                  Map<String, String> metadata){
         if (interceptorsEnabled()) {
-            for (BrokerInterceptorWithClassLoader value : interceptors.values()) {
+            for (BrokerInterceptorWithClassLoader value : interceptors) {
                 value.producerCreated(cnx, producer, metadata);
             }
         }
@@ -177,7 +180,7 @@ public class BrokerInterceptors implements BrokerInterceptor {
                                Producer producer,
                                Map<String, String> metadata) {
         if (interceptorsEnabled()) {
-            for (BrokerInterceptorWithClassLoader value : interceptors.values()) {
+            for (BrokerInterceptorWithClassLoader value : interceptors) {
                 value.producerClosed(cnx, producer, metadata);
             }
         }
@@ -187,7 +190,7 @@ public class BrokerInterceptors implements BrokerInterceptor {
     public void messageProduced(ServerCnx cnx, Producer producer, long startTimeNs, long ledgerId,
                                  long entryId, Topic.PublishContext publishContext) {
         if (interceptorsEnabled()) {
-            for (BrokerInterceptorWithClassLoader value : interceptors.values()) {
+            for (BrokerInterceptorWithClassLoader value : interceptors) {
                 value.messageProduced(cnx, producer, startTimeNs, ledgerId, entryId, publishContext);
             }
         }
@@ -197,7 +200,7 @@ public class BrokerInterceptors implements BrokerInterceptor {
     public  void messageDispatched(ServerCnx cnx, Consumer consumer, long ledgerId,
                                    long entryId, ByteBuf headersAndPayload) {
         if (interceptorsEnabled()) {
-            for (BrokerInterceptorWithClassLoader value : interceptors.values()) {
+            for (BrokerInterceptorWithClassLoader value : interceptors) {
                 value.messageDispatched(cnx, consumer, ledgerId, entryId, headersAndPayload);
             }
         }
@@ -207,7 +210,7 @@ public class BrokerInterceptors implements BrokerInterceptor {
     public void messageAcked(ServerCnx cnx, Consumer consumer,
                               CommandAck ackCmd) {
         if (interceptorsEnabled()) {
-            for (BrokerInterceptorWithClassLoader value : interceptors.values()) {
+            for (BrokerInterceptorWithClassLoader value : interceptors) {
                 value.messageAcked(cnx, consumer, ackCmd);
             }
         }
@@ -216,7 +219,7 @@ public class BrokerInterceptors implements BrokerInterceptor {
     @Override
     public void txnOpened(long tcId, String txnID) {
         if (interceptorsEnabled()) {
-            for (BrokerInterceptorWithClassLoader value : interceptors.values()) {
+            for (BrokerInterceptorWithClassLoader value : interceptors) {
                 value.txnOpened(tcId, txnID);
             }
         }
@@ -225,7 +228,7 @@ public class BrokerInterceptors implements BrokerInterceptor {
     @Override
     public void txnEnded(String txnID, long txnAction) {
         if (interceptorsEnabled()) {
-            for (BrokerInterceptorWithClassLoader value : interceptors.values()) {
+            for (BrokerInterceptorWithClassLoader value : interceptors) {
                 value.txnEnded(txnID, txnAction);
             }
         }
@@ -234,7 +237,7 @@ public class BrokerInterceptors implements BrokerInterceptor {
     @Override
     public void onConnectionCreated(ServerCnx cnx) {
         if (interceptorsEnabled()) {
-            for (BrokerInterceptorWithClassLoader value : interceptors.values()) {
+            for (BrokerInterceptorWithClassLoader value : interceptors) {
                 value.onConnectionCreated(cnx);
             }
         }
@@ -242,21 +245,21 @@ public class BrokerInterceptors implements BrokerInterceptor {
 
     @Override
     public void onPulsarCommand(BaseCommand command, ServerCnx cnx) throws InterceptException {
-        for (BrokerInterceptorWithClassLoader value : interceptors.values()) {
+        for (BrokerInterceptorWithClassLoader value : interceptors) {
             value.onPulsarCommand(command, cnx);
         }
     }
 
     @Override
     public void onConnectionClosed(ServerCnx cnx) {
-        for (BrokerInterceptorWithClassLoader value : interceptors.values()) {
+        for (BrokerInterceptorWithClassLoader value : interceptors) {
             value.onConnectionClosed(cnx);
         }
     }
 
     @Override
     public void onWebserviceRequest(ServletRequest request) throws IOException, ServletException, InterceptException {
-        for (BrokerInterceptorWithClassLoader value : interceptors.values()) {
+        for (BrokerInterceptorWithClassLoader value : interceptors) {
             value.onWebserviceRequest(request);
         }
     }
@@ -264,29 +267,31 @@ public class BrokerInterceptors implements BrokerInterceptor {
     @Override
     public void onWebserviceResponse(ServletRequest request, ServletResponse response)
             throws IOException, ServletException {
-        for (BrokerInterceptorWithClassLoader value : interceptors.values()) {
+        for (BrokerInterceptorWithClassLoader value : interceptors) {
             value.onWebserviceResponse(request, response);
         }
     }
 
     @Override
     public void initialize(PulsarService pulsarService) throws Exception {
-        for (BrokerInterceptorWithClassLoader v : interceptors.values()) {
+        for (BrokerInterceptorWithClassLoader v : interceptors) {
             v.initialize(pulsarService);
         }
     }
 
     @Override
     public void close() {
-        interceptors.values().forEach(BrokerInterceptorWithClassLoader::close);
+        for (BrokerInterceptorWithClassLoader value : interceptors) {
+            value.close();
+        }
     }
 
     private boolean interceptorsEnabled() {
-        return interceptors != null && !interceptors.isEmpty();
+        return interceptors.length > 0;
     }
 
     @VisibleForTesting
-    public Map<String, BrokerInterceptorWithClassLoader> getInterceptors() {
-        return interceptors;
+    public List<BrokerInterceptorWithClassLoader> getInterceptors() {
+        return List.of(interceptors);
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/WebService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/WebService.java
@@ -285,7 +285,7 @@ public class WebService implements AutoCloseable {
                 // hold all interceptors, instead we need to create a `ProcessHandlerFilter` for each `interceptor`.
                 if (pulsarService.getBrokerInterceptor() instanceof BrokerInterceptors) {
                     for (BrokerInterceptor interceptor: ((BrokerInterceptors) pulsarService.getBrokerInterceptor())
-                            .getInterceptors().values()) {
+                            .getInterceptors()) {
                         filterHolders.add(new FilterHolder(new ProcessHandlerFilter(interceptor)));
                     }
                 } else {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/BrokerInterceptorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/BrokerInterceptorTest.java
@@ -104,7 +104,7 @@ public class BrokerInterceptorTest extends ProducerConsumerBase {
     private CounterBrokerInterceptor getCounterBrokerInterceptor() {
         BrokerInterceptor brokerInterceptor = pulsar.getBrokerInterceptor();
         BrokerInterceptorWithClassLoader brokerInterceptorWithClassLoader =
-                ((BrokerInterceptors) brokerInterceptor).getInterceptors().get(CounterBrokerInterceptor.NAME);
+                ((BrokerInterceptors) brokerInterceptor).getInterceptors().get(0);
         return (CounterBrokerInterceptor) brokerInterceptorWithClassLoader.getInterceptor();
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/ExceptionsBrokerInterceptorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/ExceptionsBrokerInterceptorTest.java
@@ -78,7 +78,7 @@ public class ExceptionsBrokerInterceptorTest extends ProducerConsumerBase {
 
         BrokerInterceptors listener = (BrokerInterceptors) pulsar.getBrokerInterceptor();
         assertNotNull(listener);
-        BrokerInterceptorWithClassLoader brokerInterceptor = listener.getInterceptors().get(interceptorName);
+        BrokerInterceptorWithClassLoader brokerInterceptor = listener.getInterceptors().get(0);
         assertNotNull(brokerInterceptor);
         BrokerInterceptor interceptor = brokerInterceptor.getInterceptor();
         assertTrue(interceptor instanceof ExceptionsBrokerInterceptor);


### PR DESCRIPTION
### Motivation

`BrokerInterceptors` keeps the loaded interceptors in a `Map` built with `Map.copyOf()`, and every hook iterates `interceptors.values()`. The values view of `ImmutableCollections.MapN` allocates a new iterator on every call, and the JIT did not scalar-replace it. This shows up in allocation profiles on the per-message paths: `beforeSendMessage`, `onMessagePublish`, `messageProduced`, `messageDispatched`, `messageAcked` and `onPulsarCommand`.

Separately, `Map.copyOf()` does not preserve insertion order. Since #25160 replaced Guava's order-preserving `ImmutableMap.copyOf()`, the interceptors have been invoked in arbitrary order rather than in the order configured in `brokerInterceptors`, despite the code comment promising insertion order.

### Modifications

- `BrokerInterceptors` stores the interceptors in a `BrokerInterceptorWithClassLoader[]`, filled in configured order from the `LinkedHashMap` built by `load()`. All hooks and `close()` iterate the array. An enhanced `for` over an array compiles to an indexed loop (`arraylength` / `aaload`), so there is no iterator object at all, verified with `javap`.
- The constructor still accepts a `Map` (used by `load()` and by tests) but no longer retains it.
- `getInterceptors()` now returns a `List<BrokerInterceptorWithClassLoader>`. `WebService` iterates it directly, and `BrokerInterceptorTest` / `ExceptionsBrokerInterceptorTest`, which each register a single interceptor, take element 0 instead of looking up by name.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

Existing tests `BrokerInterceptorTest` and `ExceptionsBrokerInterceptorTest` cover the hooks and pass. Checkstyle for main and test sources is clean.

### Does this pull request potentially affect one of the following parts:

- [x] The public API: `BrokerInterceptors#getInterceptors()` (annotated `@VisibleForTesting`) now returns a `List` instead of a `Map`.
