### PR TITLE
[fix][broker]Incorrect source side topic permission deletion when disabling replication

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1680,7 +1680,13 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
                 closeClientFuture.thenAccept(__ -> {
                     CompletableFuture<Void> deleteTopicAuthenticationFuture = new CompletableFuture<>();
-                    brokerService.deleteTopicAuthenticationWithRetry(topic, deleteTopicAuthenticationFuture, 5);
+                    checkAllowedCluster(brokerService.getPulsar().getConfig().getClusterName()).thenAccept(allow -> {
+                        if (!allow) {
+                            deleteTopicAuthenticationFuture.complete(null);
+                        } else {
+                            brokerService.deleteTopicAuthenticationWithRetry(topic, deleteTopicAuthenticationFuture, 5);
+                        }
+                    });
 
                         deleteTopicAuthenticationFuture.thenCompose(ignore -> deleteSchema())
                                 .thenCompose(ignore -> deleteTopicPolicies())

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorUsingGlobalZKTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorUsingGlobalZKTest.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.broker.service;
 
 import static org.apache.pulsar.broker.service.TopicPoliciesService.GetType.GLOBAL_ONLY;
 import static org.apache.pulsar.broker.service.TopicPoliciesService.GetType.LOCAL_ONLY;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -28,6 +29,7 @@ import static org.testng.Assert.fail;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -51,6 +53,7 @@ import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.policies.data.AuthAction;
 import org.apache.pulsar.common.policies.data.AutoFailoverPolicyData;
 import org.apache.pulsar.common.policies.data.AutoFailoverPolicyType;
 import org.apache.pulsar.common.policies.data.AutoTopicCreationOverride;
@@ -118,6 +121,41 @@ public class OneWayReplicatorUsingGlobalZKTest extends OneWayReplicatorTest {
     @Test(dataProvider = "isPartitioned")
     public void testReplicatorCreateTopic(boolean isPartitioned) throws Exception {
         super.testReplicatorCreateTopic(isPartitioned);
+    }
+
+    @Test
+    public void testDeletingTopicOnOneClusterKeepsSharedTopicPermissions() throws Exception {
+        String topic = BrokerTestUtil.newUniqueName("persistent://" + replicatedNamespace + "/topic-permissions-");
+        String role = "test-role";
+        Set<AuthAction> permissions = EnumSet.of(AuthAction.produce, AuthAction.consume);
+
+        admin1.topics().createNonPartitionedTopic(topic);
+        waitReplicatorStarted(topic);
+        admin1.topics().grantPermission(topic, role, permissions);
+        Awaitility.await().untilAsserted(() -> {
+            assertThat(admin1.topics().getPermissions(topic)).containsEntry(role, permissions);
+            assertThat(admin2.topics().getPermissions(topic)).containsEntry(role, permissions);
+        });
+
+        admin1.topicPolicies(true).setReplicationClusters(topic, Arrays.asList(cluster1));
+        Awaitility.await().untilAsserted(() -> {
+            assertFalse(admin2.topics().getList(replicatedNamespace).contains(topic));
+            assertThat(admin1.topics().getPermissions(topic)).containsEntry(role, permissions);
+        });
+
+        admin1.topicPolicies(true).setReplicationClusters(topic, Arrays.asList(cluster1, cluster2));
+        Awaitility.await().untilAsserted(() -> {
+            assertThat(admin1.topics().getPermissions(topic)).containsEntry(role, permissions);
+            assertThat(admin2.topics().getPermissions(topic)).containsEntry(role, permissions);
+        });
+
+        // clear topic.
+        admin1.topicPolicies(true).setReplicationClusters(topic, Arrays.asList(cluster1));
+        Awaitility.await().untilAsserted(() -> {
+            assertFalse(admin2.topics().getList(replicatedNamespace).contains(topic));
+            assertThat(admin1.topics().getPermissions(topic)).containsEntry(role, permissions);
+        });
+        admin1.topics().delete(topic);
     }
 
     @Override


### PR DESCRIPTION
### Motivation

**Env**
- two clsuters `[c1, c2]` with shared metadata store

**Issue**
- disabled replication by set topic level replication `[c1]`
  - then `c2` can not access the topic anymore
- Issue: `c1` cluster topic permission configuration was deleted 

### Modifications

fix the issue

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment