### PR TITLE
[fix][admin] Reject empty cluster migration URL: fix inverted ClusterUrl.isEmpty()

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
@@ -80,6 +80,8 @@ import org.apache.pulsar.common.policies.data.AutoFailoverPolicyType;
 import org.apache.pulsar.common.policies.data.BrokerInfo;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.ClusterDataImpl;
+import org.apache.pulsar.common.policies.data.ClusterPolicies;
+import org.apache.pulsar.common.policies.data.ClusterPolicies.ClusterUrl;
 import org.apache.pulsar.common.policies.data.ErrorData;
 import org.apache.pulsar.common.policies.data.NamespaceIsolationDataImpl;
 import org.apache.pulsar.common.policies.data.Policies;
@@ -291,6 +293,20 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
         assertEquals(asyncRequests(ctx -> clusters.getCluster(ctx, "use")),
                 ClusterData.builder().serviceUrl("http://new-broker.messaging.use.example.com:8080").build());
 
+        // Marking a cluster as migrated without any target url must be rejected
+        try {
+            asyncRequests(ctx -> clusters.updateClusterMigration(ctx, "use", true, new ClusterUrl()));
+            fail("should have failed");
+        } catch (RestException e) {
+            assertEquals(e.getResponse().getStatus(), Status.BAD_REQUEST.getStatusCode());
+        }
+        // ... while a target url of any kind is accepted
+        ClusterUrl migratedUrl = new ClusterUrl(null, null, "pulsar://green.example.com:6650", null);
+        asyncRequests(ctx -> clusters.updateClusterMigration(ctx, "use", true, migratedUrl));
+        ClusterPolicies migration = (ClusterPolicies) asyncRequests(ctx -> clusters.getClusterMigration(ctx, "use"));
+        assertTrue(migration.isMigrated());
+        assertEquals(migration.getMigratedClusterUrl(), migratedUrl);
+
         try {
             asyncRequests(ctx -> clusters.getNamespaceIsolationPolicies(ctx, "use"));
             fail("should have failed");
@@ -458,7 +474,7 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
         } catch (RestException e) {
             assertEquals(e.getResponse().getStatus(), Status.PRECONDITION_FAILED.getStatusCode());
         }
-        verify(clusters, times(24)).validateSuperUserAccessAsync();
+        verify(clusters, times(26)).validateSuperUserAccessAsync();
     }
 
     @Test

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/ClusterPolicies.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/ClusterPolicies.java
@@ -53,9 +53,16 @@ public interface ClusterPolicies {
         String brokerServiceUrl;
         String brokerServiceUrlTls;
 
+        /**
+         * @return true when no URL of any kind (HTTP or binary, plain or TLS) is configured.
+         */
         public boolean isEmpty() {
-            return serviceUrl != null && serviceUrlTls != null && brokerServiceUrl == null
-                    && brokerServiceUrlTls == null;
+            return isBlank(serviceUrl) && isBlank(serviceUrlTls)
+                    && isBlank(brokerServiceUrl) && isBlank(brokerServiceUrlTls);
+        }
+
+        private static boolean isBlank(String s) {
+            return s == null || s.isBlank();
         }
     }
 }

--- a/pulsar-client-admin-api/src/test/java/org/apache/pulsar/common/policies/data/ClusterUrlTest.java
+++ b/pulsar-client-admin-api/src/test/java/org/apache/pulsar/common/policies/data/ClusterUrlTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.policies.data;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import org.apache.pulsar.common.policies.data.ClusterPolicies.ClusterUrl;
+import org.testng.annotations.Test;
+
+public class ClusterUrlTest {
+
+    @Test
+    public void testNoUrlIsEmpty() {
+        // The broker rejects "migrated=true" when the target ClusterUrl is empty. A ClusterUrl with
+        // no URL at all is the canonical empty value and must be reported as such.
+        assertTrue(new ClusterUrl().isEmpty());
+        assertTrue(new ClusterUrl(null, null, null, null).isEmpty());
+    }
+
+    @Test
+    public void testBlankUrlsAreEmpty() {
+        assertTrue(new ClusterUrl("", "", "", "").isEmpty());
+        assertTrue(new ClusterUrl(" ", null, "", null).isEmpty());
+    }
+
+    @Test
+    public void testHttpOnlyUrlIsNotEmpty() {
+        // Only the HTTP endpoints configured: still a URL, so not empty.
+        assertFalse(new ClusterUrl("http://green:8080", "https://green:8443", null, null).isEmpty());
+        assertFalse(new ClusterUrl("http://green:8080", null, null, null).isEmpty());
+    }
+
+    @Test
+    public void testBrokerOnlyUrlIsNotEmpty() {
+        assertFalse(new ClusterUrl(null, null, "pulsar://green:6650", null).isEmpty());
+        assertFalse(new ClusterUrl(null, null, null, "pulsar+ssl://green:6651").isEmpty());
+    }
+
+    @Test
+    public void testFullUrlIsNotEmpty() {
+        assertFalse(new ClusterUrl("http://green:8080", "https://green:8443",
+                "pulsar://green:6650", "pulsar+ssl://green:6651").isEmpty());
+    }
+}


### PR DESCRIPTION
### Motivation

`ClusterPolicies.ClusterUrl#isEmpty()` has its condition inverted:

```java
return serviceUrl != null && serviceUrlTls != null && brokerServiceUrl == null && brokerServiceUrlTls == null;
```

It only returns `true` when both HTTP URLs are *set* and both broker URLs are unset, and returns `false` for a `ClusterUrl` whose four fields are all `null`.

Its only caller is the cluster-migration admin endpoint (`ClustersBase#updateClusterMigration`), which uses it to reject `migrated=true` without a target:

```java
if (isMigrated && clusterUrl.isEmpty()) {
    asyncResponse.resume(new RestException(Status.BAD_REQUEST, "Cluster url must not be empty"));
```

Because of the inverted predicate this guard never fires for the case it exists for. `pulsar-admin clusters update-cluster-migration --migrated` with no `--service-url`/`--broker-url` options is accepted and persisted; later, when the broker redirects producers/consumers with `CommandTopicMigrated`, the client receives null URLs and fails in `HandlerState#setRedirectedClusterURI` (logged, not surfaced), so the affected producers/consumers reconnect in a loop with no clear error. Conversely, a legitimate `ClusterUrl` carrying only the HTTP endpoints is rejected as "empty".

### Modifications

- `ClusterPolicies.ClusterUrl#isEmpty()` now returns `true` only when none of the four URLs is set (null or blank). Any single configured URL — HTTP or binary, plain or TLS — makes it non-empty. No signature, wire, or REST change; the guard in `ClustersBase#updateClusterMigration` is unchanged and now behaves as its error message says.

### Verifying this change

This change added tests and can be verified as follows:

- `ClusterUrlTest` (pulsar-client-admin-api) — pins the predicate: all-null / all-blank is empty; HTTP-only, broker-only, and fully populated URLs are not. Fails on the unpatched code (`testNoUrlIsEmpty`, `testBlankUrlsAreEmpty`, `testHttpOnlyUrlIsNotEmpty`).
- `AdminTest#clusters` (pulsar-broker) — adds the end-to-end assertion at the admin resource: `updateClusterMigration(..., migrated=true, new ClusterUrl())` returns `400 BAD_REQUEST`, and a `ClusterUrl` with only a broker service URL is accepted and read back via `getClusterMigration`. On the unpatched code the empty-URL call is accepted and the test fails at `fail("should have failed")`. The `validateSuperUserAccessAsync` invocation count in this test is bumped 24 → 26 for the two accepted calls (the rejected call fails at the guard before any authorization check).

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

This is an internal behavior change: the only user-visible effect is that `POST /admin/v2/clusters/{cluster}/migrate?migrated=true` with an empty body/URL now returns `400` as documented, instead of being accepted. No public API, schema, configuration, wire protocol, REST endpoint shape, CLI option, or metric changes.

### Documentation

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->


