### PR TITLE
[fix][client] Release the reserved memory only once when failing a send in a terminal state

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -2553,8 +2553,8 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
             if (state == State.Terminated || state == State.Closed || state == State.ProducerFenced) {
                 // The producer is in a terminal state and will never reconnect. Fail the message immediately
                 // rather than leaving it stuck in pendingMessages until sendTimeout.
+                // releaseSemaphoreForSendOp() also gives the reserved memory back, so it must not be released again.
                 releaseSemaphoreForSendOp(op);
-                client.getMemoryLimitController().releaseMemory(op.uncompressedSize);
                 op.sendComplete(getTerminalException(state));
                 ReferenceCountUtil.safeRelease(op.cmd);
                 op.recycle();

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ProducerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ProducerImplTest.java
@@ -27,6 +27,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import java.nio.ByteBuffer;
+import java.util.Collections;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
@@ -146,5 +147,50 @@ public class ProducerImplTest {
                 "Retry Op should exist in the pending Queue");
         assertEquals(pendingQueue.peek().sequenceId, 2L,
                 "Retry Op SequenceId should match with the one in pendingQueue");
+    }
+
+    /**
+     * When the producer is in a terminal state, {@link ProducerImpl#processOpSendMsg} fails the message right away.
+     * The memory reserved for that message must be given back to the {@link MemoryLimitController} exactly once:
+     * releasing it twice makes {@code currentUsage} drift below zero and permanently disables the client memory
+     * limit.
+     */
+    @Test
+    public void testProcessOpSendMsgInTerminalStateReleasesMemoryOnce() throws Exception {
+        for (ProducerImpl.State state : new ProducerImpl.State[] {
+                ProducerImpl.State.Terminated, ProducerImpl.State.Closed, ProducerImpl.State.ProducerFenced}) {
+            @SuppressWarnings("unchecked")
+            ProducerImpl<byte[]> producer = Mockito.mock(ProducerImpl.class, Mockito.CALLS_REAL_METHODS);
+            // Disable batching, so that releaseSemaphoreForSendOp() releases a single permit
+            Mockito.doReturn(false).when(producer).isBatchMessagingEnabled();
+            // The semaphore is not under test
+            Mockito.doNothing().when(producer).semaphoreRelease(Mockito.anyInt());
+
+            MemoryLimitController memoryLimitController = new MemoryLimitController(1024 * 1024);
+            PulsarClientImpl client = Mockito.mock(PulsarClientImpl.class);
+            Mockito.when(client.getMemoryLimitController()).thenReturn(memoryLimitController);
+            FieldUtils.writeField(producer, "client", client, true);
+
+            int uncompressedSize = 128;
+            MessageImpl<?> msg = Mockito.mock(MessageImpl.class);
+            Mockito.when(msg.getUncompressedSize()).thenReturn(uncompressedSize);
+            // Build the op through the batch factory so that op.msg is null and the message size check is skipped
+            ProducerImpl.OpSendMsg op = ProducerImpl.OpSendMsg.create(
+                    Mockito.mock(LatencyHistogram.class),
+                    Collections.<MessageImpl<?>>singletonList(msg),
+                    Mockito.mock(ByteBufPair.class),
+                    1L,
+                    Mockito.mock(SendCallback.class),
+                    0);
+
+            memoryLimitController.forceReserveMemory(op.uncompressedSize);
+            assertEquals(memoryLimitController.currentUsage(), uncompressedSize);
+
+            producer.setState(state);
+            producer.processOpSendMsg(op);
+
+            assertEquals(memoryLimitController.currentUsage(), 0,
+                    "The memory reserved for the message must be released exactly once in state " + state);
+        }
     }
 }


### PR DESCRIPTION
### Motivation

`ProducerImpl#processOpSendMsg` fails a message immediately when the producer is in a terminal
state (`Terminated` / `Closed` / `ProducerFenced`) instead of leaving it in `pendingMessages`
until the send timeout fires. That path releases the memory reserved for the message twice:

```java
releaseSemaphoreForSendOp(op);
client.getMemoryLimitController().releaseMemory(op.uncompressedSize);
```

`releaseSemaphoreForSendOp(op)` already returns `op.uncompressedSize` to the
`MemoryLimitController`, so the explicit call right after it releases the same bytes a second
time.

`MemoryLimitController` only validates that the argument is non-negative, not that the running
total stays sane, so this fails silently: every message published after the producer reaches a
terminal state drives `currentUsage` further below zero. Once it is negative,
`tryReserveMemory()` never returns `false` again and `memoryLimitBytes` is effectively disabled
for the whole client — every producer and consumer sharing that `PulsarClient` loses its memory
limit, which is exactly the protection that is supposed to keep the client from running out of
memory. An application that keeps publishing to a terminated topic, or that publishes after the
producer was fenced, hits this on every send.

This is a regression from #25317, which introduced the terminal-state fast-fail branch.

### Modifications

- `ProducerImpl#processOpSendMsg`: drop the redundant
  `client.getMemoryLimitController().releaseMemory(op.uncompressedSize)` from the terminal-state
  branch, leaving the single release performed by `releaseSemaphoreForSendOp(op)`. Added a short
  comment recording that `releaseSemaphoreForSendOp()` already gives the reserved memory back, so
  the call is not re-added later.

No other path changes: the semaphore permits, the send callback, the `ByteBufPair` release and
the `OpSendMsg` recycling in that branch are untouched.

### Verifying this change

This change added tests and can be verified as follows:

- `ProducerImplTest#testProcessOpSendMsgInTerminalStateReleasesMemoryOnce` — reserves a known
  number of bytes in a real `MemoryLimitController`, drives `processOpSendMsg()` once for each of
  the three terminal states (`Terminated`, `Closed`, `ProducerFenced`), and asserts that
  `currentUsage()` returns to exactly `0`. On the unpatched code it fails with
  `expected [0] but found [-128]`, i.e. for the real reason — the double release — rather than by
  forcing internal state. The `OpSendMsg` is built through the batched factory so that `op.msg` is
  `null`, which keeps the test on the memory-accounting path and out of the batch-flush and
  message-size checks.

Local run:

```
./gradlew :pulsar-client-original:test --tests "ProducerImplTest" -PtestRetryCount=0
BUILD SUCCESSFUL

./gradlew rat spotlessCheck checkstyleMain checkstyleTest
BUILD SUCCESSFUL
```

The whole `:pulsar-client-original:test` module also passes.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

This is an internal bug fix in the client send path. It changes no public API, schema,
configuration default, wire protocol, REST endpoint, CLI option or metric; it restores the
intended behaviour of the existing `memoryLimitBytes` setting rather than changing it.
