### PR TITLE
[fix][misc] Resolve void by name in Reflections.loadClass

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/Reflections.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/Reflections.java
@@ -51,6 +51,7 @@ public class Reflections {
         PRIMITIVE_NAME_TYPE_MAP.put("long", Long.TYPE);
         PRIMITIVE_NAME_TYPE_MAP.put("float", Float.TYPE);
         PRIMITIVE_NAME_TYPE_MAP.put("double", Double.TYPE);
+        PRIMITIVE_NAME_TYPE_MAP.put("void", Void.TYPE);
     }
 
     /**

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/ReflectionsTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/ReflectionsTest.java
@@ -186,6 +186,7 @@ public class ReflectionsTest {
             Boolean.class,
             boolean.class,
             Void.class,
+            void.class,
             Reflections.class,
             Integer[].class,
             int[].class


### PR DESCRIPTION
### Motivation

`Reflections.loadClass("void", classLoader)` throws `ClassNotFoundException`, even though the helper resolves the other primitive names and already handles the `V` descriptor. This leaves `void.class.getName()` out of the supported class-name round trip.

### Modifications

Add `void` to the primitive-name map and include `void.class` in the existing `testLoadClass` cases.

### Verifying this change

- The added case fails before the fix with `ClassNotFoundException: void`.
- Compiled the real utility sources and `ReflectionsTest` with JDK 21 (`--release 17`) and ran TestNG 7.12.0 directly using cached dependencies: all 12 tests pass after the fix.
- `git diff --check` passes.
- `./gradlew quickCheck` was attempted but stopped during the slow Gradle 9.7.1 distribution download; Gradle checks and the full module suite have not run.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

Assisted by OpenAI Codex.
