### PR TITLE
[improve][ml] Parse message metadata at entry cache insert time instead of under the wrapper write lock

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeCacheEntryWrapper.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeCacheEntryWrapper.java
@@ -65,6 +65,9 @@ class RangeCacheEntryWrapper {
             entryWrapper.key = key;
             entryWrapper.value = value;
             entryWrapper.size = size;
+            // When the value already carries parsed message metadata, there's no need to lazily initialize it
+            // under the write lock on the first read
+            entryWrapper.messageMetadataInitialized = value.getMessageMetadata() != null;
             // Set the timestamp to the current time in nanoseconds
             // This is used for time-based eviction of entries
             entryWrapper.timestampNanos = System.nanoTime();

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImpl.java
@@ -151,6 +151,12 @@ public class RangeEntryCacheImpl implements EntryCache {
             cachedData = entry.getDataBuffer().retain();
         }
 
+        // Parse the message metadata once at insert time so that cache reads don't have to do it lazily while
+        // holding the RangeCacheEntryWrapper write lock
+        if (entry instanceof EntryImpl entryImpl) {
+            entryImpl.initializeMessageMetadataIfNeeded(ml.getName());
+        }
+
         Position position = entry.getPosition();
         ReferenceCountedEntry cacheEntry =
                 EntryImpl.createWithRetainedDuplicate(position, cachedData, entry.getReadCountHandler(),

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImplTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImplTest.java
@@ -27,7 +27,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -45,6 +47,8 @@ import org.apache.bookkeeper.mledger.impl.EntryImpl;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryMBeanImpl;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerMBeanImpl;
+import org.apache.pulsar.common.api.proto.MessageMetadata;
+import org.apache.pulsar.common.protocol.Commands;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -92,6 +96,27 @@ public class RangeEntryCacheImplTest {
         lh = mock(ReadHandle.class);
         when(lh.getId()).thenReturn(1L);
         expectedReadCount = () -> 1;
+    }
+
+    @Test
+    public void testInsertParsesMessageMetadata() {
+        MessageMetadata metadata = new MessageMetadata()
+                .setProducerName("producer")
+                .setSequenceId(7)
+                .setPublishTime(123456789L);
+        ByteBuf headersAndPayload = Commands.serializeMetadataAndPayload(Commands.ChecksumType.Crc32c, metadata,
+                Unpooled.copiedBuffer("payload", StandardCharsets.UTF_8));
+        EntryImpl entry = EntryImpl.create(1, 50, headersAndPayload);
+        headersAndPayload.release();
+        assertThat(entry.getMessageMetadata()).isNull();
+
+        assertThat(rangeEntryCache.insert(entry)).isTrue();
+
+        // the metadata is parsed once at insert time instead of lazily on the first cache read
+        assertThat(entry.getMessageMetadata()).isNotNull();
+        assertThat(entry.getMessageMetadata().getProducerName()).isEqualTo("producer");
+        assertThat(entry.getMessageMetadata().getSequenceId()).isEqualTo(7);
+        entry.release();
     }
 
     @Test


### PR DESCRIPTION
### Motivation

Profiling a broker under a tailing workload showed `EntryImpl.initializeMessageMetadataIfNeeded` being invoked from `RangeCacheEntryWrapper.withWriteLock`, i.e. a write lock taken on the entry cache **read** path.

Entries reach the cache through two paths. The read-miss path in `RangeEntryCacheImpl.readFromStorage` already parses the message metadata before inserting. The tailing-write path in `OpAddEntry` inserts entries with no parsed metadata, so the first cache read of every freshly published entry has to take the wrapper write lock, parse the metadata inside it, and every other cursor reading the same entry is serialized behind that lock. With several subscriptions tailing a topic this is the common case, not the exception.

### Modifications

- `RangeEntryCacheImpl.insert` now parses the message metadata once before creating the cached entry. Since `insert` is the single chokepoint for both the add path and the read-miss path, the cached copy always carries its metadata. On the read-miss path this is a no-op because the entry is already parsed.
- `RangeCacheEntryWrapper.withNewInstance` marks `messageMetadataInitialized` when the value already has metadata, so reads stay on the optimistic-read branch and never enter the write lock for it. The lazy initialization is kept as a fallback for values inserted without metadata (non-`EntryImpl` values or a failed parse).

The parse cost itself is not removed, it moves from the first read to the add path on the managed ledger executor. The net effect is that each entry is parsed exactly once, with no lock and no cross-cursor contention on the read path.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- Added `RangeEntryCacheImplTest.testInsertParsesMessageMetadata`, which inserts an entry built from a real serialized message with no pre-parsed metadata and asserts that the insert itself populated it.
- Existing `RangeCacheTest`, `RangeCacheRemovalQueueTest` and `RangeEntryCacheImplTest` pass.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
