### PR TITLE
[improve][broker] Copy small entries into a flat buffer when prepending broker entry metadata

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
@@ -138,6 +138,13 @@ public class Commands {
     public static final short magicCrc32c = 0x0e01;
     @SuppressWarnings("checkstyle:ConstantName")
     public static final short magicBrokerEntryMetadata = 0x0e02;
+
+    /**
+     * Payloads up to this size are copied into a single buffer when broker entry metadata is prepended; larger ones
+     * are wrapped in a composite instead. Matches the size below which the BookKeeper client copies entries anyway.
+     */
+    @VisibleForTesting
+    static final int BROKER_ENTRY_METADATA_COPY_THRESHOLD = 16 * 1024;
     private static final int checksumSize = 4;
 
     @VisibleForTesting
@@ -2086,6 +2093,24 @@ public class Commands {
         }
 
         int brokerMetaSize = brokerEntryMetadata.getSerializedSize();
+        int payloadSize = headerAndPayload.readableBytes();
+
+        if (payloadSize <= BROKER_ENTRY_METADATA_COPY_THRESHOLD) {
+            // For small payloads, produce a single contiguous buffer. A composite reaching the socket goes through
+            // nioBuffers(), which allocates two NIO views per component on every flush (BK write and each consumer
+            // dispatch), and makes every metadata parse walk the components. At this size the copy is cheaper than
+            // that, and it happens once at publish while the entry is written and parsed many more times.
+            int totalSize = 6 + brokerMetaSize + payloadSize;
+            ByteBuf entry = PulsarByteBufAllocator.DEFAULT.buffer(totalSize, totalSize);
+            entry.writeShort(Commands.magicBrokerEntryMetadata);
+            entry.writeInt(brokerMetaSize);
+            brokerEntryMetadata.writeTo(entry);
+            entry.writeBytes(headerAndPayload, headerAndPayload.readerIndex(), payloadSize);
+            headerAndPayload.release();
+            return entry;
+        }
+
+        // For large payloads the copy would cost more than the per-flush view allocations it saves.
         ByteBuf brokerMeta =
                 PulsarByteBufAllocator.DEFAULT.buffer(brokerMetaSize + 6, brokerMetaSize + 6);
         brokerMeta.writeShort(Commands.magicBrokerEntryMetadata);

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/protocol/CommandUtilsTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/protocol/CommandUtilsTest.java
@@ -149,6 +149,30 @@ public class CommandUtilsTest {
     }
 
     @Test
+    public void testAddBrokerEntryMetadataLargePayload() throws Exception {
+        int mockBatchSize = 10;
+        byte[] data = new byte[Commands.BROKER_ENTRY_METADATA_COPY_THRESHOLD + 1];
+        for (int i = 0; i < data.length; i++) {
+            data[i] = (byte) i;
+        }
+        ByteBuf byteBuf = PulsarByteBufAllocator.DEFAULT.buffer(data.length, data.length);
+        byteBuf.writeBytes(data);
+        ByteBuf dataWithBrokerEntryMetadata =
+                Commands.addBrokerEntryMetadata(byteBuf, getBrokerEntryMetadataInterceptors(), mockBatchSize);
+        assertTrue(dataWithBrokerEntryMetadata instanceof CompositeByteBuf);
+
+        BrokerEntryMetadata brokerMetadata =
+                Commands.parseBrokerEntryMetadataIfExist(dataWithBrokerEntryMetadata);
+        assertEquals(brokerMetadata.getIndex(), mockBatchSize - 1);
+        assertEquals(data.length, dataWithBrokerEntryMetadata.readableBytes());
+
+        byte[] content = new byte[dataWithBrokerEntryMetadata.readableBytes()];
+        dataWithBrokerEntryMetadata.readBytes(content);
+        assertEquals(content, data);
+        dataWithBrokerEntryMetadata.release();
+    }
+
+    @Test
     public void testSkipBrokerEntryMetadata() throws Exception {
         String data = "test-message";
         ByteBuf byteBuf = PulsarByteBufAllocator.DEFAULT.buffer(data.length(), data.length());


### PR DESCRIPTION
### Motivation

`Commands.addBrokerEntryMetadata` wraps `[brokerMeta, headerAndPayload]` in a `CompositeByteBuf`. When `brokerEntryMetadataInterceptors` is configured, that composite is the entry: it is written to every bookie in the ensemble and to every consumer the entry is dispatched to.

A multi-component composite reaching the socket goes through `CompositeByteBuf.nioBuffers()` inside Netty's `IovArray.add` (the pair encoder and BookKeeper's `ByteBufList` encoder write single buffers via the memory-address fast path, but a composite has no memory address). That allocates a `DirectByteBuffer` duplicate plus a slice per component on every flush. In an allocation profile of a broker with interceptors enabled, these throwaway views were ~11% of all allocations. On top of that, every metadata parse over the entry (dedup, dispatch filters, message finder, etc.) walks the composite's components byte by byte, and the BookKeeper CRC32C loses its memory-address fast path.

### Modifications

- For payloads up to 16KB, copy the payload into a single contiguous pooled buffer with the broker entry metadata prepended, and release the input. Ownership semantics are unchanged: the returned buffer owns the input, as the composite did.
- 16KB matches the size below which the BookKeeper client already copies entries into its own header buffer, so for typical message sizes this trades a copy that happened anyway for one that happens once at publish.
- Larger payloads keep the composite, where a full copy would cost more than the per-flush view allocations it saves.
- Added a `CommandUtilsTest` case for the over-threshold path; the existing cases exercise the copy path.
