### PR TITLE
[fix][cli] pulsar-perf: register subcommand classes with picocli instead of instances

### DIFF
--- a/pulsar-testclient/src/main/java/org/apache/pulsar/proxy/socket/client/PerformanceClient.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/proxy/socket/client/PerformanceClient.java
@@ -59,10 +59,8 @@ import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
-import picocli.CommandLine.Spec;
 
 @Command(name = "websocket-producer", description = "Test pulsar websocket producer performance.")
 @CustomLog
@@ -136,12 +134,8 @@ public class PerformanceClient extends CmdBase {
         super("websocket-producer");
     }
 
-
-    @Spec
-    CommandSpec spec;
-
     public void loadArguments() {
-        CommandLine commander = spec.commandLine();
+        CommandLine commander = getCommander();
 
         if (isBlank(this.authPluginClassName) && !isBlank(this.deprecatedAuthPluginClassName)) {
             this.authPluginClassName = this.deprecatedAuthPluginClassName;

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/CmdGenerateDocumentation.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/CmdGenerateDocumentation.java
@@ -27,9 +27,7 @@ import lombok.CustomLog;
 import org.apache.pulsar.proxy.socket.client.PerformanceClient;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Option;
-import picocli.CommandLine.Spec;
 
 @CustomLog
 @Command(name = "gen-doc", description = "Generate documentation automatically.")
@@ -42,12 +40,9 @@ public class CmdGenerateDocumentation extends CmdBase{
         super("gen-doc");
     }
 
-    @Spec
-    CommandSpec spec;
-
     @Override
     public void run() throws Exception {
-        CommandLine commander = spec.commandLine();
+        CommandLine commander = getCommander();
 
         Map<String, Class<?>> cmdClassMap = new LinkedHashMap<>();
         cmdClassMap.put("produce", PerformanceProducer.class);

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/ManagedLedgerWriter.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/ManagedLedgerWriter.java
@@ -61,9 +61,7 @@ import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
 import org.apache.pulsar.testclient.utils.PaddingDecimalFormat;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Option;
-import picocli.CommandLine.Spec;
 
 @Command(name = "managed-ledger", description = "Write directly on managed-ledgers")
 @CustomLog
@@ -134,13 +132,9 @@ public class ManagedLedgerWriter extends CmdBase{
         super("managed-ledger");
     }
 
-
-    @Spec
-    CommandSpec spec;
-
     @Override
     public void run() throws Exception {
-        CommandLine commander = spec.commandLine();
+        CommandLine commander = getCommander();
 
         if (this.metadataStoreUrl == null && this.zookeeperServers == null) {
             System.err.println("Metadata store address argument is required (--metadata-store)");

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PulsarPerfTestTool.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PulsarPerfTestTool.java
@@ -21,7 +21,6 @@ package org.apache.pulsar.testclient;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import java.io.FileInputStream;
-import java.lang.reflect.Constructor;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -64,24 +63,24 @@ public class PulsarPerfTestTool {
                 prop.load(fis);
             }
         }
-        commander.setDefaultValueProvider(PulsarPerfTestPropertiesProvider.create(prop));
-
+        // Register the command classes rather than instances: picocli builds each subcommand's spec
+        // from annotations and only instantiates the user object once that subcommand is selected.
+        // Instantiating them all here ran every command's static initializers on every invocation,
+        // which is how `pulsar-perf produce` ended up allocating the latency histograms of `consume`,
+        // `read`, `transaction` and `managed-ledger` as well.
         for (Map.Entry<String, Class<?>> c : commandMap.entrySet()) {
-            Constructor<?> constructor = c.getValue().getDeclaredConstructor();
-            constructor.setAccessible(true);
-            addCommand(c.getKey(), constructor.newInstance());
+            commander.addSubcommand(c.getKey(), c.getValue());
         }
+
+        // Both settings propagate to the subcommand hierarchy as it exists when they are called, so
+        // they must be applied after the subcommands are registered. CmdBase used to set the enum
+        // behaviour on the per-command CommandLine it built in its own constructor; that instance is
+        // no longer the one picocli parses with.
+        commander.setDefaultValueProvider(PulsarPerfTestPropertiesProvider.create(prop));
+        commander.setCaseInsensitiveEnumValuesAllowed(true);
 
         // Remove the first argument, it's the config file path
         return Arrays.copyOfRange(args, 1, args.length);
-    }
-
-    private void addCommand(String name, Object o) {
-        if (o instanceof CmdBase) {
-            commander.addSubcommand(name, ((CmdBase) o).getCommander());
-        } else {
-            commander.addSubcommand(o);
-        }
     }
 
     public static void main(String[] args) throws Exception {


### PR DESCRIPTION
### Motivation

`PulsarPerfTestTool.initCommander` reflectively instantiates **every** registered subcommand before a single argument is parsed:

```java
for (Map.Entry<String, Class<?>> c : commandMap.entrySet()) {
    Constructor<?> constructor = c.getValue().getDeclaredConstructor();
    constructor.setAccessible(true);
    addCommand(c.getKey(), constructor.newInstance());   // <- runs every command's <clinit>
}
```

`Constructor.newInstance` is a class-initialization trigger, so `pulsar-perf produce` runs the static initializers of `consume`, `read`, `transaction`, `managed-ledger`, `monitor-brokers`, `websocket-producer` and `gen-doc` too. Those classes hold their latency `Recorder`s in static fields, so a `produce` run allocates their HdrHistogram counts arrays and never touches them again. On a heap dump of a `pulsar-perf produce` run this accounted for roughly 170 MB.

This is a regression, not long-standing behaviour. Before #22388 (PIP-343, May 2024) `bin/pulsar-perf` dispatched to one main class per subcommand:

```sh
if [ "$COMMAND" == "produce" ]; then
    exec $JAVA $OPTS org.apache.pulsar.testclient.PerformanceProducer --conf-file $PULSAR_PERFTEST_CONF "$@"
elif [ "$COMMAND" == "consume" ]; then
...
```

so only the selected command was ever loaded. The subcommand refactor kept the dispatch table but made it eager.

picocli does not require instances: `addSubcommand(String, Class)` builds the command spec from annotations and defers creating the user object until that subcommand is actually selected.

### Modifications

- Register the command `Class` objects rather than pre-built instances, and drop the now-unused reflective instantiation and the `addCommand` helper.
- Move `setDefaultValueProvider` to *after* the subcommands are registered, and set `setCaseInsensitiveEnumValuesAllowed(true)` on the root commander there as well. Both settings propagate to the subcommand hierarchy as it exists at the moment they are invoked. The enum setting previously came from `CmdBase`'s constructor, which applied it to the per-command `CommandLine` that `CmdBase` builds for itself — that instance is no longer the one picocli parses with, so it has to be set on the root.
- Drop the `@Spec CommandSpec spec` field from `ManagedLedgerWriter`, `CmdGenerateDocumentation` and `PerformanceClient`. Registering the class is not sufficient for these three: picocli must create the user object to inject a `@Spec` field, so they stayed eager while the five commands without `@Spec` became lazy. All three used the injected spec only to reach `spec.commandLine()`, and that returned exactly the `CommandLine` `CmdBase` builds in its own constructor — because the old code registered `((CmdBase) o).getCommander()` as the subcommand. Calling `getCommander()` directly is the same object the code was already using.

Net effect on class initialization for `pulsar-perf <conf> produce --help`, measured with `-Xlog:class+init`:

| class | before | after |
|---|---|---|
| `PerformanceProducer` (the selected one) | 1 | 1 |
| `PerformanceConsumer` | 1 | **0** |
| `PerformanceReader` | 1 | **0** |
| `PerformanceTransaction` | 1 | **0** |
| `BrokerMonitor` | 1 | **0** |
| `ManagedLedgerWriter` | 1 | **0** |
| `CmdGenerateDocumentation` | 1 | **0** |
| `PerformanceClient` | 1 | **0** |

`pulsar-perf produce` now initializes `PerformanceProducer` and no other command class. On current `master` that stops roughly 170 MB of histogram allocation (`PerformanceConsumer` 2 x 14,680,080 B, `PerformanceReader` 2 x 14,680,080 B, `PerformanceTransaction` 4 x 22,020,112 B, `ManagedLedgerWriter` 2 x 11,534,352 B). Note that #26466, which shrinks those same histograms about 100x, reduces the size of this particular win considerably if it lands first — the lasting value here is that unused subcommands stop doing *any* startup work, not just histogram allocation.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests (`GenerateDocumentionTest`, `PerformanceBaseArgumentsTest`, `PerformanceClientTest`, `PerfClientUtilsTest` — the full `pulsar-testclient` suite passes), and was additionally verified by running the real CLI before and after against the same classpath and config file:

| probe | before | after |
|---|---|---|
| `--help` subcommand list | all 8 | identical, all 8 |
| `produce --help` defaults sourced from the conf file | `pulsar://<from conf>:6650` | identical |
| case-insensitive enum `produce -z lz4` (constant is `LZ4`) | parses | parses |
| case-insensitive enum `consume -st shared` (constant is `Shared`) | parses | parses |
| invalid enum `produce -z nosuchcodec` | `Invalid value for option '--compression': expected one of [NONE, LZ4, ZLIB, ZSTD, SNAPPY] (case-insensitive) but was 'nosuchcodec'` | byte-identical |
| unknown subcommand | `Unmatched argument at index 0: 'nosuchcommand'` | byte-identical |

Plus, for the `@Spec` removal, the three code paths that used the injected spec:

| probe | before | after |
|---|---|---|
| `managed-ledger` with a bad argument -> error + usage | error text and full usage block, defaults included | byte-identical |
| `websocket-producer` with a missing required parameter -> usage | usage block | byte-identical |
| `gen-doc` -> generated tables | 7 command sections, 14 headings | byte-identical |

The full captured output of every probe above was diffed between `master` and this branch: the **only** differences are the class-initialization lines. `./gradlew quickCheck` and `./gradlew sanityCheck` both pass.

The case-insensitive enum probes matter specifically because that setting moved from `CmdBase` to the root commander; the invalid-enum message still reporting "(case-insensitive)" confirms it is still in effect on the subcommand.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
