### PR TITLE
[fix][client] Remove the dead letter candidate entry using the entry-level message id

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DeadLetterTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DeadLetterTopicTest.java
@@ -36,6 +36,7 @@ import static org.testng.Assert.fail;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -64,6 +65,7 @@ import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
 import org.apache.pulsar.client.util.RetryMessageUtil;
 import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
 import org.apache.pulsar.common.policies.data.SchemaCompatibilityStrategy;
+import org.apache.pulsar.common.util.FutureUtil;
 import org.awaitility.Awaitility;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -1761,4 +1763,77 @@ public class DeadLetterTopicTest extends SharedPulsarBaseTest {
         consumer.close();
     }
 
+    /**
+     * {@link org.apache.pulsar.client.impl.ConsumerImpl#processPossibleToDLQ} looks the entry up with the batch
+     * index discarded, because {@code possibleSendToDeadLetterTopicMessages} is always keyed by the entry-level
+     * message id. It must delete it with the same key: a message id that still carries its batch index -- the
+     * shape {@link MultiTopicsConsumerImpl} passes down from its unacked-message tracker, which keeps the batch
+     * index -- otherwise the entry survives the delivery to the DLQ, the map grows without bound and the whole
+     * batch is written to the DLQ again on the next redelivery of that entry.
+     */
+    @Test
+    public void testPossibleToDeadLetterEntryIsRemovedWhenRedeliveringABatchMessageId() throws Exception {
+        final String topic = newTopicName();
+        final String subscriptionName = "my-subscription";
+        final int batchSize = 5;
+
+        @Cleanup
+        Consumer<byte[]> consumer = pulsarClient.newConsumer(Schema.BYTES)
+                .topic(topic)
+                .subscriptionName(subscriptionName)
+                .subscriptionType(SubscriptionType.Shared)
+                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
+                .deadLetterPolicy(DeadLetterPolicy.builder().maxRedeliverCount(1).build())
+                .subscribe();
+
+        @Cleanup
+        Consumer<byte[]> deadLetterConsumer = pulsarClient.newConsumer(Schema.BYTES)
+                .topic(topic + "-" + subscriptionName + "-DLQ")
+                .subscriptionName(subscriptionName)
+                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
+                .subscribe();
+
+        @Cleanup
+        Producer<byte[]> producer = pulsarClient.newProducer(Schema.BYTES)
+                .topic(topic)
+                .enableBatching(true)
+                .batchingMaxMessages(batchSize)
+                .batchingMaxPublishDelay(1, TimeUnit.SECONDS)
+                .create();
+        List<CompletableFuture<MessageId>> sendFutures = new ArrayList<>();
+        for (int i = 0; i < batchSize; i++) {
+            sendFutures.add(producer.newMessage().value(("message-" + i).getBytes()).sendAsync());
+        }
+        FutureUtil.waitForAll(sendFutures).get();
+
+        // First delivery: redeliveryCount is 0, below maxRedeliverCount, so nothing is registered yet
+        for (int i = 0; i < batchSize; i++) {
+            assertNotNull(consumer.receive(5, TimeUnit.SECONDS));
+        }
+        consumer.redeliverUnacknowledgedMessages();
+
+        // Second delivery: redeliveryCount reaches maxRedeliverCount, so the whole batch is registered as a
+        // DLQ candidate under its entry-level message id
+        List<Message<byte[]>> messages = new ArrayList<>();
+        for (int i = 0; i < batchSize; i++) {
+            messages.add(consumer.receive(5, TimeUnit.SECONDS));
+        }
+        ConsumerImpl<byte[]> consumerImpl = (ConsumerImpl<byte[]>) consumer;
+        assertThat(consumerImpl.getPossibleSendToDeadLetterTopicMessages()).hasSize(1);
+
+        // Redeliver a single message id that still carries its batch index
+        MessageId batchMessageId = messages.get(0).getMessageId();
+        assertThat(((MessageIdAdv) batchMessageId).getBatchIndex()).isNotNegative();
+        consumerImpl.redeliverUnacknowledgedMessages(Collections.singleton(batchMessageId));
+
+        // The batch really was routed to the DLQ, so the bookkeeping below is not vacuously satisfied
+        for (int i = 0; i < batchSize; i++) {
+            assertNotNull(deadLetterConsumer.receive(10, TimeUnit.SECONDS),
+                    "every message of the batch should be routed to the DLQ");
+        }
+
+        Awaitility.await().untilAsserted(() -> assertThat(consumerImpl.getPossibleSendToDeadLetterTopicMessages())
+                .as("the entry must be dropped once its batch reached the DLQ")
+                .isEmpty());
+    }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -2350,9 +2350,11 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
 
     @SuppressWarnings("unchecked")
     private CompletableFuture<Boolean> processPossibleToDLQ(MessageIdAdv messageId) {
+        // The map is always keyed by the entry-level message id, while messageId may still carry a batch index
+        final MessageIdAdv deadLetterMessagesKey = MessageIdAdvUtils.discardBatch(messageId);
         List<MessageImpl<T>> deadLetterMessages = null;
         if (possibleSendToDeadLetterTopicMessages != null) {
-            deadLetterMessages = possibleSendToDeadLetterTopicMessages.get(MessageIdAdvUtils.discardBatch(messageId));
+            deadLetterMessages = possibleSendToDeadLetterTopicMessages.get(deadLetterMessagesKey);
         }
         CompletableFuture<Boolean> result = new CompletableFuture<>();
         if (deadLetterMessages != null) {
@@ -2373,7 +2375,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                         copyMessageEventTime(message, typedMessageBuilderNew);
                         typedMessageBuilderNew.sendAsync()
                                 .thenAccept(messageIdInDLQ -> {
-                                    possibleSendToDeadLetterTopicMessages.remove(messageId);
+                                    possibleSendToDeadLetterTopicMessages.remove(deadLetterMessagesKey);
                                     acknowledgeAsync(messageId).whenComplete((v, ex) -> {
                                         if (ex != null) {
                                             log.warn().attr("messageId", messageId)


### PR DESCRIPTION
### Motivation

`ConsumerImpl#possibleSendToDeadLetterTopicMessages` is always keyed by the **entry-level** message
id: `receiveIndividualMessagesFromBatch()` registers a batch under `batchMessage`
(a `MessageIdImpl`), and `messageReceived()` registers a non-batched message under its own
`MessageIdImpl`.

`processPossibleToDLQ()` respects that when it looks the entry up:

```java
deadLetterMessages = possibleSendToDeadLetterTopicMessages.get(MessageIdAdvUtils.discardBatch(messageId));
```

but not when it deletes it, once the messages have reached the DLQ:

```java
possibleSendToDeadLetterTopicMessages.remove(messageId);
```

`MessageIdAdvUtils#equals`/`#hashCode` include the batch index, so as soon as `messageId` still
carries one the removal silently matches nothing.

That is reachable on a plain multi-topic / partitioned consumer, with no tracing or custom code
involved: `MultiTopicsConsumerImpl` adds `topicMessage.getMessageId()` — a `TopicMessageIdImpl`
that keeps the batch index — to its unacked-message tracker, unlike `ConsumerImpl#trackMessage()`
which discards it first. When the ack timeout fires, those ids are routed back to
`ConsumerImpl#redeliverUnacknowledgedMessages(Set)` and reach `processPossibleToDLQ()` with the
batch index intact.

The consequences for a consumer using batching + a dead letter policy on a partitioned topic:

- the entry is never dropped — the map only ever gets cleared on reconnect or on close — so it
  grows for the lifetime of the consumer;
- because the entry survives, the next redelivery of any message of that same entry finds it again
  and writes the **whole batch** to the dead letter topic a second time, so the DLQ accumulates
  duplicates.

### Modifications

`ConsumerImpl#processPossibleToDLQ()`: compute the entry-level key once
(`MessageIdAdvUtils.discardBatch(messageId)`) and use it for both the lookup and the removal.

`acknowledgeAsync(messageId)` deliberately keeps using the original id — acknowledging is
per-batch-index and must not have the batch index stripped.

### Verifying this change

This change added tests and can be verified as follows:

- `DeadLetterTopicTest#testPossibleToDeadLetterEntryIsRemovedWhenRedeliveringABatchMessageId` —
  publishes one batch, lets it reach `maxRedeliverCount` so the batch is registered as a DLQ
  candidate, then redelivers a single message id that still carries its batch index (the shape
  `MultiTopicsConsumerImpl` passes down), and asserts the entry is gone once the batch has been
  written to the DLQ. The test first asserts that all messages of the batch really did arrive on
  the dead letter topic, so the final assertion cannot pass vacuously. On the unpatched code it
  fails for the real reason:

  ```
  org.awaitility.core.ConditionTimeoutException: ... [the entry must be dropped once its batch reached the DLQ]
  Expecting empty but was: {3:0:-1=[MessageImpl@6c435cb6, ...]} within 10 seconds.
  ```

Local runs:

```
./gradlew :pulsar-broker:test --tests "DeadLetterTopicTest" \
    --tests "DeadLetterTopicDefaultMultiPartitionsTest" -PtestRetryCount=0
BUILD SUCCESSFUL

./gradlew rat spotlessCheck checkstyleMain checkstyleTest
BUILD SUCCESSFUL
```

The `:pulsar-client-original:test` module passes as well.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

This is an internal bug fix in the consumer's dead letter bookkeeping. It changes no public API,
schema, configuration default, wire protocol, REST endpoint, CLI option or metric.
