### PR TITLE
[improve][cli] pulsar-perf: cut latency histogram memory ~100x, fix range units and static stats state

### DIFF
--- a/pulsar-testclient/src/main/java/org/apache/pulsar/proxy/socket/client/PerformanceClient.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/proxy/socket/client/PerformanceClient.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.proxy.socket.client;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.apache.pulsar.testclient.PerfClientUtils.LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS;
 import com.google.common.util.concurrent.RateLimiter;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import java.io.FileInputStream;
@@ -44,6 +45,7 @@ import java.util.concurrent.atomic.LongAdder;
 import lombok.CustomLog;
 import org.HdrHistogram.Histogram;
 import org.HdrHistogram.HistogramLogWriter;
+import org.HdrHistogram.Recorder;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.AuthenticationDataProvider;
@@ -68,10 +70,13 @@ import picocli.CommandLine.Spec;
 @CustomLog
 public class PerformanceClient extends CmdBase {
 
-    private static final LongAdder messagesSent = new LongAdder();
-    private static final LongAdder bytesSent = new LongAdder();
-    private static final LongAdder totalMessagesSent = new LongAdder();
-    private static final LongAdder totalBytesSent = new LongAdder();
+    private final LongAdder messagesSent = new LongAdder();
+    private final LongAdder bytesSent = new LongAdder();
+    private final LongAdder totalMessagesSent = new LongAdder();
+    private final LongAdder totalBytesSent = new LongAdder();
+
+    private final Recorder recorder =
+            new Recorder(SimpleTestProducerSocket.MAX_LATENCY_MICROS, LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS);
     private static IMessageFormatter messageFormatter = null;
 
     @Option(names = { "-cf", "--conf-file" }, description = "Configuration file")
@@ -267,7 +272,7 @@ public class PerformanceClient extends CmdBase {
                 }
             }
 
-            SimpleTestProducerSocket produceSocket = new SimpleTestProducerSocket();
+            SimpleTestProducerSocket produceSocket = new SimpleTestProducerSocket(recorder);
 
             try {
                 produceClient.start();
@@ -379,7 +384,7 @@ public class PerformanceClient extends CmdBase {
             double rate = messagesSent.sumThenReset() / elapsed;
             double throughput = bytesSent.sumThenReset() / elapsed / 1024 / 1024 * 8;
 
-            reportHistogram = SimpleTestProducerSocket.recorder.getIntervalHistogram(reportHistogram);
+            reportHistogram = recorder.getIntervalHistogram(reportHistogram);
 
             log.infof("Throughput produced: %7d msg --- %8.1f msg/s --- %8.1f Mbit/s"
                             + " --- Latency: mean: %7.3f ms - med: %7.3f ms"
@@ -450,7 +455,7 @@ public class PerformanceClient extends CmdBase {
 
     }
 
-    private static void printAggregatedThroughput(long start) {
+    private void printAggregatedThroughput(long start) {
         double elapsed = (System.nanoTime() - start) / 1e9;
         double rate = totalMessagesSent.sum() / elapsed;
         double throughput = totalBytesSent.sum() / elapsed / 1024 / 1024 * 8;
@@ -458,8 +463,8 @@ public class PerformanceClient extends CmdBase {
                 totalMessagesSent.sum(), rate, throughput);
     }
 
-    private static void printAggregatedStats() {
-        Histogram reportHistogram = SimpleTestProducerSocket.recorder.getIntervalHistogram();
+    private void printAggregatedStats() {
+        Histogram reportHistogram = recorder.getIntervalHistogram();
 
         log.infof("Aggregated latency stats --- Latency: mean: %7.3f ms"
                         + " - med: %d - 95pct: %d - 99pct: %d"

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/proxy/socket/client/SimpleTestProducerSocket.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/proxy/socket/client/SimpleTestProducerSocket.java
@@ -20,7 +20,6 @@ package org.apache.pulsar.proxy.socket.client;
 
 import static java.util.Base64.getEncoder;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
-import static org.apache.pulsar.testclient.PerfClientUtils.LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
@@ -43,17 +42,20 @@ import org.eclipse.jetty.websocket.api.annotations.WebSocket;
 @CustomLog
 public class SimpleTestProducerSocket {
     // Latencies are recorded in microseconds; values above this ceiling are clamped rather than
-    // rejected, since HdrHistogram throws on an out-of-range value.
-    private static final long MAX_LATENCY_MICROS = TimeUnit.HOURS.toMicros(1);
+    // rejected, since HdrHistogram throws on an out-of-range value. Package-private so that
+    // PerformanceClient, which owns the shared Recorder, can size it consistently.
+    static final long MAX_LATENCY_MICROS = TimeUnit.HOURS.toMicros(1);
 
-    public static Recorder recorder = new Recorder(MAX_LATENCY_MICROS, LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS);
+    // Shared by every socket of one PerformanceClient run so that latencies aggregate.
+    private final Recorder recorder;
 
     private final CountDownLatch closeLatch;
     private volatile Session session;
     private ConcurrentHashMap<String, Long> startTimeMap = new ConcurrentHashMap<>();
     private static final String CONTEXT = "context";
 
-    public SimpleTestProducerSocket() {
+    public SimpleTestProducerSocket(Recorder recorder) {
+        this.recorder = recorder;
         this.closeLatch = new CountDownLatch(2);
     }
 

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/proxy/socket/client/SimpleTestProducerSocket.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/proxy/socket/client/SimpleTestProducerSocket.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.proxy.socket.client;
 
 import static java.util.Base64.getEncoder;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static org.apache.pulsar.testclient.PerfClientUtils.LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
@@ -41,7 +42,11 @@ import org.eclipse.jetty.websocket.api.annotations.WebSocket;
 @WebSocket
 @CustomLog
 public class SimpleTestProducerSocket {
-    public static Recorder recorder = new Recorder(TimeUnit.SECONDS.toMillis(120000), 5);
+    // Latencies are recorded in microseconds; values above this ceiling are clamped rather than
+    // rejected, since HdrHistogram throws on an out-of-range value.
+    private static final long MAX_LATENCY_MICROS = TimeUnit.HOURS.toMicros(1);
+
+    public static Recorder recorder = new Recorder(MAX_LATENCY_MICROS, LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS);
 
     private final CountDownLatch closeLatch;
     private volatile Session session;
@@ -78,7 +83,7 @@ public class SimpleTestProducerSocket {
             startTime = startTimeMap.get(json.get(CONTEXT).getAsString());
         }
         long latencyNs = endTimeNs - startTime;
-        recorder.recordValue(NANOSECONDS.toMicros(latencyNs));
+        recorder.recordValue(Math.min(NANOSECONDS.toMicros(latencyNs), MAX_LATENCY_MICROS));
     }
 
     public Session getSession() {

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/ManagedLedgerWriter.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/ManagedLedgerWriter.java
@@ -70,17 +70,17 @@ import picocli.CommandLine.Spec;
 @CustomLog
 public class ManagedLedgerWriter extends CmdBase{
 
-    private static final LongAdder messagesSent = new LongAdder();
-    private static final LongAdder bytesSent = new LongAdder();
-    private static final LongAdder totalMessagesSent = new LongAdder();
-    private static final LongAdder totalBytesSent = new LongAdder();
+    private final LongAdder messagesSent = new LongAdder();
+    private final LongAdder bytesSent = new LongAdder();
+    private final LongAdder totalMessagesSent = new LongAdder();
+    private final LongAdder totalBytesSent = new LongAdder();
 
     // Latencies are recorded in microseconds. A managed-ledger write slower than this means the
     // benchmark is broken rather than slow, so values are clamped instead of widening the range.
     private static final long MAX_LATENCY_MICROS = TimeUnit.HOURS.toMicros(1);
 
-    private static Recorder recorder = new Recorder(MAX_LATENCY_MICROS, LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS);
-    private static Recorder cumulativeRecorder =
+    private final Recorder recorder = new Recorder(MAX_LATENCY_MICROS, LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS);
+    private final Recorder cumulativeRecorder =
             new Recorder(MAX_LATENCY_MICROS, LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS);
 
 
@@ -412,7 +412,7 @@ public class ManagedLedgerWriter extends CmdBase{
         return map;
     }
 
-    private static void printAggregatedThroughput(long start) {
+    private void printAggregatedThroughput(long start) {
         double elapsed = (System.nanoTime() - start) / 1e9;
         double rate = totalMessagesSent.sum() / elapsed;
         double throughput = totalBytesSent.sum() / elapsed / 1024 / 1024 * 8;
@@ -423,7 +423,7 @@ public class ManagedLedgerWriter extends CmdBase{
                 .log("Aggregated throughput stats --- records sent --- msg/s --- Mbit/s");
     }
 
-    private static void printAggregatedStats() {
+    private void printAggregatedStats() {
         Histogram reportHistogram = cumulativeRecorder.getIntervalHistogram();
 
         log.info()

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/ManagedLedgerWriter.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/ManagedLedgerWriter.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.testclient;
 
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static org.apache.pulsar.testclient.PerfClientUtils.LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.google.common.util.concurrent.RateLimiter;
@@ -74,8 +75,13 @@ public class ManagedLedgerWriter extends CmdBase{
     private static final LongAdder totalMessagesSent = new LongAdder();
     private static final LongAdder totalBytesSent = new LongAdder();
 
-    private static Recorder recorder = new Recorder(TimeUnit.SECONDS.toMillis(120000), 5);
-    private static Recorder cumulativeRecorder = new Recorder(TimeUnit.SECONDS.toMillis(120000), 5);
+    // Latencies are recorded in microseconds. A managed-ledger write slower than this means the
+    // benchmark is broken rather than slow, so values are clamped instead of widening the range.
+    private static final long MAX_LATENCY_MICROS = TimeUnit.HOURS.toMicros(1);
+
+    private static Recorder recorder = new Recorder(MAX_LATENCY_MICROS, LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS);
+    private static Recorder cumulativeRecorder =
+            new Recorder(MAX_LATENCY_MICROS, LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS);
 
 
     @Option(names = { "-r", "--rate" }, description = "Write rate msg/s across managed ledgers")
@@ -257,7 +263,8 @@ public class ManagedLedgerWriter extends CmdBase{
                             totalMessagesSent.increment();
                             totalBytesSent.add(payloadData.length);
 
-                            long latencyMicros = NANOSECONDS.toMicros(System.nanoTime() - sendTime);
+                            long latencyMicros = Math.min(
+                                    NANOSECONDS.toMicros(System.nanoTime() - sendTime), MAX_LATENCY_MICROS);
                             recorder.recordValue(latencyMicros);
                             cumulativeRecorder.recordValue(latencyMicros);
 

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerfClientUtils.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerfClientUtils.java
@@ -51,6 +51,23 @@ import org.apache.pulsar.tls.TlsPolicy;
 @UtilityClass
 public class PerfClientUtils {
 
+    /**
+     * Number of significant decimal digits kept by the perf clients' latency histograms.
+     *
+     * <p>HdrHistogram sizes a fixed-range histogram's counts array proportionally to
+     * {@code 2^ceil(log2(2 * 10^digits))}, so every extra digit multiplies the allocation by
+     * roughly 10. At 5 digits (HdrHistogram's maximum) a single {@code Recorder} over the
+     * ranges used here costs 11-22 MB, and since these recorders are static fields the JVM
+     * pays for every perf subcommand, not just the one being run.
+     *
+     * <p>3 digits bounds the error of a reported percentile at 0.1%. That is far below the
+     * run-to-run variance of a benchmark, and finer than the reports resolve anyway: the
+     * microsecond-based tools print milliseconds with {@code %.3f}, and the millisecond-based
+     * ones print whole milliseconds with {@code %d}. It is also HdrHistogram's own recommended
+     * default.
+     */
+    public static final int LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS = 3;
+
     private static volatile  Consumer<Integer> exitProcedure = System::exit;
 
     public static void setExitProcedure(Consumer<Integer> exitProcedure) {

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.testclient;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.apache.pulsar.testclient.PerfClientUtils.LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.google.common.util.concurrent.RateLimiter;
@@ -107,9 +108,10 @@ public class PerformanceConsumer extends PerformanceTopicListArguments{
     private static final LongAdder totalEndTxnOpSuccessNum = new LongAdder();
     private static final LongAdder numTxnOpSuccess = new LongAdder();
 
-    private static final long MAX_LATENCY = TimeUnit.DAYS.toMillis(10);
-    private static final Recorder recorder = new Recorder(MAX_LATENCY, 5);
-    private static final Recorder cumulativeRecorder = new Recorder(MAX_LATENCY, 5);
+    private static final long MAX_LATENCY_MILLIS = TimeUnit.DAYS.toMillis(10);
+    private static final Recorder recorder = new Recorder(MAX_LATENCY_MILLIS, LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS);
+    private static final Recorder cumulativeRecorder =
+            new Recorder(MAX_LATENCY_MILLIS, LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS);
 
     @Option(names = { "-n", "--num-consumers" }, description = "Number of consumers (per subscription), only "
             + "one consumer is allowed when subscriptionType is Exclusive",
@@ -515,8 +517,8 @@ public class PerformanceConsumer extends PerformanceTopicListArguments{
 
             long latencyMillis = System.currentTimeMillis() - msg.publishTime().toEpochMilli();
             if (latencyMillis >= 0) {
-                if (latencyMillis >= MAX_LATENCY) {
-                    latencyMillis = MAX_LATENCY;
+                if (latencyMillis >= MAX_LATENCY_MILLIS) {
+                    latencyMillis = MAX_LATENCY_MILLIS;
                 }
                 recorder.recordValue(latencyMillis);
                 cumulativeRecorder.recordValue(latencyMillis);

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
@@ -91,26 +91,26 @@ public class PerformanceConsumer extends PerformanceTopicListArguments{
         Stream
     }
 
-    private static final LongAdder messagesReceived = new LongAdder();
-    private static final LongAdder bytesReceived = new LongAdder();
+    private final LongAdder messagesReceived = new LongAdder();
+    private final LongAdder bytesReceived = new LongAdder();
 
-    private static final LongAdder totalMessagesReceived = new LongAdder();
-    private static final LongAdder totalBytesReceived = new LongAdder();
+    private final LongAdder totalMessagesReceived = new LongAdder();
+    private final LongAdder totalBytesReceived = new LongAdder();
 
-    private static final LongAdder totalNumTxnOpenFail = new LongAdder();
-    private static final LongAdder totalNumTxnOpenSuccess = new LongAdder();
+    private final LongAdder totalNumTxnOpenFail = new LongAdder();
+    private final LongAdder totalNumTxnOpenSuccess = new LongAdder();
 
-    private static final LongAdder totalMessageAck = new LongAdder();
-    private static final LongAdder totalMessageAckFailed = new LongAdder();
-    private static final LongAdder messageAck = new LongAdder();
+    private final LongAdder totalMessageAck = new LongAdder();
+    private final LongAdder totalMessageAckFailed = new LongAdder();
+    private final LongAdder messageAck = new LongAdder();
 
-    private static final LongAdder totalEndTxnOpFailNum = new LongAdder();
-    private static final LongAdder totalEndTxnOpSuccessNum = new LongAdder();
-    private static final LongAdder numTxnOpSuccess = new LongAdder();
+    private final LongAdder totalEndTxnOpFailNum = new LongAdder();
+    private final LongAdder totalEndTxnOpSuccessNum = new LongAdder();
+    private final LongAdder numTxnOpSuccess = new LongAdder();
 
     private static final long MAX_LATENCY_MILLIS = TimeUnit.DAYS.toMillis(10);
-    private static final Recorder recorder = new Recorder(MAX_LATENCY_MILLIS, LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS);
-    private static final Recorder cumulativeRecorder =
+    private final Recorder recorder = new Recorder(MAX_LATENCY_MILLIS, LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS);
+    private final Recorder cumulativeRecorder =
             new Recorder(MAX_LATENCY_MILLIS, LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS);
 
     @Option(names = { "-n", "--num-consumers" }, description = "Number of consumers (per subscription), only "
@@ -249,21 +249,6 @@ public class PerformanceConsumer extends PerformanceTopicListArguments{
     }
     @Override
     public void run() throws Exception {
-        // Reset static counters to avoid stale state from previous runs in the same JVM
-        messagesReceived.reset();
-        bytesReceived.reset();
-        totalMessagesReceived.reset();
-        totalBytesReceived.reset();
-        totalNumTxnOpenFail.reset();
-        totalNumTxnOpenSuccess.reset();
-        totalMessageAck.reset();
-        totalMessageAckFailed.reset();
-        messageAck.reset();
-        totalEndTxnOpFailNum.reset();
-        totalEndTxnOpSuccessNum.reset();
-        numTxnOpSuccess.reset();
-        recorder.reset();
-        cumulativeRecorder.reset();
 
         // Dump config variables
         PerfClientUtils.printJVMInformation(log);
@@ -751,7 +736,7 @@ public class PerformanceConsumer extends PerformanceTopicListArguments{
                 totalMessagesReceived.sum(), rate, throughput, rateAck, totalnumMessageAckFailed);
     }
 
-    private static void printAggregatedStats() {
+    private void printAggregatedStats() {
         Histogram reportHistogram = cumulativeRecorder.getIntervalHistogram();
 
         log.infof("Aggregated latency stats --- Latency: mean: %.3f ms"

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
@@ -90,28 +90,28 @@ import picocli.CommandLine.TypeConversionException;
 @Command(name = "produce", description = "Test pulsar producer performance.")
 @CustomLog
 public class PerformanceProducer extends PerformanceTopicListArguments{
-    private static final LongAdder messagesSent = new LongAdder();
-    private static final LongAdder messagesFailed = new LongAdder();
-    private static final LongAdder bytesSent = new LongAdder();
+    private final LongAdder messagesSent = new LongAdder();
+    private final LongAdder messagesFailed = new LongAdder();
+    private final LongAdder bytesSent = new LongAdder();
 
-    private static final LongAdder totalNumTxnOpenTxnFail = new LongAdder();
-    private static final LongAdder totalNumTxnOpenTxnSuccess = new LongAdder();
+    private final LongAdder totalNumTxnOpenTxnFail = new LongAdder();
+    private final LongAdder totalNumTxnOpenTxnSuccess = new LongAdder();
 
-    private static final LongAdder totalMessagesSent = new LongAdder();
-    private static final LongAdder totalBytesSent = new LongAdder();
+    private final LongAdder totalMessagesSent = new LongAdder();
+    private final LongAdder totalBytesSent = new LongAdder();
 
     // Publish latencies are recorded in microseconds. A send slower than this means the benchmark is
     // broken rather than slow, so values are clamped to keep HdrHistogram in range.
     private static final long MAX_LATENCY_MICROS = TimeUnit.HOURS.toMicros(1);
 
-    private static final Recorder recorder =
+    private final Recorder recorder =
             new Recorder(MAX_LATENCY_MICROS, LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS);
-    private static final Recorder cumulativeRecorder =
+    private final Recorder cumulativeRecorder =
             new Recorder(MAX_LATENCY_MICROS, LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS);
 
-    private static final LongAdder totalEndTxnOpSuccessNum = new LongAdder();
-    private static final LongAdder totalEndTxnOpFailNum = new LongAdder();
-    private static final LongAdder numTxnOpSuccess = new LongAdder();
+    private final LongAdder totalEndTxnOpSuccessNum = new LongAdder();
+    private final LongAdder totalEndTxnOpFailNum = new LongAdder();
+    private final LongAdder numTxnOpSuccess = new LongAdder();
 
     private static IMessageFormatter messageFormatter = null;
 
@@ -263,19 +263,6 @@ public class PerformanceProducer extends PerformanceTopicListArguments{
 
     @Override
     public void run() throws Exception {
-        // Reset static counters to avoid stale state from previous runs in the same JVM
-        messagesSent.reset();
-        messagesFailed.reset();
-        bytesSent.reset();
-        totalNumTxnOpenTxnFail.reset();
-        totalNumTxnOpenTxnSuccess.reset();
-        totalMessagesSent.reset();
-        totalBytesSent.reset();
-        totalEndTxnOpSuccessNum.reset();
-        totalEndTxnOpFailNum.reset();
-        numTxnOpSuccess.reset();
-        recorder.reset();
-        cumulativeRecorder.reset();
 
         // Dump config variables
         PerfClientUtils.printJVMInformation(log);
@@ -822,7 +809,7 @@ public class PerformanceProducer extends PerformanceTopicListArguments{
                 totalMessagesSent.sum(), rate, throughput);
     }
 
-    private static void printAggregatedStats() {
+    private void printAggregatedStats() {
         Histogram reportHistogram = cumulativeRecorder.getIntervalHistogram();
 
         log.infof("Aggregated latency stats --- Latency: mean: %7.3f ms"

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
@@ -24,6 +24,7 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.pulsar.client.impl.conf.ProducerConfigurationData.DEFAULT_BATCHING_MAX_MESSAGES;
 import static org.apache.pulsar.client.impl.conf.ProducerConfigurationData.DEFAULT_MAX_PENDING_MESSAGES;
 import static org.apache.pulsar.client.impl.conf.ProducerConfigurationData.DEFAULT_MAX_PENDING_MESSAGES_ACROSS_PARTITIONS;
+import static org.apache.pulsar.testclient.PerfClientUtils.LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.google.common.collect.Range;
@@ -99,8 +100,14 @@ public class PerformanceProducer extends PerformanceTopicListArguments{
     private static final LongAdder totalMessagesSent = new LongAdder();
     private static final LongAdder totalBytesSent = new LongAdder();
 
-    private static final Recorder recorder = new Recorder(TimeUnit.SECONDS.toMicros(120000), 5);
-    private static final Recorder cumulativeRecorder = new Recorder(TimeUnit.SECONDS.toMicros(120000), 5);
+    // Publish latencies are recorded in microseconds. A send slower than this means the benchmark is
+    // broken rather than slow, so values are clamped to keep HdrHistogram in range.
+    private static final long MAX_LATENCY_MICROS = TimeUnit.HOURS.toMicros(1);
+
+    private static final Recorder recorder =
+            new Recorder(MAX_LATENCY_MICROS, LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS);
+    private static final Recorder cumulativeRecorder =
+            new Recorder(MAX_LATENCY_MICROS, LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS);
 
     private static final LongAdder totalEndTxnOpSuccessNum = new LongAdder();
     private static final LongAdder totalEndTxnOpFailNum = new LongAdder();
@@ -679,17 +686,13 @@ public class PerformanceProducer extends PerformanceTopicListArguments{
 
                         long now = System.nanoTime();
                         if (now > warmupEndTime) {
-                            long latencyMicros = NANOSECONDS.toMicros(now - sendTime);
+                            long latencyMicros =
+                                    Math.min(NANOSECONDS.toMicros(now - sendTime), MAX_LATENCY_MICROS);
                             recorder.recordValue(latencyMicros);
                             cumulativeRecorder.recordValue(latencyMicros);
                         }
                     }).exceptionally(ex -> {
-                        // Ignore the exception of recorder since a very large latencyMicros will lead
-                        // ArrayIndexOutOfBoundsException in AbstractHistogram
                         Throwable cause = FutureUtil.unwrapCompletionException(ex);
-                        if (cause instanceof ArrayIndexOutOfBoundsException) {
-                            return null;
-                        }
                         // Ignore the exception when the producer is closed
                         if (cause instanceof PulsarClientException.AlreadyClosedException) {
                             return null;

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceReader.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceReader.java
@@ -51,16 +51,16 @@ import picocli.CommandLine.Option;
 @Command(name = "read", description = "Test pulsar reader performance.")
 @CustomLog
 public class PerformanceReader extends PerformanceTopicListArguments {
-    private static final LongAdder messagesReceived = new LongAdder();
-    private static final LongAdder bytesReceived = new LongAdder();
+    private final LongAdder messagesReceived = new LongAdder();
+    private final LongAdder bytesReceived = new LongAdder();
 
-    private static final LongAdder totalMessagesReceived = new LongAdder();
-    private static final LongAdder totalBytesReceived = new LongAdder();
+    private final LongAdder totalMessagesReceived = new LongAdder();
+    private final LongAdder totalBytesReceived = new LongAdder();
 
     private static final long MAX_LATENCY_MILLIS = TimeUnit.DAYS.toMillis(10);
 
-    private static Recorder recorder = new Recorder(MAX_LATENCY_MILLIS, LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS);
-    private static Recorder cumulativeRecorder =
+    private final Recorder recorder = new Recorder(MAX_LATENCY_MILLIS, LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS);
+    private final Recorder cumulativeRecorder =
             new Recorder(MAX_LATENCY_MILLIS, LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS);
 
     @Option(names = {"-r", "--rate"}, description = "Simulate a slow message reader (rate in msg/s)")
@@ -268,7 +268,7 @@ public class PerformanceReader extends PerformanceTopicListArguments {
         }
     }
 
-    private static void printAggregatedThroughput(long start) {
+    private void printAggregatedThroughput(long start) {
         double elapsed = (System.nanoTime() - start) / 1e9;
         double rate = totalMessagesReceived.sum() / elapsed;
         double throughput = totalBytesReceived.sum() / elapsed * 8 / 1024 / 1024;
@@ -276,7 +276,7 @@ public class PerformanceReader extends PerformanceTopicListArguments {
                 totalMessagesReceived.sum(), rate, throughput);
     }
 
-    private static void printAggregatedStats() {
+    private void printAggregatedStats() {
         Histogram reportHistogram = cumulativeRecorder.getIntervalHistogram();
 
         log.infof("Aggregated latency stats --- Latency: mean: %.3f ms"

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceReader.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceReader.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.testclient;
 
+import static org.apache.pulsar.testclient.PerfClientUtils.LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS;
 import static org.apache.pulsar.testclient.PerfClientUtils.addShutdownHook;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
@@ -56,8 +57,11 @@ public class PerformanceReader extends PerformanceTopicListArguments {
     private static final LongAdder totalMessagesReceived = new LongAdder();
     private static final LongAdder totalBytesReceived = new LongAdder();
 
-    private static Recorder recorder = new Recorder(TimeUnit.DAYS.toMillis(10), 5);
-    private static Recorder cumulativeRecorder = new Recorder(TimeUnit.DAYS.toMillis(10), 5);
+    private static final long MAX_LATENCY_MILLIS = TimeUnit.DAYS.toMillis(10);
+
+    private static Recorder recorder = new Recorder(MAX_LATENCY_MILLIS, LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS);
+    private static Recorder cumulativeRecorder =
+            new Recorder(MAX_LATENCY_MILLIS, LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS);
 
     @Option(names = {"-r", "--rate"}, description = "Simulate a slow message reader (rate in msg/s)")
     public double rate = 0;
@@ -256,8 +260,10 @@ public class PerformanceReader extends PerformanceTopicListArguments {
 
             long latencyMillis = System.currentTimeMillis() - msg.publishTime().toEpochMilli();
             if (latencyMillis >= 0) {
-                recorder.recordValue(latencyMillis);
-                cumulativeRecorder.recordValue(latencyMillis);
+                // Reading a backlog older than the histogram range must not blow up the read loop.
+                long clampedLatencyMillis = Math.min(latencyMillis, MAX_LATENCY_MILLIS);
+                recorder.recordValue(clampedLatencyMillis);
+                cumulativeRecorder.recordValue(clampedLatencyMillis);
             }
         }
     }

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceTransaction.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceTransaction.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.testclient;
 
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static org.apache.pulsar.testclient.PerfClientUtils.LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS;
 import static org.apache.pulsar.testclient.PerfClientUtils.addShutdownHook;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
@@ -88,15 +89,19 @@ public class PerformanceTransaction extends PerformanceBaseArguments{
     private static final LongAdder numMessagesSendFailed = new LongAdder();
     private static final LongAdder numMessagesSendSuccess = new LongAdder();
 
+    // Send and ack latencies are recorded in microseconds. Anything slower than this means the
+    // benchmark is broken rather than slow, so values are clamped to keep HdrHistogram in range.
+    private static final long MAX_LATENCY_MICROS = TimeUnit.HOURS.toMicros(1);
+
     private static final Recorder messageAckRecorder =
-            new Recorder(TimeUnit.SECONDS.toMicros(120000), 5);
+            new Recorder(MAX_LATENCY_MICROS, LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS);
     private static final Recorder messageAckCumulativeRecorder =
-            new Recorder(TimeUnit.SECONDS.toMicros(120000), 5);
+            new Recorder(MAX_LATENCY_MICROS, LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS);
 
     private static final Recorder messageSendRecorder =
-            new Recorder(TimeUnit.SECONDS.toMicros(120000), 5);
+            new Recorder(MAX_LATENCY_MICROS, LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS);
     private static final Recorder messageSendRCumulativeRecorder =
-            new Recorder(TimeUnit.SECONDS.toMicros(120000), 5);
+            new Recorder(MAX_LATENCY_MICROS, LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS);
 
     @Option(names = "--topics-c", description = "All topics that need ack for a transaction", required =
             true)
@@ -377,8 +382,8 @@ public class PerformanceTransaction extends PerformanceBaseArguments{
                                         } else {
                                             consumer.acknowledge(message.id());
                                         }
-                                        long latencyMicros = NANOSECONDS.toMicros(
-                                                System.nanoTime() - receiveTime);
+                                        long latencyMicros = Math.min(NANOSECONDS.toMicros(
+                                                System.nanoTime() - receiveTime), MAX_LATENCY_MICROS);
                                         messageAckRecorder.recordValue(latencyMicros);
                                         messageAckCumulativeRecorder.recordValue(latencyMicros);
                                         numMessagesAckSuccess.increment();
@@ -413,8 +418,8 @@ public class PerformanceTransaction extends PerformanceBaseArguments{
                                 }
                                 pendingSends.add(msg.send().whenComplete((id, ex) -> {
                                     if (ex == null) {
-                                        long latencyMicros = NANOSECONDS.toMicros(
-                                                System.nanoTime() - sendTime);
+                                        long latencyMicros = Math.min(NANOSECONDS.toMicros(
+                                                System.nanoTime() - sendTime), MAX_LATENCY_MICROS);
                                         messageSendRecorder.recordValue(latencyMicros);
                                         messageSendRCumulativeRecorder.recordValue(latencyMicros);
                                         numMessagesSendSuccess.increment();

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceTransaction.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceTransaction.java
@@ -78,29 +78,29 @@ public class PerformanceTransaction extends PerformanceBaseArguments{
     }
 
 
-    private static final LongAdder totalNumEndTxnOpFailed = new LongAdder();
-    private static final LongAdder totalNumEndTxnOpSuccess = new LongAdder();
-    private static final LongAdder numTxnOpSuccess = new LongAdder();
-    private static final LongAdder totalNumTxnOpenTxnFail = new LongAdder();
-    private static final LongAdder totalNumTxnOpenTxnSuccess = new LongAdder();
+    private final LongAdder totalNumEndTxnOpFailed = new LongAdder();
+    private final LongAdder totalNumEndTxnOpSuccess = new LongAdder();
+    private final LongAdder numTxnOpSuccess = new LongAdder();
+    private final LongAdder totalNumTxnOpenTxnFail = new LongAdder();
+    private final LongAdder totalNumTxnOpenTxnSuccess = new LongAdder();
 
-    private static final LongAdder numMessagesAckFailed = new LongAdder();
-    private static final LongAdder numMessagesAckSuccess = new LongAdder();
-    private static final LongAdder numMessagesSendFailed = new LongAdder();
-    private static final LongAdder numMessagesSendSuccess = new LongAdder();
+    private final LongAdder numMessagesAckFailed = new LongAdder();
+    private final LongAdder numMessagesAckSuccess = new LongAdder();
+    private final LongAdder numMessagesSendFailed = new LongAdder();
+    private final LongAdder numMessagesSendSuccess = new LongAdder();
 
     // Send and ack latencies are recorded in microseconds. Anything slower than this means the
     // benchmark is broken rather than slow, so values are clamped to keep HdrHistogram in range.
     private static final long MAX_LATENCY_MICROS = TimeUnit.HOURS.toMicros(1);
 
-    private static final Recorder messageAckRecorder =
+    private final Recorder messageAckRecorder =
             new Recorder(MAX_LATENCY_MICROS, LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS);
-    private static final Recorder messageAckCumulativeRecorder =
+    private final Recorder messageAckCumulativeRecorder =
             new Recorder(MAX_LATENCY_MICROS, LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS);
 
-    private static final Recorder messageSendRecorder =
+    private final Recorder messageSendRecorder =
             new Recorder(MAX_LATENCY_MICROS, LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS);
-    private static final Recorder messageSendRCumulativeRecorder =
+    private final Recorder messageSendRCumulativeRecorder =
             new Recorder(MAX_LATENCY_MICROS, LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS);
 
     @Option(names = "--topics-c", description = "All topics that need ack for a transaction", required =
@@ -196,20 +196,6 @@ public class PerformanceTransaction extends PerformanceBaseArguments{
     public void run() throws Exception {
         super.parseCLI();
 
-        // Reset static counters to avoid stale state from previous runs in the same JVM
-        totalNumEndTxnOpFailed.reset();
-        totalNumEndTxnOpSuccess.reset();
-        numTxnOpSuccess.reset();
-        totalNumTxnOpenTxnFail.reset();
-        totalNumTxnOpenTxnSuccess.reset();
-        numMessagesAckFailed.reset();
-        numMessagesAckSuccess.reset();
-        numMessagesSendFailed.reset();
-        numMessagesSendSuccess.reset();
-        messageAckRecorder.reset();
-        messageAckCumulativeRecorder.reset();
-        messageSendRecorder.reset();
-        messageSendRCumulativeRecorder.reset();
 
         // Dump config variables
         PerfClientUtils.printJVMInformation(log);
@@ -589,7 +575,7 @@ public class PerformanceTransaction extends PerformanceBaseArguments{
     }
 
 
-    private static void printTxnAggregatedThroughput(long start) {
+    private void printTxnAggregatedThroughput(long start) {
         double elapsed = (System.nanoTime() - start) / 1e9;
         long numTransactionEndFailed = totalNumEndTxnOpFailed.sum();
         long numTransactionEndSuccess = totalNumEndTxnOpSuccess.sum();
@@ -615,7 +601,7 @@ public class PerformanceTransaction extends PerformanceBaseArguments{
 
     }
 
-    private static void printAggregatedThroughput(long start) {
+    private void printAggregatedThroughput(long start) {
         double elapsed = (System.nanoTime() - start) / 1e9;
         long total = totalNumEndTxnOpFailed.sum() + totalNumEndTxnOpSuccess.sum();
         double rate = total / elapsed;
@@ -631,7 +617,7 @@ public class PerformanceTransaction extends PerformanceBaseArguments{
                 numMessageAckSuccess, numMessageSendSuccess);
     }
 
-    private static void printAggregatedStats() {
+    private void printAggregatedStats() {
         Histogram reportAckHistogram = messageAckCumulativeRecorder.getIntervalHistogram();
         Histogram reportSendHistogram = messageSendRCumulativeRecorder.getIntervalHistogram();
         log.infof("Messages ack aggregated latency stats --- Latency: mean: %7.3f ms"

--- a/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerfClientUtilsTest.java
+++ b/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerfClientUtilsTest.java
@@ -25,6 +25,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import org.HdrHistogram.Histogram;
 import org.apache.pulsar.client.admin.internal.PulsarAdminBuilderImpl;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.ProxyProtocol;
@@ -228,6 +230,26 @@ public class PerfClientUtilsTest {
             Assert.assertNull(conf.getProxyProtocol());
         } finally {
             Files.deleteIfExists(testConf);
+        }
+    }
+
+    /**
+     * The perf clients hold their latency recorders in static fields, so every subcommand allocates them on
+     * startup rather than only the one being run. HdrHistogram grows the counts array by roughly 10x per
+     * significant digit, and at 5 digits these same ranges cost 11-22 MB each. Pin the bound so raising the
+     * precision again fails here instead of silently costing hundreds of megabytes.
+     */
+    @Test
+    public void latencyHistogramsStaySmallAtTheConfiguredPrecision() {
+        long[] rangesUsedByPerfClients = {
+                TimeUnit.HOURS.toMicros(1), // publish / ack / managed-ledger write latency, in microseconds
+                TimeUnit.DAYS.toMillis(10), // end-to-end consume / read latency, in milliseconds
+        };
+        for (long range : rangesUsedByPerfClients) {
+            Histogram histogram = new Histogram(range, PerfClientUtils.LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS);
+            assertThat(histogram.getEstimatedFootprintInBytes())
+                    .as("histogram footprint for range %d", range)
+                    .isLessThan(512 * 1024);
         }
     }
 }


### PR DESCRIPTION
### Motivation

A heap dump of a `pulsar-perf produce` run (1.03 GB live) showed **246 MB — 25% of the client heap — held by HdrHistogram counts arrays before a single message had been sent.** Eclipse MAT attributed it to *class* objects, i.e. static fields:

```
class PerformanceProducer     88,090,448   8.52%
class PerformanceTransaction  88,084,968   8.52%
class PerformanceConsumer     29,363,080   2.84%
class PerformanceReader       29,362,392   2.84%
class ManagedLedgerWriter     23,073,760   2.23%
```

Only `produce` was running. Investigating this turned up two independent problems.

#### 1. The histograms are built at HdrHistogram's maximum precision

All 13 `Recorder` construction sites in `pulsar-testclient` used `numberOfSignificantValueDigits = 5`, which is the maximum the API allows. HdrHistogram sizes a fixed-range histogram's counts array as `(bucketsNeeded + 1) * subBucketHalfCount`, where `subBucketHalfCount = 2^ceil(log2(2 * 10^digits)) / 2` — so each additional digit multiplies the allocation by roughly 10. Measured against HdrHistogram 2.2.2 over the range `PerformanceProducer` used:

| significant digits | counts array, per `Recorder` |
|---|---|
| 3 | 229,888 B |
| 4 | 3,146,240 B |
| 5 | **22,020,608 B** |

Because these recorders are `static` fields and `PulsarPerfTestTool.initCommander` reflectively instantiates *every* registered subcommand before parsing arguments (`PulsarPerfTestTool.java:72`, `constructor.newInstance()`), each class's `<clinit>` runs on every invocation. So `pulsar-perf produce` was also paying for `transaction`, `consume`, `read` and `managed-ledger` — about 170 MB of histograms for commands that never ran.

The 5th digit is not visible anywhere in the output. The microsecond-based tools divide by 1000 and print milliseconds with `%7.3f`; the millisecond-based tools print whole milliseconds with `%d`. Over 2M synthetic lognormal samples, 3 vs 5 digits differ by at most 0.088%:

```
  p50     5-digit=    2.001 ms   3-digit=    2.001 ms   rel.err=0.0000%
  p99     5-digit=   12.840 ms   3-digit=   12.847 ms   rel.err=0.0545%
  p99.99  5-digit=   38.243 ms   3-digit=   38.271 ms   rel.err=0.0732%
  p100    5-digit=  143.872 ms   3-digit=  143.999 ms   rel.err=0.0883%
```

That is far below the run-to-run variance of a throughput benchmark, and 3 digits is HdrHistogram's own recommended default. The quantization is one-sided upward for percentiles and Max, so reduced precision can only inflate a reported tail, never understate it.

The precision change is also provably incapable of introducing a new `ArrayIndexOutOfBoundsException`: the throw threshold is a function of the range alone. Measured first-throwing values are byte-identical at 5 and at 3 digits for every range used here.

Note that switching to an *auto-resizing* `Recorder` is **not** the fix: `Recorder(int)` uses `ConcurrentHistogram`, which keeps both an active and an inactive counts array. Measured, `new Recorder(5)` starts at 4.2 MB and grows to 44 MB — twice the fixed-range cost.

#### 2. Two ranges are in the wrong unit, and two record sites can throw

`new Recorder(highestTrackableValue, digits)` builds a fixed-range histogram that throws `ArrayIndexOutOfBoundsException` on an out-of-range value. #5786 fixed such a mismatch in `PerformanceProducer` by switching its range from `SECONDS.toMillis(120000)` to `SECONDS.toMicros(120000)`, but the same bug was left in place elsewhere:

- **`ManagedLedgerWriter`** records `latencyMicros` (`NANOSECONDS.toMicros(...)`) into a range of `SECONDS.toMillis(120000)` = 1.2e8. Its real ceiling is therefore **about two minutes, not 120000 seconds**. There is no clamp and no handler — the `recordValue` sits directly in the `AddEntryCallback.addComplete` callback. Present since the file was added in #1270.
- **`SimpleTestProducerSocket`** (`pulsar-perf websocket-producer`) has exactly the same mismatch, inside an `@OnWebSocketMessage` handler. Dates to the initial import.
- **`PerformanceReader`** records a wall-clock `latencyMillis` with only a `>= 0` guard. `PerformanceConsumer` was given an upper clamp in #17160 ("do not fail in case of reading data older than 10 days"); `PerformanceReader` never was, so reading a sufficiently old backlog throws out of the read loop.

Note that the declared `highestTrackableValue` is not itself the throw threshold — HdrHistogram rounds the counts array up to the next power-of-two bucket boundary, so each histogram tolerates 12-24% more than its declared range. Measured first-throwing values: 134,217,728 us (**134.2 s**) for the two mismatched ranges, and 1,073,741,824 ms (**12.43 days**) for consume/read. The bugs stand; only the exact ceilings differ from the declared ones.

Separately, the 33.3-hour (`SECONDS.toMicros(120000)`) ceiling on the publish-side recorders is not a meaningful latency bound for a send or an ack. Consume and read keep their 10-day range on purpose, because a backlogged message legitimately can be that old.

#### 3. The same fields are JVM-global for no reason

While fixing the above it became clear the recorders did not need to be `static` at all, and neither do the 51 `LongAdder` counters sitting next to them in the same declaration blocks. The only static accessors are `printAggregatedStats` and `printAggregatedThroughput`, and those are called from a shutdown-hook lambda that is already constructed inside `run()`:

```java
// PerformanceReader.java:156 — inside run(), the lambda already captures `this`
Thread shutdownHookThread = addShutdownHook(() -> {
    printAggregatedThroughput(start);
    printAggregatedStats();
});
```

`PerformanceProducer` and `PerformanceConsumer` had in fact already made `printAggregatedThroughput` an instance method, so their counters had **no** static accessor left.

What the `static` did cost is 26 defensive `reset()` calls, under a comment that names the problem:

```java
public void run() throws Exception {
    // Reset static counters to avoid stale state from previous runs in the same JVM
    messagesSent.reset();
    ...
```

and the compensation is incomplete: `PerformanceReader`, `ManagedLedgerWriter` and `PerformanceClient` have **no** resets at all, so a second run in the same JVM folds the first run's messages, bytes and latencies into its aggregate stats. `PerformanceProducerTest` already constructs four `PerformanceProducer` instances in one JVM.

This is handled here rather than in a follow-up because it is the same fields, in the same declaration blocks, in the same six classes this PR already rewrites — splitting it would mean touching every one of those lines twice for no reviewer benefit.

### Modifications

- Add `PerfClientUtils.LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS = 3` and use it at all 13 `Recorder` construction sites, with the sizing rationale documented on the constant.
- Give each publish-side recorder a `MAX_LATENCY_MICROS = TimeUnit.HOURS.toMicros(1)` ceiling (`PerformanceProducer`, `PerformanceTransaction`, `ManagedLedgerWriter`, `SimpleTestProducerSocket`) — correcting the unit for the latter two — and clamp with `Math.min` before recording. Consume/read keep `TimeUnit.DAYS.toMillis(10)`.
- Clamp in `PerformanceReader`, matching what `PerformanceConsumer` already does.
- Rename `PerformanceConsumer.MAX_LATENCY` to `MAX_LATENCY_MILLIS`; unit-ambiguous names are what allowed this class of bug in the first place.
- Drop the now-unnecessary `ArrayIndexOutOfBoundsException` branch in `PerformanceProducer`'s `exceptionally` handler. It was a workaround for the recorder throwing; with clamping it can only mask a genuine error.

And, for the JVM-global state:

- Make all 12 `Recorder` and 51 `LongAdder` fields instance fields, and `printAggregatedStats` / `printAggregatedThroughput` / `printTxnAggregatedThroughput` instance methods, across `PerformanceProducer`, `PerformanceConsumer`, `PerformanceReader`, `PerformanceTransaction`, `ManagedLedgerWriter` and `PerformanceClient`.
- Delete the 26 compensating `reset()` calls; the state now cannot outlive the command object.
- `SimpleTestProducerSocket.recorder` was the one field with a genuine reason to be shared, since `PerformanceClient` creates one socket per connection. `PerformanceClient` now owns the `Recorder` and injects it through the constructor, which keeps the aggregation while dropping the JVM-global.

That part is a pure refactor with no behaviour change for a single run, and it is net-negative in size (-116 / +81 lines). One piece of mutable static state remains in `PerformanceClient` (`messageFormatter`); it is unrelated to the stats and left alone.

Measured effect on the startup allocation for a `pulsar-perf produce` run (the 14 arrays MAT observed):

```
  before = 257,956,864 bytes (246.0 MB)
  after  =   2,579,456 bytes (2.46 MB)   -> 100x smaller
```

Reported percentiles shift by at most ~0.09% (visible only in the third decimal of the millisecond figures); the `%d` millisecond reports are unchanged for any value below ~2 seconds, where 3-digit buckets are still exact.

This does not address the underlying issue that every subcommand is instantiated at startup. That is worth fixing separately and would recover the ~170 MB attributable to commands that never run. It is also a comparatively recent regression: before #22388 (PIP-343, May 2024) `bin/pulsar-perf` `exec`-ed one main class per subcommand (`exec $JAVA $OPTS org.apache.pulsar.testclient.PerformanceProducer ...`), so only the selected command's `<clinit>` ran. Registering the subcommand `Class` objects with picocli instead of pre-built instances would restore that property — picocli defers `CommandUserObject.getInstance()` until a subcommand is actually selected.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- The de-staticizing is verified by the compiler: had any of the 63 fields genuinely needed to be `static`, the build would fail. `PerformanceProducerTest`, which constructs four `PerformanceProducer` instances in one JVM, passes without the reset calls that previously made that safe.
- Added `PerfClientUtilsTest.latencyHistogramsStaySmallAtTheConfiguredPrecision`, which asserts that a `Recorder` built at `LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS` over each range the perf clients use stays under 512 KB. Verified that it pins the change: it fails with the constant set back to 5 (`Expecting actual ... to be less than 524288`) and passes at 3.
- The array-sizing figures above were measured by running against `HdrHistogram-2.2.2.jar` directly, and the three array lengths seen in the heap dump (2,752,512 / 1,835,008 / 1,441,792) reproduce exactly from the declared ranges.
- Also confirmed that this is not a regression from the recent HdrHistogram 2.1.9 -> 2.2.2 bump (#26353). Both versions compute byte-identical counts-array *sizes* for these declarations. If anything the bump helped: in 2.1.9 `Recorder` allocated both the active and the inactive histogram up front (measured 44,040,224 B per `Recorder` at construction), whereas 2.2.2 leaves `inactiveHistogram` null until the first `getIntervalHistogram()` (22,020,112 B). The same dump taken before #26353 would have carried 24 arrays / 427,819,392 B rather than 14 arrays / 257,949,920 B. The ranges and the digit count are the Pulsar-side cause, and they predate both versions.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
