### PR TITLE
[improve][test] Make PulsarProfilingTest test Scalable Topics and adjust memory parameters

### DIFF
--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/profiling/PulsarProfilingTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/profiling/PulsarProfilingTest.java
@@ -30,6 +30,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import lombok.CustomLog;
+import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.tests.ManualTestUtil;
 import org.apache.pulsar.tests.integration.containers.PulsarContainer;
@@ -69,8 +70,15 @@ public class PulsarProfilingTest extends PulsarTestSuite {
     // echo madvise | sudo tee /sys/kernel/mm/transparent_hugepage/defrag
     // More info about -XX:+UseTransparentHugePages at
     // https://shipilev.net/jvm/anatomy-quarks/2-transparent-huge-pages/
-    private static final String DEFAULT_PULSAR_MEM = "-Xms512m -Xmx1g -XX:+UseTransparentHugePages -XX:+AlwaysPreTouch";
+    private static final String DEFAULT_PULSAR_MEM = "-Xmx1g -XX:+UseTransparentHugePages -XX:+AlwaysPreTouch";
+    private static final String PERF_PULSAR_MEM =
+            "-XX:+UseTransparentHugePages -XX:+AlwaysPreTouch -XX:+HeapDumpOnOutOfMemoryError "
+                    + "-XX:HeapDumpPath=/testoutput/%HEAP_DUMP_NAME%";
+    private static final String PRODUCE_MEM_LIMIT = "200M";
+    private static final String CONSUME_MEM_LIMIT = "200M";
     private static final String BROKER_PULSAR_MEM = "-Xms2g -Xmx2g -XX:+UseTransparentHugePages -XX:+AlwaysPreTouch";
+    // test v5 scalable topics
+    private static final TopicDomain TOPIC_DOMAIN = TopicDomain.topic;
 
     // A container that runs pulsar-perf, arguments are currently hard-coded since this is an example
     static class PulsarPerfContainer extends GenericContainer<PulsarPerfContainer> {
@@ -80,14 +88,16 @@ public class PulsarProfilingTest extends PulsarTestSuite {
         public PulsarPerfContainer(File testOutputDir,
                                    String clusterName,
                                    String brokerHostname,
-                                   String hostname) {
+                                   String hostname,
+                                   String memArgs) {
             super(PulsarContainer.DEFAULT_IMAGE_NAME);
             this.brokerHostname = brokerHostname;
             withCreateContainerCmdModifier(createContainerCmd -> {
                 createContainerCmd.withHostName(hostname);
                 createContainerCmd.withName(clusterName + "-" + hostname);
             });
-            withEnv("PULSAR_MEM", DEFAULT_PULSAR_MEM + " -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/testoutput");
+            String heapDumpName = hostname + "-oom-" + System.currentTimeMillis() + ".hprof";
+            withEnv("PULSAR_MEM", PERF_PULSAR_MEM.replace("%HEAP_DUMP_NAME%", heapDumpName) + " " + memArgs);
             withEnv("PULSAR_GC", "-XX:+UseZGC -XX:+ZGenerational");
             setCommand("sleep 1000000");
             withFileSystemBind(testOutputDir.getAbsolutePath(), "/testoutput", BindMode.READ_WRITE);
@@ -100,7 +110,7 @@ public class PulsarProfilingTest extends PulsarTestSuite {
                             + "-u pulsar://" + brokerHostname + ":6650 "
                             + "-st Shared "
                             + "-q 50000 "
-                            + "-m " + numberOfMessages + " -ml 400M "
+                            + "-m " + numberOfMessages + " -ml " + CONSUME_MEM_LIMIT + " "
                             + "--histogram-file=/testoutput/consume.histogram.$(date +%s).hdr "
                             + "2>&1 | tee /testoutput/consume.$(date +%s).txt");
         }
@@ -113,8 +123,9 @@ public class PulsarProfilingTest extends PulsarTestSuite {
                             + "-au http://" + brokerHostname + ":8080 "
                             + "-r " + Integer.MAX_VALUE + " "
                             + "-s 128 -db "
+                            // maxOutstanding is ignored for Pulsar 5.x pulsar-perf
                             + "-o 20000 "
-                            + "-m " + numberOfMessages + " -ml 400M "
+                            + "-m " + numberOfMessages + " -ml " + PRODUCE_MEM_LIMIT + " "
                             + "--histogram-file=/testoutput/produce.histogram.$(date +%s).hdr "
                             + "2>&1 | tee /testoutput/produce.$(date +%s).txt");
         }
@@ -283,9 +294,9 @@ public class PulsarProfilingTest extends PulsarTestSuite {
 
         // Create pulsar-perf containers
         String brokerHostname = clusterName + "-pulsar-broker-0";
-        perfProduce = new PulsarPerfContainer(testOutputDir, clusterName, brokerHostname, "perf-produce");
-        perfConsume = new PulsarPerfContainer(testOutputDir, clusterName, brokerHostname, "perf-consume");
-        printStats = new PulsarPerfContainer(testOutputDir, clusterName, brokerHostname, "print-stats");
+        perfProduce = new PulsarPerfContainer(testOutputDir, clusterName, brokerHostname, "perf-produce", "-Xmx2g");
+        perfConsume = new PulsarPerfContainer(testOutputDir, clusterName, brokerHostname, "perf-consume", "-Xmx1g");
+        printStats = new PulsarPerfContainer(testOutputDir, clusterName, brokerHostname, "print-stats", "-Xmx1g");
         specBuilder.externalServices(Map.of(
                 "pulsar-produce", perfProduce,
                 "pulsar-consume", perfConsume,
@@ -297,7 +308,7 @@ public class PulsarProfilingTest extends PulsarTestSuite {
 
     @Test(timeOut = 600_000)
     public void runPulsarPerf() throws Exception {
-        String topicName = generateTopicName("profiletest", true);
+        String topicName = generateTopicName("profiletest", TOPIC_DOMAIN);
         CompletableFuture<Long> consumeFuture = perfConsume.consume(topicName);
         Thread.sleep(1000);
         CompletableFuture<Long> produceFuture = perfProduce.produce(topicName);

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarTestBase.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarTestBase.java
@@ -32,6 +32,8 @@ import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.common.naming.TopicDomain;
+import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.apache.pulsar.tests.TestRetrySupport;
@@ -68,18 +70,23 @@ public abstract class PulsarTestBase extends TestRetrySupport {
         return generateTopicName("default", topicPrefix, isPersistent);
     }
 
+    protected static String generateTopicName(String topicPrefix, TopicDomain topicDomain) {
+        return generateTopicName("default", topicPrefix, topicDomain);
+    }
+
     protected static String generateTopicName(String namespace, String topicPrefix, boolean isPersistent) {
+        return generateTopicName(namespace, topicPrefix,
+                isPersistent ? TopicDomain.persistent : TopicDomain.non_persistent);
+    }
+
+    protected static String generateTopicName(String namespace, String topicPrefix, TopicDomain topicDomain) {
         String topicName = new StringBuilder(topicPrefix)
                 .append("-")
                 .append(randomName(8))
                 .append("-")
                 .append(System.currentTimeMillis())
                 .toString();
-        if (isPersistent) {
-            return "persistent://public/" + namespace + "/" + topicName;
-        } else {
-            return "non-persistent://public/" + namespace + "/" + topicName;
-        }
+        return TopicName.get(topicDomain.toString(), "public", namespace, topicName).toString();
     }
 
     protected void testPublishAndConsume(String serviceUrl, boolean isPersistent) throws Exception {


### PR DESCRIPTION
### Motivation

`PulsarProfilingTest` is a manual profiling harness that runs a broker plus `pulsar-perf` produce/consume containers under async-profiler. So far it only exercised classic `persistent://` topics, so it could not be used to profile or stress the v5 Scalable Topics (`topic://`) code path.

While switching it over, it turned out that this test case reproduces an issue with Scalable Topics: the `pulsar-perf` **produce** side crashes with an `OutOfMemoryError`. This still happens after #26466, which reduced `pulsar-perf` heap usage — so the reduced histogram footprint is not what keeps the producer alive here, and the remaining growth is on the Scalable Topics produce path itself.

Note that the producer in this test runs with the publish rate limit set to `Integer.MAX_VALUE` (`-r 2147483647`), so producing is effectively never rate limited and the producer pushes as fast as the broker will accept.

Reproducing it:

1. Run `./gradlew :tests:integration:profilingIntegrationTest`
2. Wait about a minute for the Docker containers to start running.
3. Watch `tests/integration/build/pulsar-profiling` until a `perf-produce-oom-*.hprof` file is created.
4. Kill the Gradle build execution and analyze the heap dump.

Example heap dump: https://drive.google.com/file/d/1i2Oy8k1DMMRHYqRjIjurhFgvLc-TD32b/view

### Modifications

- Route the test topic through a `TopicDomain` constant (`TopicDomain.topic`), so the harness now exercises v5 Scalable Topics; flipping the constant back to `persistent` restores the previous behavior.
- Add `generateTopicName(...)` overloads taking a `TopicDomain` in `PulsarTestBase`, and build the topic name with `TopicName.get(...)` instead of string concatenation. The existing `boolean isPersistent` overloads are kept and delegate to the new ones, so other tests are unaffected.
- Give the `pulsar-perf` containers their own JVM memory settings (`PERF_PULSAR_MEM`) instead of reusing the broker/`DEFAULT_PULSAR_MEM` ones, and pass per-container heap sizes: 2g for produce, 1g for consume and print-stats.
- Write the heap dump to a unique, container-specific file (`<hostname>-oom-<timestamp>.hprof`) so that repeated runs and the three containers no longer overwrite each other's dumps.
- Lower the `pulsar-perf` client memory limits (`-ml`) from 400M to 200M for both produce and consume, so the failure shows up quickly and within the container heap.
- Drop `-Xms512m` from `DEFAULT_PULSAR_MEM` and note that `-o` (`maxOutstanding`) is ignored by the Pulsar 5.x `pulsar-perf`.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a test-tooling change to a manually-run profiling test which is not part of CI. It was verified by running `./gradlew :tests:integration:profilingIntegrationTest` locally and observing the `perf-produce-oom-*.hprof` heap dump appear in `tests/integration/build/pulsar-profiling`.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
