### PR TITLE
[improve][cli] Add v4-client subcommands to pulsar-perf and pulsar-client

### DIFF
--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/client/cli/PulsarClientToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/client/cli/PulsarClientToolTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.client.cli;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -43,8 +44,10 @@ import org.apache.pulsar.broker.service.BrokerTestBase;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.ProxyProtocol;
+import org.apache.pulsar.client.api.Reader;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.impl.BatchMessageIdImpl;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
@@ -224,6 +227,74 @@ public class PulsarClientToolTest extends BrokerTestBase {
                 .ignoreExceptions()
                 .atMost(Duration.ofMillis(20000))
                 .until(() -> admin.topics().getSubscriptions(topicName).isEmpty());
+    }
+
+    /**
+     * The reason {@code consume-v4} exists: the V5 {@code QueueConsumer} cannot seek to a timestamp.
+     * {@code --start-timestamp} must skip everything published before the boundary even though the
+     * subscription starts at {@code Earliest}, and {@code --end-timestamp} must stop the loop at the
+     * boundary before the requested message count is reached.
+     */
+    @Test(timeOut = 60000)
+    public void testConsumeV4StartAndEndTimestamp() throws Exception {
+        Properties properties = initializeToolProperties();
+
+        final String topicName = getTopicWithRandomSuffix("timestamp-v4");
+        admin.topics().createNonPartitionedTopic(topicName);
+
+        @Cleanup
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName)
+                .enableBatching(false).create();
+        producer.send("before-1".getBytes(StandardCharsets.UTF_8));
+        producer.send("before-2".getBytes(StandardCharsets.UTF_8));
+
+        final long boundary = lastPublishTime(topicName);
+        // Publish times have millisecond resolution, so let the clock pass the boundary to make the
+        // next two messages strictly newer than it.
+        Awaitility.await()
+                .pollDelay(Duration.ZERO)
+                .pollInterval(Duration.ofMillis(1))
+                .until(() -> System.currentTimeMillis() > boundary);
+        producer.send("after-1".getBytes(StandardCharsets.UTF_8));
+        producer.send("after-2".getBytes(StandardCharsets.UTF_8));
+
+        // --start-timestamp seeks past the two older messages, even though the subscription starts
+        // at Earliest.
+        String seekOutput = runCapturingStdout(properties, "consume-v4", "-s", "start-sub",
+                "-p", "Earliest", "-n", "2", "-stp", Long.toString(boundary + 1), topicName);
+        assertThat(seekOutput).contains("after-1", "after-2")
+                .doesNotContain("before-1", "before-2");
+
+        // --end-timestamp stops the loop at the boundary, so only the two older messages are
+        // consumed even though four were requested.
+        String endOutput = runCapturingStdout(properties, "consume-v4", "-s", "end-sub",
+                "-p", "Earliest", "-n", "4", "-etp", Long.toString(boundary), topicName);
+        assertThat(endOutput).contains("before-1", "before-2")
+                .doesNotContain("after-1", "after-2");
+    }
+
+    /** Publish time of the last message currently on the topic, read with the v4 client. */
+    private long lastPublishTime(String topicName) throws Exception {
+        @Cleanup
+        Reader<byte[]> reader = pulsarClient.newReader().topic(topicName)
+                .startMessageId(MessageId.earliest).create();
+        long publishTime = 0L;
+        while (reader.hasMessageAvailable()) {
+            publishTime = reader.readNext().getPublishTime();
+        }
+        return publishTime;
+    }
+
+    private static String runCapturingStdout(Properties properties, String... args) {
+        ByteArrayOutputStream consoleOutput = new ByteArrayOutputStream();
+        PrintStream originalOut = System.out;
+        System.setOut(new PrintStream(consoleOutput, true, StandardCharsets.UTF_8));
+        try {
+            assertEquals(new PulsarClientTool(properties).run(args), 0);
+        } finally {
+            System.setOut(originalOut);
+        }
+        return consoleOutput.toString(StandardCharsets.UTF_8);
     }
 
     @Test(timeOut = 60000)
@@ -575,7 +646,7 @@ public class PulsarClientToolTest extends BrokerTestBase {
 
     // KeyValue schema production has no V5 equivalent (`produce` rejects --key-value-encoding-type
     // with a clear message), so it is exercised through the v4-client command.
-    @Test
+    @Test(timeOut = 60000)
     public void testProduceKeyValueSchemaInlineValue() throws Exception {
 
         Properties properties = initializeToolProperties();
@@ -609,6 +680,8 @@ public class PulsarClientToolTest extends BrokerTestBase {
                 future.completeExceptionally(t);
             }
         });
+        // Surface a produce-v4 failure as itself rather than as a null message below.
+        future.get();
         final Message<KeyValue<TestKey, String>> message = consumer.receive(10, TimeUnit.SECONDS);
         assertNotNull(message);
         assertFalse(message.hasKey());
@@ -626,7 +699,7 @@ public class PulsarClientToolTest extends BrokerTestBase {
     }
 
     // As above: KeyValue schema production is exercised through the v4-client command.
-    @Test(dataProvider = "keyValueKeySchema")
+    @Test(dataProvider = "keyValueKeySchema", timeOut = 60000)
     public void testProduceKeyValueSchemaFileValue(String schema) throws Exception {
 
         Properties properties = initializeToolProperties();
@@ -673,6 +746,8 @@ public class PulsarClientToolTest extends BrokerTestBase {
                 future.completeExceptionally(t);
             }
         });
+        // Surface a produce-v4 failure as itself rather than as a null message below.
+        future.get();
         final Message<KeyValue<TestKey, String>> message = consumer.receive(10, TimeUnit.SECONDS);
         assertNotNull(message);
         // -k should not be considered

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/client/cli/PulsarClientToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/client/cli/PulsarClientToolTest.java
@@ -167,7 +167,63 @@ public class PulsarClientToolTest extends BrokerTestBase {
         // The V5-based pulsar-client has no non-durable subscription mode: --subscription-mode
         // NonDurable falls back to a durable subscription (with a warning). So unlike the v4
         // client, the subscription is NOT removed when the consumer disconnects — it persists.
+        // testNonDurableSubscribeWithV4Client covers the v4 behaviour.
         assertEquals(admin.topics().getSubscriptions(topicName).size(), 1);
+    }
+
+    /**
+     * The v4 counterpart of {@link #testNonDurableSubscribe()}: {@code consume-v4} really creates a
+     * non-durable subscription, so it disappears once the consumer disconnects. This is the
+     * behaviour the V5-based {@code consume} cannot express.
+     */
+    @Test(timeOut = 60000)
+    public void testNonDurableSubscribeWithV4Client() throws Exception {
+
+        Properties properties = new Properties();
+        properties.setProperty("serviceUrl", pulsar.getBrokerServiceUrl());
+        properties.setProperty("useTls", "false");
+
+        final String topicName = getTopicWithRandomSuffix("non-durable-v4");
+        admin.topics().createNonPartitionedTopic(topicName);
+
+        int numberOfMessages = 10;
+        @Cleanup("shutdownNow")
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        executor.execute(() -> {
+            try {
+                PulsarClientTool pulsarClientToolConsumer = new PulsarClientTool(properties);
+                String[] args = {"consume-v4", "-t", "Exclusive", "-s", "sub-name", "-n",
+                        Integer.toString(numberOfMessages), "--hex", "-m", "NonDurable", "-r", "30", topicName};
+                Assert.assertEquals(pulsarClientToolConsumer.run(args), 0);
+                future.complete(null);
+            } catch (Throwable t) {
+                future.completeExceptionally(t);
+            }
+        });
+
+        // Make sure subscription has been created
+        retryStrategically((test) -> {
+            try {
+                return admin.topics().getSubscriptions(topicName).size() == 1;
+            } catch (Exception e) {
+                return false;
+            }
+        }, 10, 500);
+
+        assertEquals(admin.topics().getSubscriptions(topicName).size(), 1);
+        PulsarClientTool pulsarClientToolProducer = new PulsarClientTool(properties);
+
+        String[] args = {"produce-v4", "--messages", "Have a nice day", "-n", Integer.toString(numberOfMessages),
+                "-r", "20", "-p", "key1=value1", "-p", "key2=value2", "-k", "partition_key", topicName};
+        Assert.assertEquals(pulsarClientToolProducer.run(args), 0);
+        Assert.assertFalse(future.isCompletedExceptionally());
+        future.get();
+
+        Awaitility.await()
+                .ignoreExceptions()
+                .atMost(Duration.ofMillis(20000))
+                .until(() -> admin.topics().getSubscriptions(topicName).isEmpty());
     }
 
     @Test(timeOut = 60000)
@@ -517,9 +573,9 @@ public class PulsarClientToolTest extends BrokerTestBase {
 
     }
 
-    // KeyValue schema production is not yet supported by the V5-based pulsar-client (CmdProduce
-    // rejects --key-value-encoding-type with a clear message); deferred to a follow-up.
-    @Test(enabled = false)
+    // KeyValue schema production has no V5 equivalent (`produce` rejects --key-value-encoding-type
+    // with a clear message), so it is exercised through the v4-client command.
+    @Test
     public void testProduceKeyValueSchemaInlineValue() throws Exception {
 
         Properties properties = initializeToolProperties();
@@ -539,7 +595,7 @@ public class PulsarClientToolTest extends BrokerTestBase {
         executor.execute(() -> {
             try {
                 PulsarClientTool pulsarClientToolConsumer = new PulsarClientTool(properties);
-                String[] args = {"produce",
+                String[] args = {"produce-v4",
                         "-kvet", "inline",
                         "-ks", String.format("json:%s", keySchema.getSchemaInfo().getSchemaDefinition()),
                         "-kvk", ObjectMapperFactory.getMapper().writer().writeValueAsString(
@@ -569,9 +625,8 @@ public class PulsarClientToolTest extends BrokerTestBase {
         };
     }
 
-    // KeyValue schema production is not yet supported by the V5-based pulsar-client (CmdProduce
-    // rejects --key-value-encoding-type with a clear message); deferred to a follow-up.
-    @Test(dataProvider = "keyValueKeySchema", enabled = false)
+    // As above: KeyValue schema production is exercised through the v4-client command.
+    @Test(dataProvider = "keyValueKeySchema")
     public void testProduceKeyValueSchemaFileValue(String schema) throws Exception {
 
         Properties properties = initializeToolProperties();
@@ -604,7 +659,7 @@ public class PulsarClientToolTest extends BrokerTestBase {
         executor.execute(() -> {
             try {
                 PulsarClientTool pulsarClientToolConsumer = new PulsarClientTool(properties);
-                String[] args = {"produce",
+                String[] args = {"produce-v4",
                         "-k", "partitioning-key",
                         "-kvet", "inline",
                         "-ks", String.format("%s:%s", schema, keySchema.getSchemaInfo().getSchemaDefinition()),

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/AbstractCmdConsume.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/AbstractCmdConsume.java
@@ -23,10 +23,6 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -34,15 +30,6 @@ import java.util.concurrent.TimeUnit;
 import lombok.CustomLog;
 import org.apache.commons.io.HexDump;
 import org.apache.pulsar.client.api.Authentication;
-import org.apache.pulsar.client.api.v5.Message;
-import org.apache.pulsar.client.api.v5.PulsarClientBuilder;
-import org.apache.pulsar.client.api.v5.auth.ConsumerCryptoFailureAction;
-import org.apache.pulsar.client.api.v5.auth.EncryptionKey;
-import org.apache.pulsar.client.api.v5.auth.PrivateKeyProvider;
-import org.apache.pulsar.client.api.v5.config.ConsumerEncryptionPolicy;
-import org.apache.pulsar.client.api.v5.schema.Field;
-import org.apache.pulsar.client.api.v5.schema.GenericRecord;
-import org.apache.pulsar.client.api.v5.schema.KeyValue;
 import org.apache.pulsar.common.util.collections.GrowableArrayBlockingQueue;
 import org.eclipse.jetty.websocket.api.Callback;
 import org.eclipse.jetty.websocket.api.Session;
@@ -54,15 +41,16 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * common part of consume command and read command of pulsar-client.
- *
+ * Client-agnostic part shared by the consume and read commands of pulsar-client: the connection
+ * details the WebSocket path needs, the byte rendering, and the WebSocket consumer socket itself.
+ * The message rendering is client-specific and lives in {@link V5MessageSupport} /
+ * {@link V4MessageSupport}.
  */
 public abstract class AbstractCmdConsume extends AbstractCmd {
 
     protected static final Logger LOG = LoggerFactory.getLogger(PulsarClientTool.class);
     protected static final String MESSAGE_BOUNDARY = "----- got message -----";
 
-    protected PulsarClientBuilder clientBuilder;
     protected Authentication authentication;
     protected String serviceURL;
 
@@ -70,60 +58,10 @@ public abstract class AbstractCmdConsume extends AbstractCmd {
         // Do nothing
     }
 
-    /**
-     * Set client configuration.
-     *
-     */
-    public void updateConfig(PulsarClientBuilder clientBuilder, Authentication authentication, String serviceURL) {
-        this.clientBuilder = clientBuilder;
+    /** Record the client-generation-independent configuration. */
+    protected void updateSharedConfig(Authentication authentication, String serviceURL) {
         this.authentication = authentication;
         this.serviceURL = serviceURL;
-    }
-
-    /**
-     * Interprets the message to create a string representation.
-     *
-     * @param message
-     *            The message to interpret
-     * @param displayHex
-     *            Whether to display BytesMessages in hexdump style, ignored for simple text messages
-     * @return String representation of the message
-     */
-    protected String interpretMessage(Message<?> message, boolean displayHex, boolean printMetadata)
-            throws IOException {
-        StringBuilder sb = new StringBuilder();
-
-        String properties = Arrays.toString(message.properties().entrySet().toArray());
-
-        Object value = message.value();
-        String data;
-        if (value == null) {
-            data = "null";
-        } else if (value instanceof byte[]) {
-            data = interpretByteArray(displayHex, (byte[]) value);
-        } else if (value instanceof GenericRecord) {
-            data = genericObjectToMap((GenericRecord) value, displayHex).toString();
-        } else {
-            data = value.toString();
-        }
-
-        sb.append("publishTime:[").append(message.publishTime()).append("], ");
-        sb.append("eventTime:[").append(message.eventTime().orElse(null)).append("], ");
-        sb.append("key:[").append(message.key().orElse(null)).append("], ");
-        if (!properties.isEmpty()) {
-            sb.append("properties:").append(properties).append(", ");
-        }
-        sb.append("content:").append(data);
-
-        if (printMetadata) {
-            sb.append(", ").append("message-id:").append(message.id());
-            sb.append(", ").append("producer-name:").append(message.producerName().orElse(null));
-            sb.append(", ").append("sequence-id:").append(message.sequenceId());
-            sb.append(", ").append("replicated-from:").append(message.replicatedFrom().orElse(null));
-            sb.append(", ").append("redelivery-count:").append(message.redeliveryCount());
-        }
-
-        return sb.toString();
     }
 
     protected static String interpretByteArray(boolean displayHex, byte[] msgData) throws IOException {
@@ -136,88 +74,7 @@ public abstract class AbstractCmdConsume extends AbstractCmd {
         }
     }
 
-    /**
-     * Render an {@code auto_consume} {@link GenericRecord} value into a {@link Map} for display.
-     * The shape is dispatched on the record's runtime schema type: structured records become a map
-     * of their fields, key/value records become a {@code {key, value}} map, and primitives are
-     * wrapped in a single {@code value} entry.
-     */
-    protected static Map<String, Object> genericObjectToMap(GenericRecord value, boolean displayHex)
-            throws IOException {
-        switch (value.schemaType()) {
-            case AVRO:
-            case JSON:
-            case PROTOBUF_NATIVE:
-                return genericRecordToMap(value, displayHex);
-            case KEY_VALUE:
-                return keyValueToMap((KeyValue<?, ?>) value.nativeObject(), displayHex);
-            default:
-                return primitiveValueToMap(value.nativeObject(), displayHex);
-        }
-    }
-
-    protected static Map<String, Object> keyValueToMap(KeyValue<?, ?> value, boolean displayHex)
-            throws IOException {
-        if (value == null) {
-            return Map.of("value", "NULL");
-        }
-        return Map.of("key", primitiveValueToMap(value.key(), displayHex),
-                "value", primitiveValueToMap(value.value(), displayHex));
-    }
-
-    protected static Map<String, Object> primitiveValueToMap(Object value, boolean displayHex)
-            throws IOException {
-        if (value == null) {
-            return Map.of("value", "NULL");
-        }
-        if (value instanceof GenericRecord) {
-            return genericObjectToMap((GenericRecord) value, displayHex);
-        }
-        if (value instanceof byte[]) {
-            value = interpretByteArray(displayHex, (byte[]) value);
-        }
-        return Map.of("value", value.toString(), "type", value.getClass());
-    }
-
-    protected static Map<String, Object> genericRecordToMap(GenericRecord value, boolean displayHex)
-            throws IOException {
-        Map<String, Object> res = new HashMap<>();
-        for (Field f : value.fields()) {
-            Object fieldValue = value.field(f);
-            if (fieldValue instanceof GenericRecord) {
-                fieldValue = genericRecordToMap((GenericRecord) fieldValue, displayHex);
-            } else if (fieldValue == null) {
-                fieldValue = "NULL";
-            } else if (fieldValue instanceof byte[]) {
-                fieldValue = interpretByteArray(displayHex, (byte[]) fieldValue);
-            }
-            res.put(f.name(), fieldValue);
-        }
-        return res;
-    }
-
-    /**
-     * Build a consumer-side decryption policy from a {@code file://} key URI, mirroring the v4
-     * {@code defaultCryptoKeyReader(uri)} semantics: the private key is loaded once and returned
-     * for any key name. (The producer's logical key name travels in the message metadata, so a
-     * name-keyed provider would not resolve it; the CLI's file-based flow has a single key.)
-     */
-    protected static ConsumerEncryptionPolicy buildFileDecryptionPolicy(
-            String keyUri, ConsumerCryptoFailureAction failureAction) {
-        final byte[] keyBytes;
-        try {
-            keyBytes = Files.readAllBytes(fileUriToPath(keyUri));
-        } catch (IOException e) {
-            throw new IllegalArgumentException("Failed to read decryption key from " + keyUri, e);
-        }
-        PrivateKeyProvider provider = (keyName, metadata) ->
-                CompletableFuture.completedFuture(EncryptionKey.of(keyBytes));
-        return ConsumerEncryptionPolicy.builder()
-                .privateKeyProvider(provider)
-                .failureAction(failureAction)
-                .build();
-    }
-
+    /** WebSocket client socket used by the {@code ws://} consume and read paths. */
     @WebSocket
     @CustomLog
     public static class ConsumerSocket {

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/AbstractCmdConsumeCommand.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/AbstractCmdConsumeCommand.java
@@ -1,0 +1,276 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.cli;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.util.concurrent.RateLimiter;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Base64;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.apache.pulsar.client.api.AuthenticationDataProvider;
+import org.apache.pulsar.common.naming.TopicName;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
+import org.eclipse.jetty.websocket.client.WebSocketClient;
+import picocli.CommandLine;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+import picocli.CommandLine.Spec;
+
+/**
+ * Client-agnostic part of the {@code pulsar-client consume} command: the CLI options, the argument
+ * validation and the WebSocket consuming path (which speaks HTTP and has no client generation of
+ * its own). {@link CmdConsume} binds it to the V5 client and {@link CmdConsumeV4} to the v4
+ * ({@code pulsar-client-original}) client.
+ */
+public abstract class AbstractCmdConsumeCommand extends AbstractCmdConsume {
+
+    /**
+     * v4-compatible subscription-type flag, shared by both commands so the CLI surface does not
+     * depend on which client is driving. {@link CmdConsumeV4} maps it straight onto
+     * {@code org.apache.pulsar.client.api.SubscriptionType}; the V5-based {@link CmdConsume}
+     * consumes through a {@code QueueConsumer} for all types, since it is the only consumer that
+     * works against both regular and scalable topics, so Exclusive / Failover get work-queue
+     * (Shared-style) semantics there and log a warning.
+     */
+    public enum SubscriptionType {
+        Exclusive,
+        Shared,
+        Failover,
+        Key_Shared
+    }
+
+    /**
+     * v4-compatible subscription-mode flag. The V5 binary consumer is always durable, so
+     * {@code NonDurable} logs a warning there; {@link CmdConsumeV4} honors it.
+     */
+    public enum SubscriptionMode {
+        Durable,
+        NonDurable
+    }
+
+    @Parameters(description = "TopicName", arity = "1")
+    protected String topic;
+
+    @Option(names = { "-t", "--subscription-type" }, description = "Subscription type.")
+    protected SubscriptionType subscriptionType = SubscriptionType.Exclusive;
+
+    @Option(names = { "-m", "--subscription-mode" }, description = "Subscription mode.")
+    protected SubscriptionMode subscriptionMode = SubscriptionMode.Durable;
+
+    @Option(names = { "-s", "--subscription-name" }, required = true, description = "Subscription name.")
+    protected String subscriptionName;
+
+    @Option(names = { "-n",
+            "--num-messages" }, description = "Number of messages to consume, 0 means to consume forever.")
+    protected int numMessagesToConsume = 1;
+
+    @Option(names = { "--hex" }, description = "Display binary messages in hex.")
+    protected boolean displayHex = false;
+
+    @Option(names = { "--hide-content" }, description = "Do not write the message to console.")
+    protected boolean hideContent = false;
+
+    @Option(names = { "-r", "--rate" }, description = "Rate (in msg/sec) at which to consume, "
+            + "value 0 means to consume messages as fast as possible.")
+    protected double consumeRate = 0;
+
+    @Option(names = { "--regex" }, description = "Indicate the topic name is a regex pattern")
+    protected boolean isRegex = false;
+
+    @Option(names = {"-q", "--queue-size"}, description = "Consumer receiver queue size.")
+    protected int receiverQueueSize = 0;
+
+    @Option(names = { "-mc", "--max_chunked_msg" }, description = "Max pending chunk messages")
+    protected int maxPendingChunkedMessage = 0;
+
+    @Option(names = { "-ac",
+            "--auto_ack_chunk_q_full" }, description = "Auto ack for oldest message on queue is full")
+    protected boolean autoAckOldestChunkedMessageOnQueueFull = false;
+
+    @Option(names = { "-ekv",
+            "--encryption-key-value" }, description = "The URI of private key to decrypt payload, for example "
+                    + "file:///path/to/private.key or data:application/x-pem-file;base64,*****")
+    protected String encKeyValue;
+
+    @Option(names = { "-st", "--schema-type"},
+            description = "Set a schema type on the consumer, it can be 'bytes' or 'auto_consume'")
+    protected String schemaType = "bytes";
+
+    @Option(names = { "-pm", "--pool-messages" }, description = "Use the pooled message", arity = "1")
+    protected boolean poolMessages = true;
+
+    @Option(names = {"-rs", "--replicated" }, description = "Whether the subscription status should be replicated")
+    protected boolean replicateSubscriptionState = false;
+
+    @Option(names = { "-mp", "--print-metadata" }, description = "Message metadata")
+    protected boolean printMetadata = false;
+
+    @Option(names = { "-etp", "--end-timestamp" }, description = "End timestamp for consuming messages")
+    protected long endTimestamp = Long.MAX_VALUE;
+
+    @Spec
+    protected CommandSpec commandSpec;
+
+    public AbstractCmdConsumeCommand() {
+        super();
+    }
+
+    /**
+     * Consume over the binary protocol with this command's client generation.
+     *
+     * @return 0 for success, &lt; 0 otherwise
+     */
+    protected abstract int consume(String topic);
+
+    /** Additional argument validation for this command's client generation. */
+    protected void validateArguments() {
+    }
+
+    /**
+     * Run the consume command.
+     *
+     * @return 0 for success, &lt; 0 otherwise
+     */
+    public int run() throws IOException {
+        if (this.subscriptionName == null || this.subscriptionName.isEmpty()) {
+            throw new CommandLine.ParameterException(commandSpec.commandLine(), "Subscription name is not provided.");
+        }
+        if (this.numMessagesToConsume < 0) {
+            throw new CommandLine.ParameterException(commandSpec.commandLine(),
+                    "Number of messages should be zero or positive.");
+        }
+        if (this.endTimestamp < 0) {
+            throw new CommandLine.ParameterException(commandSpec.commandLine(),
+                    "end timestamp should be positive.");
+        }
+        validateArguments();
+
+        if (this.serviceURL.startsWith("ws")) {
+            return consumeFromWebSocket(topic);
+        } else {
+            return consume(topic);
+        }
+    }
+
+    @VisibleForTesting
+    public String getWebSocketConsumeUri(String topic) {
+        String serviceURLWithoutTrailingSlash = serviceURL.substring(0,
+                serviceURL.endsWith("/") ? serviceURL.length() - 1 : serviceURL.length());
+
+        TopicName topicName = TopicName.get(topic);
+        String wsTopic = String.format("%s/%s/%s/%s", topicName.getDomain(), topicName.getTenant(),
+                topicName.getNamespacePortion(), topicName.getLocalName());
+
+        return String.format("%s/ws/v2/consumer/%s/%s?subscriptionType=%s&subscriptionMode=%s",
+                serviceURLWithoutTrailingSlash, wsTopic, subscriptionName,
+                subscriptionType.toString(), subscriptionMode.toString());
+    }
+
+    @SuppressWarnings("deprecation")
+    private int consumeFromWebSocket(String topic) {
+        int numMessagesConsumed = 0;
+        int returnCode = 0;
+
+        URI consumerUri = URI.create(getWebSocketConsumeUri(topic));
+
+        HttpClient httpClient = new HttpClient();
+        httpClient.setSslContextFactory(new SslContextFactory.Client(true));
+        WebSocketClient consumeClient = new WebSocketClient(httpClient);
+        consumeClient.setMaxTextMessageSize(64 * 1024);
+        ClientUpgradeRequest consumeRequest = new ClientUpgradeRequest(consumerUri);
+        try {
+            if (authentication != null) {
+                authentication.start();
+                AuthenticationDataProvider authData = authentication.getAuthData(consumerUri.getHost());
+                if (authData.hasDataForHttp()) {
+                    for (Map.Entry<String, String> kv : authData.getHttpHeaders()) {
+                        consumeRequest.setHeader(kv.getKey(), kv.getValue());
+                    }
+                }
+            }
+        } catch (Exception e) {
+            LOG.error("Authentication plugin error: " + e.getMessage());
+            return -1;
+        }
+        CompletableFuture<Void> connected = new CompletableFuture<>();
+        ConsumerSocket consumerSocket = new ConsumerSocket(connected);
+        try {
+            consumeClient.start();
+        } catch (Exception e) {
+            LOG.error("Failed to start websocket-client", e);
+            return -1;
+        }
+
+        try {
+            LOG.info("Trying to create websocket session..{}", consumerUri);
+            consumeClient.connect(consumerSocket, consumeRequest);
+            connected.get();
+        } catch (Exception e) {
+            LOG.error("Failed to create web-socket session", e);
+            return -1;
+        }
+
+        try {
+            RateLimiter limiter = (this.consumeRate > 0) ? RateLimiter.create(this.consumeRate) : null;
+            while (this.numMessagesToConsume == 0 || numMessagesConsumed < this.numMessagesToConsume) {
+                if (limiter != null) {
+                    limiter.acquire();
+                }
+                String msg = consumerSocket.receive(5, TimeUnit.SECONDS);
+                if (msg == null) {
+                    LOG.debug("No message to consume after waiting for 5 seconds.");
+                } else {
+                    try {
+                        String output = interpretByteArray(displayHex, Base64.getDecoder().decode(msg));
+                        System.out.println(output); // print decode
+                    } catch (Exception e) {
+                        System.out.println(msg);
+                    }
+                    numMessagesConsumed += 1;
+                }
+            }
+            consumerSocket.awaitClose(2, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            LOG.error("Error while consuming messages");
+            LOG.error(e.getMessage(), e);
+            returnCode = -1;
+        } finally {
+            LOG.info("{} messages successfully consumed", numMessagesConsumed);
+        }
+
+
+        try {
+            consumeClient.stop();
+        } catch (Exception e) {
+            LOG.error("Failed to stop websocket-client", e);
+        }
+        try {
+            httpClient.stop();
+        } catch (Exception e) {
+            LOG.error("Failed to stop http-client", e);
+        }
+        return returnCode;
+    }
+}

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/AbstractCmdProduce.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/AbstractCmdProduce.java
@@ -405,6 +405,10 @@ public abstract class AbstractCmdProduce extends AbstractCmd {
         }
 
         public CompletableFuture<Void> send(int index, byte[] content) throws Exception {
+            // Publish the future before the frame goes out: onMessage() runs on Jetty's read
+            // thread and can see the ack before sendText() returns. Assigning afterwards would
+            // overwrite the future that ack completed and leave the caller waiting the full
+            // timeout.
             this.result = new CompletableFuture<>();
             this.session.sendText(getTestJsonPayload(index, content), Callback.NOOP);
             return result;
@@ -430,7 +434,7 @@ public abstract class AbstractCmdProduce extends AbstractCmd {
         }
 
         @OnWebSocketOpen
-        public void onConnect(Session session) throws InterruptedException {
+        public void onConnect(Session session) {
             log.info().attr("session", session).log("Got connect");
             this.session = session;
             this.connected.complete(null);
@@ -438,8 +442,12 @@ public abstract class AbstractCmdProduce extends AbstractCmd {
 
         @OnWebSocketMessage
         public synchronized void onMessage(String msg) throws JsonParseException {
-            log.info().attr("msg", msg).log("ack= ");
-            this.result.complete(null);
+            log.info().attr("ack", msg).log("Received ack");
+            // A text frame can arrive outside a pending send — before the first send() or after
+            // close() — in which case there is no future to complete and the frame is ignored.
+            if (this.result != null) {
+                this.result.complete(null);
+            }
         }
 
         public Session getSession() {
@@ -447,6 +455,8 @@ public abstract class AbstractCmdProduce extends AbstractCmd {
         }
 
         public void close() {
+            // onClose() nulls the session, so a close after the proxy already closed the
+            // connection would otherwise NPE.
             if (session != null) {
                 session.close();
             }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/AbstractCmdProduce.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/AbstractCmdProduce.java
@@ -1,0 +1,455 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.cli;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.util.concurrent.RateLimiter;
+import com.google.gson.JsonParseException;
+import io.github.merlimat.slog.Logger;
+import java.io.ByteArrayOutputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+import lombok.CustomLog;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.io.EncoderFactory;
+import org.apache.avro.io.JsonDecoder;
+import org.apache.pulsar.client.api.Authentication;
+import org.apache.pulsar.client.api.AuthenticationDataProvider;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.util.ObjectMapperFactory;
+import org.apache.pulsar.websocket.data.ProducerMessage;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.eclipse.jetty.websocket.api.Callback;
+import org.eclipse.jetty.websocket.api.Session;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketClose;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketMessage;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketOpen;
+import org.eclipse.jetty.websocket.api.annotations.WebSocket;
+import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
+import org.eclipse.jetty.websocket.client.WebSocketClient;
+import picocli.CommandLine;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+import picocli.CommandLine.Spec;
+
+/**
+ * Client-agnostic part of the {@code pulsar-client produce} command: the CLI options, the message
+ * bodies, the WebSocket publishing path (which speaks HTTP and has no client generation of its own)
+ * and the argument validation. {@link CmdProduce} binds it to the V5 client and
+ * {@link CmdProduceV4} to the v4 ({@code pulsar-client-original}) client.
+ */
+public abstract class AbstractCmdProduce extends AbstractCmd {
+    protected static final int MAX_MESSAGES = 1000;
+    static final String KEY_VALUE_ENCODING_TYPE_NOT_SET = "";
+
+    /**
+     * Logger named after the <em>concrete</em> command class, so that everything this base logs
+     * still appears under {@code CmdProduce} for {@code produce} (and under {@code CmdProduceV4}
+     * for {@code produce-v4}) rather than moving to the base's own name.
+     */
+    protected final Logger log = Logger.get(getClass());
+
+    /** Counterpart of {@link #log} for the static message-body helper. */
+    private static final Logger STATIC_LOG = Logger.get(AbstractCmdProduce.class);
+
+    @Parameters(description = "TopicName", arity = "1")
+    protected String topic;
+
+    @Option(names = { "-m", "--messages" },
+            description = "Messages to send, either -m or -f must be specified. Specify -m for each message.")
+    protected List<String> messages = new ArrayList<>();
+
+    @Option(names = { "-f", "--files" },
+            description = "Comma separated file paths to send, either -m or -f must be specified.")
+    protected List<String> messageFileNames = new ArrayList<>();
+
+    @Option(names = { "-n", "--num-produce" },
+            description = "Number of times to send message(s), the count of messages/files * num-produce "
+                    + "should below than " + MAX_MESSAGES + ".")
+    protected int numTimesProduce = 1;
+
+    @Option(names = { "-r", "--rate" },
+            description = "Rate (in msg/sec) at which to produce,"
+                    + " value 0 means to produce messages as fast as possible.")
+    protected double publishRate = 0;
+
+    @Option(names = { "-db", "--disable-batching" }, description = "Disable batch sending of messages")
+    protected boolean disableBatching = false;
+
+    @Option(names = { "-c",
+            "--chunking" }, description = "Should split the message and publish in chunks if message size is "
+            + "larger than allowed max size")
+    protected boolean chunkingAllowed = false;
+
+    @Option(names = { "-s", "--separator" },
+            description = "Character to split messages string on default is comma")
+    protected String separator = ",";
+
+    @Option(names = { "-p", "--properties"}, description = "Properties to add, Comma separated "
+            + "key=value string, like k1=v1,k2=v2.")
+    protected List<String> properties = new ArrayList<>();
+
+    @Option(names = { "-k", "--key"}, description = "Partitioning key to add to each message")
+    protected String key;
+
+    @Option(names = { "-kvk", "--key-value-key"}, description = "Value to add as message key in KeyValue schema")
+    protected String keyValueKey;
+
+    @Option(names = {"-kvkf", "--key-value-key-file"},
+            description = "Path to file containing the value to add as message key in KeyValue schema. "
+            + "JSON and AVRO files are supported.")
+    protected String keyValueKeyFile;
+
+    @Option(names = { "-vs", "--value-schema"}, description = "Schema type (can be bytes,avro,json,string...)")
+    protected String valueSchema = "bytes";
+
+    @Option(names = { "-ks", "--key-schema"}, description = "Schema type (can be bytes,avro,json,string...)")
+    protected String keySchema = "string";
+
+    @Option(names = { "-kvet", "--key-value-encoding-type"},
+            description = "Key Value Encoding Type (it can be separated or inline)")
+    protected String keyValueEncodingType = null;
+
+    @Option(names = { "-ekn", "--encryption-key-name" }, description = "The public key name to encrypt payload")
+    protected String encKeyName = null;
+
+    @Option(names = { "-ekv",
+            "--encryption-key-value" }, description = "The URI of public key to encrypt payload, for example "
+            + "file:///path/to/public.key or data:application/x-pem-file;base64,*****")
+    protected String encKeyValue = null;
+
+    @Option(names = { "-dr",
+            "--disable-replication" }, description = "Disable geo-replication for messages.")
+    protected boolean disableReplication = false;
+
+    protected Authentication authentication;
+    protected String serviceURL;
+
+    @Spec
+    protected CommandSpec commandSpec;
+
+    public AbstractCmdProduce() {
+        // Do nothing
+    }
+
+    /** Record the client-generation-independent configuration. */
+    protected void updateSharedConfig(Authentication authentication, String serviceURL) {
+        this.authentication = authentication;
+        this.serviceURL = serviceURL;
+    }
+
+    /**
+     * Publish over the binary protocol with this command's client generation.
+     *
+     * @return 0 for success, &lt; 0 otherwise
+     */
+    protected abstract int publish(String topic);
+
+    /**
+     * Validate the schema-related options, on the raw {@link #keyValueEncodingType} — {@code null}
+     * when the flag was not given. The V5 command rejects the KeyValue options it cannot express;
+     * the v4 command accepts {@code separated} / {@code inline} and rejects anything else.
+     */
+    protected abstract void validateSchemaOptions();
+
+    /**
+     * Run the producer.
+     *
+     * @return 0 for success, &lt; 0 otherwise
+     */
+    public int run() {
+        if (this.numTimesProduce <= 0) {
+            throw new CommandLine.ParameterException(commandSpec.commandLine(),
+                    "Number of times need to be positive number.");
+        }
+
+        if (messages.size() > 0) {
+            messages = messages.stream().map(str -> str.split(separator)).flatMap(Stream::of).toList();
+        }
+
+        if (messages.size() == 0 && messageFileNames.size() == 0) {
+            throw new CommandLine.ParameterException(commandSpec.commandLine(),
+                    "Please supply message content with either --messages or --files");
+        }
+
+        // Validate before normalising: "flag absent" (null) and "flag present but empty" are
+        // different to the v4 command, which rejects the latter.
+        validateSchemaOptions();
+        if (keyValueEncodingType == null) {
+            keyValueEncodingType = KEY_VALUE_ENCODING_TYPE_NOT_SET;
+        }
+
+        int totalMessages = (messages.size() + messageFileNames.size()) * numTimesProduce;
+        if (totalMessages > MAX_MESSAGES) {
+            String msg = "Attempting to send " + totalMessages + " messages. Please do not send more than "
+                    + MAX_MESSAGES + " messages";
+            throw new IllegalArgumentException(msg);
+        }
+
+        if (this.serviceURL.startsWith("ws")) {
+            return publishToWebSocket(topic);
+        } else {
+            return publish(topic);
+        }
+    }
+
+    /** The {@code -p/--properties} arguments as a map. */
+    protected Map<String, String> propertiesMap() {
+        Map<String, String> kvMap = new HashMap<>();
+        for (String property : properties) {
+            String[] kv = property.split("=");
+            kvMap.put(kv[0], kv[1]);
+        }
+        return kvMap;
+    }
+
+    /*
+     * Generate a list of message bodies which can be used to build messages
+     *
+     * @param stringMessages List of strings to send
+     *
+     * @param messageFileNames List of file names to read and send
+     *
+     * @return list of message bodies
+     */
+    static List<byte[]> generateMessageBodies(List<String> stringMessages, List<String> messageFileNames,
+                                              org.apache.avro.Schema avroSchema) {
+        List<byte[]> messageBodies = new ArrayList<>();
+
+        for (String m : stringMessages) {
+            if (avroSchema != null) {
+                // JSON TO AVRO — the V5 Schema does not expose the native Avro schema, so the
+                // caller passes the parsed Avro definition directly.
+                messageBodies.add(jsonToAvro(m, avroSchema));
+            } else {
+                messageBodies.add(m.getBytes());
+            }
+        }
+
+        try {
+            for (String filename : messageFileNames) {
+                byte[] fileBytes = Files.readAllBytes(Paths.get(filename));
+                messageBodies.add(fileBytes);
+            }
+        } catch (Exception e) {
+            STATIC_LOG.error().exception(e).log(e.getMessage());
+        }
+
+        return messageBodies;
+    }
+
+    private static byte[] jsonToAvro(String m, org.apache.avro.Schema avroSchema) {
+        try {
+            GenericDatumReader<Object> reader = new GenericDatumReader<>(avroSchema);
+            JsonDecoder jsonDecoder = DecoderFactory.get().jsonDecoder(avroSchema, m);
+            GenericDatumWriter<Object> writer = new GenericDatumWriter<>(avroSchema);
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            Encoder e = EncoderFactory.get().binaryEncoder(out, null);
+            Object datum = null;
+            while (true) {
+                try {
+                    datum = reader.read(datum, jsonDecoder);
+                } catch (EOFException eofException) {
+                    break;
+                }
+                writer.write(datum, e);
+                e.flush();
+            }
+            return out.toByteArray();
+        } catch (IOException e) {
+            throw new RuntimeException("Cannot convert " + m + " to AVRO " + e.getMessage(), e);
+        }
+    }
+
+    @VisibleForTesting
+    public String getWebSocketProduceUri(String topic) {
+        String serviceURLWithoutTrailingSlash = serviceURL.substring(0,
+                serviceURL.endsWith("/") ? serviceURL.length() - 1 : serviceURL.length());
+
+        TopicName topicName = TopicName.get(topic);
+        String wsTopic = String.format("%s/%s/%s/%s", topicName.getDomain(), topicName.getTenant(),
+                topicName.getNamespacePortion(), topicName.getLocalName());
+
+        return String.format("%s/ws/v2/producer/%s", serviceURLWithoutTrailingSlash, wsTopic);
+    }
+
+    @SuppressWarnings("deprecation")
+    private int publishToWebSocket(String topic) {
+        int numMessagesSent = 0;
+        int returnCode = 0;
+
+        URI produceUri = URI.create(getWebSocketProduceUri(topic));
+
+        HttpClient httpClient = new HttpClient();
+        httpClient.setSslContextFactory(new SslContextFactory.Client(true));
+        WebSocketClient produceClient = new WebSocketClient(httpClient);
+        produceClient.setMaxTextMessageSize(64 * 1024);
+
+        ClientUpgradeRequest produceRequest = new ClientUpgradeRequest(produceUri);
+        try {
+            if (authentication != null) {
+                authentication.start();
+                AuthenticationDataProvider authData = authentication.getAuthData(produceUri.getHost());
+                if (authData.hasDataForHttp()) {
+                    for (Map.Entry<String, String> kv : authData.getHttpHeaders()) {
+                        produceRequest.setHeader(kv.getKey(), kv.getValue());
+                    }
+                }
+            }
+        } catch (Exception e) {
+            log.error().exceptionMessage(e).log("Authentication plugin error");
+            return -1;
+        }
+
+        CompletableFuture<Void> connected = new CompletableFuture<>();
+        ProducerSocket produceSocket = new ProducerSocket(connected);
+        try {
+            produceClient.start();
+        } catch (Exception e) {
+            log.error().exception(e).log("Failed to start websocket-client");
+            return -1;
+        }
+
+        try {
+            log.info().attr("uri", produceUri).attr("request", produceRequest)
+                    .log("Trying to create websocket session");
+            produceClient.connect(produceSocket, produceRequest);
+            connected.get();
+        } catch (Exception e) {
+            log.error().exception(e).log("Failed to create web-socket session");
+            return -1;
+        }
+
+        try {
+            List<byte[]> messageBodies = generateMessageBodies(this.messages, this.messageFileNames, null);
+            RateLimiter limiter = (this.publishRate > 0) ? RateLimiter.create(this.publishRate) : null;
+            for (int i = 0; i < this.numTimesProduce; i++) {
+                int index = i * 10;
+                for (byte[] content : messageBodies) {
+                    if (limiter != null) {
+                        limiter.acquire();
+                    }
+                    produceSocket.send(index++, content).get(30, TimeUnit.SECONDS);
+                    numMessagesSent++;
+                }
+            }
+            produceSocket.close();
+        } catch (Exception e) {
+            log.error().exception(e).log("Error while producing messages");
+            returnCode = -1;
+        } finally {
+            log.infof("%d messages successfully produced", numMessagesSent);
+        }
+
+        try {
+            produceClient.stop();
+        } catch (Exception e) {
+            log.error().exception(e).log("Failed to stop websocket-client");
+        }
+        try {
+            httpClient.stop();
+        } catch (Exception e) {
+            log.error().exception(e).log("Failed to stop http-client");
+        }
+
+        return returnCode;
+    }
+
+    /** WebSocket client socket used by the {@code ws://} publishing path. */
+    @WebSocket
+    @CustomLog
+    public static class ProducerSocket {
+
+        private final CountDownLatch closeLatch;
+        private Session session;
+        private CompletableFuture<Void> connected;
+        private volatile CompletableFuture<Void> result;
+
+        public ProducerSocket(CompletableFuture<Void> connected) {
+            this.closeLatch = new CountDownLatch(1);
+            this.connected = connected;
+        }
+
+        public CompletableFuture<Void> send(int index, byte[] content) throws Exception {
+            this.result = new CompletableFuture<>();
+            this.session.sendText(getTestJsonPayload(index, content), Callback.NOOP);
+            return result;
+        }
+
+        private static String getTestJsonPayload(int index, byte[] content) throws JsonProcessingException {
+            ProducerMessage msg = new ProducerMessage();
+            msg.payload = Base64.getEncoder().encodeToString(content);
+            msg.key = Integer.toString(index);
+            return ObjectMapperFactory.getMapper().writer().writeValueAsString(msg);
+        }
+
+        public boolean awaitClose(int duration, TimeUnit unit) throws InterruptedException {
+            return this.closeLatch.await(duration, unit);
+        }
+
+        @OnWebSocketClose
+        public void onClose(int statusCode, String reason) {
+            log.info().attr("statusCode", statusCode).attr("reason", reason)
+                    .log("Connection closed");
+            this.session = null;
+            this.closeLatch.countDown();
+        }
+
+        @OnWebSocketOpen
+        public void onConnect(Session session) throws InterruptedException {
+            log.info().attr("session", session).log("Got connect");
+            this.session = session;
+            this.connected.complete(null);
+        }
+
+        @OnWebSocketMessage
+        public synchronized void onMessage(String msg) throws JsonParseException {
+            log.info().attr("msg", msg).log("ack= ");
+            this.result.complete(null);
+        }
+
+        public Session getSession() {
+            return session;
+        }
+
+        public void close() {
+            if (session != null) {
+                session.close();
+            }
+        }
+    }
+}

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/AbstractCmdReadCommand.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/AbstractCmdReadCommand.java
@@ -1,0 +1,227 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.cli;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.util.concurrent.RateLimiter;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Base64;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.apache.pulsar.client.api.AuthenticationDataProvider;
+import org.apache.pulsar.common.naming.TopicName;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
+import org.eclipse.jetty.websocket.client.WebSocketClient;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+/**
+ * Client-agnostic part of the {@code pulsar-client read} command: the CLI options, the argument
+ * validation and the WebSocket reading path (which speaks HTTP and has no client generation of its
+ * own). {@link CmdRead} binds it to the V5 client's {@code CheckpointConsumer} and
+ * {@link CmdReadV4} to the v4 {@code Reader}.
+ */
+public abstract class AbstractCmdReadCommand extends AbstractCmdConsume {
+
+    protected static final String START_EARLIEST = "earliest";
+    protected static final String START_LATEST = "latest";
+
+    @Parameters(description = "TopicName", arity = "1")
+    protected String topic;
+
+    @Option(names = { "-n",
+            "--num-messages" }, description = "Number of messages to read, 0 means to read forever.")
+    protected int numMessagesToRead = 1;
+
+    @Option(names = { "--hex" }, description = "Display binary messages in hex.")
+    protected boolean displayHex = false;
+
+    @Option(names = { "--hide-content" }, description = "Do not write the message to console.")
+    protected boolean hideContent = false;
+
+    @Option(names = { "-r", "--rate" }, description = "Rate (in msg/sec) at which to read, "
+            + "value 0 means to read messages as fast as possible.")
+    protected double readRate = 0;
+
+    @Option(names = { "-q", "--queue-size" }, description = "Reader receiver queue size.")
+    protected int receiverQueueSize = 0;
+
+    @Option(names = { "-mc", "--max_chunked_msg" }, description = "Max pending chunk messages")
+    protected int maxPendingChunkedMessage = 0;
+
+    @Option(names = { "-ac",
+            "--auto_ack_chunk_q_full" }, description = "Auto ack for oldest message on queue is full")
+    protected boolean autoAckOldestChunkedMessageOnQueueFull = false;
+
+    @Option(names = { "-ekv",
+            "--encryption-key-value" }, description = "The URI of private key to decrypt payload, for example "
+            + "file:///path/to/private.key or data:application/x-pem-file;base64,*****")
+    protected String encKeyValue;
+
+    @Option(names = { "-st", "--schema-type" },
+            description = "Set a schema type on the reader, it can be 'bytes' or 'auto_consume'")
+    protected String schemaType = "bytes";
+
+    @Option(names = { "-pm", "--pool-messages" }, description = "Use the pooled message", arity = "1")
+    protected boolean poolMessages = true;
+
+    @Option(names = { "-mp", "--print-metadata" }, description = "Message metadata")
+    protected boolean printMetadata = false;
+
+    public AbstractCmdReadCommand() {
+        super();
+    }
+
+    /** The {@code -m/--start-message-id} argument, whose accepted forms differ per client. */
+    protected abstract String startMessageId();
+
+    /**
+     * Read over the binary protocol with this command's client generation.
+     *
+     * @return 0 for success, &lt; 0 otherwise
+     */
+    protected abstract int read(String topic);
+
+    /** Additional argument validation for this command's client generation. */
+    protected void validateArguments() {
+    }
+
+    /** The {@code messageId} query parameter of the WebSocket reader URI. */
+    protected abstract String webSocketStartMessageId();
+
+    /**
+     * Run the read command.
+     *
+     * @return 0 for success, &lt; 0 otherwise
+     */
+    public int run() throws IOException {
+        if (this.numMessagesToRead < 0) {
+            throw (new IllegalArgumentException("Number of messages should be zero or positive."));
+        }
+        validateArguments();
+
+        if (this.serviceURL.startsWith("ws")) {
+            return readFromWebSocket(topic);
+        } else {
+            return read(topic);
+        }
+    }
+
+    @VisibleForTesting
+    public String getWebSocketReadUri(String topic) {
+        String serviceURLWithoutTrailingSlash = serviceURL.substring(0,
+                serviceURL.endsWith("/") ? serviceURL.length() - 1 : serviceURL.length());
+
+        TopicName topicName = TopicName.get(topic);
+        String wsTopic = String.format("%s/%s/%s/%s", topicName.getDomain(), topicName.getTenant(),
+                topicName.getNamespacePortion(), topicName.getLocalName());
+
+        return String.format("%s/ws/v2/reader/%s?messageId=%s", serviceURLWithoutTrailingSlash, wsTopic,
+                webSocketStartMessageId());
+    }
+
+    @SuppressWarnings("deprecation")
+    private int readFromWebSocket(String topic) {
+        int numMessagesRead = 0;
+        int returnCode = 0;
+
+        URI readerUri = URI.create(getWebSocketReadUri(topic));
+
+        HttpClient httpClient = new HttpClient();
+        httpClient.setSslContextFactory(new SslContextFactory.Client(true));
+        WebSocketClient readClient = new WebSocketClient(httpClient);
+        ClientUpgradeRequest readRequest = new ClientUpgradeRequest(readerUri);
+        try {
+            if (authentication != null) {
+                authentication.start();
+                AuthenticationDataProvider authData = authentication.getAuthData(readerUri.getHost());
+                if (authData.hasDataForHttp()) {
+                    for (Map.Entry<String, String> kv : authData.getHttpHeaders()) {
+                        readRequest.setHeader(kv.getKey(), kv.getValue());
+                    }
+                }
+            }
+        } catch (Exception e) {
+            LOG.error("Authentication plugin error: " + e.getMessage());
+            return -1;
+        }
+        CompletableFuture<Void> connected = new CompletableFuture<>();
+        ConsumerSocket readerSocket = new ConsumerSocket(connected);
+        try {
+            readClient.start();
+        } catch (Exception e) {
+            LOG.error("Failed to start websocket-client", e);
+            return -1;
+        }
+
+        try {
+            LOG.info("Trying to create websocket session..{}", readerUri);
+            readClient.connect(readerSocket, readRequest);
+            connected.get();
+        } catch (Exception e) {
+            LOG.error("Failed to create web-socket session", e);
+            return -1;
+        }
+
+        try {
+            RateLimiter limiter = (this.readRate > 0) ? RateLimiter.create(this.readRate) : null;
+            while (this.numMessagesToRead == 0 || numMessagesRead < this.numMessagesToRead) {
+                if (limiter != null) {
+                    limiter.acquire();
+                }
+                String msg = readerSocket.receive(5, TimeUnit.SECONDS);
+                if (msg == null) {
+                    LOG.debug("No message to read after waiting for 5 seconds.");
+                } else {
+                    try {
+                        String output = interpretByteArray(displayHex, Base64.getDecoder().decode(msg));
+                        System.out.println(output); // print decode
+                    } catch (Exception e) {
+                        System.out.println(msg);
+                    }
+                    numMessagesRead += 1;
+                }
+            }
+            readerSocket.awaitClose(2, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            LOG.error("Error while reading messages");
+            LOG.error(e.getMessage(), e);
+            returnCode = -1;
+        } finally {
+            LOG.info("{} messages successfully read", numMessagesRead);
+        }
+
+        try {
+            readClient.stop();
+        } catch (Exception e) {
+            LOG.error("Failed to stop websocket-client", e);
+        }
+        try {
+            httpClient.stop();
+        } catch (Exception e) {
+            LOG.error("Failed to stop http-client", e);
+        }
+
+        return returnCode;
+    }
+}

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/AbstractCmdReadCommand.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/AbstractCmdReadCommand.java
@@ -92,9 +92,6 @@ public abstract class AbstractCmdReadCommand extends AbstractCmdConsume {
         super();
     }
 
-    /** The {@code -m/--start-message-id} argument, whose accepted forms differ per client. */
-    protected abstract String startMessageId();
-
     /**
      * Read over the binary protocol with this command's client generation.
      *

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdConsume.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdConsume.java
@@ -19,163 +19,53 @@
 package org.apache.pulsar.client.cli;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.RateLimiter;
-import java.io.IOException;
-import java.net.URI;
 import java.time.Duration;
-import java.util.Base64;
-import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
-import org.apache.pulsar.client.api.AuthenticationDataProvider;
+import java.util.function.Consumer;
+import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.v5.Message;
 import org.apache.pulsar.client.api.v5.PulsarClient;
+import org.apache.pulsar.client.api.v5.PulsarClientBuilder;
 import org.apache.pulsar.client.api.v5.QueueConsumer;
 import org.apache.pulsar.client.api.v5.QueueConsumerBuilder;
 import org.apache.pulsar.client.api.v5.auth.ConsumerCryptoFailureAction;
 import org.apache.pulsar.client.api.v5.config.ConsumerEncryptionPolicy;
 import org.apache.pulsar.client.api.v5.config.SubscriptionInitialPosition;
 import org.apache.pulsar.client.api.v5.schema.Schema;
-import org.apache.pulsar.common.naming.TopicName;
-import org.eclipse.jetty.client.HttpClient;
-import org.eclipse.jetty.util.ssl.SslContextFactory;
-import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
-import org.eclipse.jetty.websocket.client.WebSocketClient;
-import picocli.CommandLine;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Option;
-import picocli.CommandLine.Parameters;
-import picocli.CommandLine.Spec;
 
 /**
- * pulsar-client consume command implementation.
+ * pulsar-client consume command implementation, on the V5 client API.
+ *
+ * <p>Everything that is not V5-specific lives in {@link AbstractCmdConsumeCommand}; the v4 client
+ * is driven by {@link CmdConsumeV4} under the {@code consume-v4} name.
  */
-@Command(description = "Consume messages from a specified topic")
-public class CmdConsume extends AbstractCmdConsume {
-
-    /**
-     * v4-compatible subscription-type flag. This version of pulsar-client consumes through a V5
-     * {@link QueueConsumer} for all types, since it is the only consumer that works against both
-     * regular and scalable topics (the ordered StreamConsumer requires a scalable-topic
-     * controller). Exclusive / Failover therefore get work-queue (Shared-style) semantics and log
-     * a warning rather than preserving single-reader ordering.
-     */
-    public enum SubscriptionType {
-        Exclusive,
-        Shared,
-        Failover,
-        Key_Shared
-    }
-
-    /** v4-compatible subscription-mode flag. Only honored by the WebSocket path; the V5 binary
-     *  consumer is always durable, so NonDurable logs a warning. */
-    public enum SubscriptionMode {
-        Durable,
-        NonDurable
-    }
-
-    @Parameters(description = "TopicName", arity = "1")
-    private String topic;
-
-    @Option(names = { "-t", "--subscription-type" }, description = "Subscription type.")
-    private SubscriptionType subscriptionType = SubscriptionType.Exclusive;
-
-    @Option(names = { "-m", "--subscription-mode" }, description = "Subscription mode.")
-    private SubscriptionMode subscriptionMode = SubscriptionMode.Durable;
+@Command(name = "consume", description = "Consume messages from a specified topic")
+public class CmdConsume extends AbstractCmdConsumeCommand {
 
     @Option(names = { "-p", "--subscription-position" }, description = "Subscription position.")
     private SubscriptionInitialPosition subscriptionInitialPosition = SubscriptionInitialPosition.LATEST;
 
-    @Option(names = { "-s", "--subscription-name" }, required = true, description = "Subscription name.")
-    private String subscriptionName;
-
-    @Option(names = { "-n",
-            "--num-messages" }, description = "Number of messages to consume, 0 means to consume forever.")
-    private int numMessagesToConsume = 1;
-
-    @Option(names = { "--hex" }, description = "Display binary messages in hex.")
-    private boolean displayHex = false;
-
-    @Option(names = { "--hide-content" }, description = "Do not write the message to console.")
-    private boolean hideContent = false;
-
-    @Option(names = { "-r", "--rate" }, description = "Rate (in msg/sec) at which to consume, "
-            + "value 0 means to consume messages as fast as possible.")
-    private double consumeRate = 0;
-
-    @Option(names = { "--regex" }, description = "Indicate the topic name is a regex pattern")
-    private boolean isRegex = false;
-
-    @Option(names = {"-q", "--queue-size"}, description = "Consumer receiver queue size.")
-    private int receiverQueueSize = 0;
-
-    @Option(names = { "-mc", "--max_chunked_msg" }, description = "Max pending chunk messages")
-    private int maxPendingChunkedMessage = 0;
-
-    @Option(names = { "-ac",
-            "--auto_ack_chunk_q_full" }, description = "Auto ack for oldest message on queue is full")
-    private boolean autoAckOldestChunkedMessageOnQueueFull = false;
-
-    @Option(names = { "-ekv",
-            "--encryption-key-value" }, description = "The URI of private key to decrypt payload, for example "
-                    + "file:///path/to/private.key or data:application/x-pem-file;base64,*****")
-    private String encKeyValue;
-
-    @Option(names = { "-st", "--schema-type"},
-            description = "Set a schema type on the consumer, it can be 'bytes' or 'auto_consume'")
-    private String schemaType = "bytes";
-
-    @Option(names = { "-pm", "--pool-messages" }, description = "Use the pooled message", arity = "1")
-    private boolean poolMessages = true;
-
-    @Option(names = {"-rs", "--replicated" }, description = "Whether the subscription status should be replicated")
-    private boolean replicateSubscriptionState = false;
-
     @Option(names = { "-ca", "--crypto-failure-action" }, description = "Crypto Failure Action")
     private ConsumerCryptoFailureAction cryptoFailureAction = ConsumerCryptoFailureAction.FAIL;
 
-    @Option(names = { "-mp", "--print-metadata" }, description = "Message metadata")
-    private boolean printMetadata = false;
-
-    @Option(names = { "-etp", "--end-timestamp" }, description = "End timestamp for consuming messages")
-    private long endTimestamp = Long.MAX_VALUE;
+    private PulsarClientBuilder clientBuilder;
 
     public CmdConsume() {
-        // Do nothing
         super();
     }
 
-    @Spec
-    private CommandSpec commandSpec;
-
     /**
-     * Run the consume command.
-     *
-     * @return 0 for success, < 0 otherwise
+     * Set client configuration.
      */
-    public int run() throws IOException {
-        if (this.subscriptionName == null || this.subscriptionName.isEmpty()) {
-            throw new CommandLine.ParameterException(commandSpec.commandLine(), "Subscription name is not provided.");
-        }
-        if (this.numMessagesToConsume < 0) {
-            throw new CommandLine.ParameterException(commandSpec.commandLine(),
-                    "Number of messages should be zero or positive.");
-        }
-        if (this.endTimestamp < 0) {
-            throw new CommandLine.ParameterException(commandSpec.commandLine(),
-                    "end timestamp should be positive.");
-        }
-
-        if (this.serviceURL.startsWith("ws")) {
-            return consumeFromWebSocket(topic);
-        } else {
-            return consume(topic);
-        }
+    public void updateConfig(PulsarClientBuilder clientBuilder, Authentication authentication, String serviceURL) {
+        this.clientBuilder = clientBuilder;
+        updateSharedConfig(authentication, serviceURL);
     }
 
-    private int consume(String topic) {
+    @Override
+    protected int consume(String topic) {
         int numMessagesConsumed = 0;
         int returnCode = 0;
 
@@ -192,7 +82,7 @@ public class CmdConsume extends AbstractCmdConsume {
         }
         if (subscriptionMode == SubscriptionMode.NonDurable) {
             LOG.warn("--subscription-mode NonDurable is not supported by this version of pulsar-client; "
-                    + "a durable subscription is used instead.");
+                    + "a durable subscription is used instead. Use consume-v4 for a non-durable subscription.");
         }
         if (subscriptionType == SubscriptionType.Exclusive || subscriptionType == SubscriptionType.Failover) {
             // The V5 StreamConsumer (ordered, single-reader) requires a scalable-topic subscription
@@ -200,7 +90,8 @@ public class CmdConsume extends AbstractCmdConsume {
             // both regular and scalable topics. So all subscription types use a QueueConsumer here
             // and Exclusive/Failover get work-queue (Shared-style) semantics rather than ordered.
             LOG.warn("--subscription-type {} : this version of pulsar-client consumes via a work-queue "
-                    + "(Shared-style) subscription; exclusive/failover ordering is not preserved.",
+                    + "(Shared-style) subscription; exclusive/failover ordering is not preserved. "
+                    + "Use consume-v4 for the v4 subscription types.",
                     subscriptionType);
         }
         if (maxPendingChunkedMessage > 0 || autoAckOldestChunkedMessageOnQueueFull) {
@@ -237,7 +128,8 @@ public class CmdConsume extends AbstractCmdConsume {
                         numMessagesConsumed += 1;
                         if (!hideContent) {
                             System.out.println(MESSAGE_BOUNDARY);
-                            System.out.println(this.interpretMessage(msg, displayHex, printMetadata));
+                            System.out.println(
+                                    V5MessageSupport.interpretMessage(msg, displayHex, printMetadata));
                         } else if (numMessagesConsumed % 1000 == 0) {
                             System.out.println("Received " + numMessagesConsumed + " messages");
                         }
@@ -260,10 +152,9 @@ public class CmdConsume extends AbstractCmdConsume {
      * Apply the topic argument to the consumer. A plain topic uses {@code topic(...)}; a
      * {@code --regex} pattern is mapped to a namespace subscription over the pattern's
      * {@code tenant/namespace} (V5 has no topic-regex; namespace subscriptions follow the
-     * namespace live).
+     * namespace live). Use {@code consume-v4} for a real topic regex.
      */
-    private void applyTopicSelection(java.util.function.Consumer<String> topicFn,
-                                     java.util.function.Consumer<String> namespaceFn) {
+    private void applyTopicSelection(Consumer<String> topicFn, Consumer<String> namespaceFn) {
         if (isRegex) {
             namespaceFn.accept(namespaceFromPattern(topic));
         } else {
@@ -288,107 +179,6 @@ public class CmdConsume extends AbstractCmdConsume {
     }
 
     private ConsumerEncryptionPolicy buildConsumerEncryptionPolicy() {
-        return buildFileDecryptionPolicy(this.encKeyValue, cryptoFailureAction);
+        return V5MessageSupport.buildFileDecryptionPolicy(this.encKeyValue, cryptoFailureAction);
     }
-
-    @VisibleForTesting
-    public String getWebSocketConsumeUri(String topic) {
-        String serviceURLWithoutTrailingSlash = serviceURL.substring(0,
-                serviceURL.endsWith("/") ? serviceURL.length() - 1 : serviceURL.length());
-
-        TopicName topicName = TopicName.get(topic);
-        String wsTopic = String.format("%s/%s/%s/%s", topicName.getDomain(), topicName.getTenant(),
-                topicName.getNamespacePortion(), topicName.getLocalName());
-
-        return String.format("%s/ws/v2/consumer/%s/%s?subscriptionType=%s&subscriptionMode=%s",
-                serviceURLWithoutTrailingSlash, wsTopic, subscriptionName,
-                subscriptionType.toString(), subscriptionMode.toString());
-    }
-
-    @SuppressWarnings("deprecation")
-    private int consumeFromWebSocket(String topic) {
-        int numMessagesConsumed = 0;
-        int returnCode = 0;
-
-        URI consumerUri = URI.create(getWebSocketConsumeUri(topic));
-
-        HttpClient httpClient = new HttpClient();
-        httpClient.setSslContextFactory(new SslContextFactory.Client(true));
-        WebSocketClient consumeClient = new WebSocketClient(httpClient);
-        consumeClient.setMaxTextMessageSize(64 * 1024);
-        ClientUpgradeRequest consumeRequest = new ClientUpgradeRequest(consumerUri);
-        try {
-            if (authentication != null) {
-                authentication.start();
-                AuthenticationDataProvider authData = authentication.getAuthData(consumerUri.getHost());
-                if (authData.hasDataForHttp()) {
-                    for (Map.Entry<String, String> kv : authData.getHttpHeaders()) {
-                        consumeRequest.setHeader(kv.getKey(), kv.getValue());
-                    }
-                }
-            }
-        } catch (Exception e) {
-            LOG.error("Authentication plugin error: " + e.getMessage());
-            return -1;
-        }
-        CompletableFuture<Void> connected = new CompletableFuture<>();
-        ConsumerSocket consumerSocket = new ConsumerSocket(connected);
-        try {
-            consumeClient.start();
-        } catch (Exception e) {
-            LOG.error("Failed to start websocket-client", e);
-            return -1;
-        }
-
-        try {
-            LOG.info("Trying to create websocket session..{}", consumerUri);
-            consumeClient.connect(consumerSocket, consumeRequest);
-            connected.get();
-        } catch (Exception e) {
-            LOG.error("Failed to create web-socket session", e);
-            return -1;
-        }
-
-        try {
-            RateLimiter limiter = (this.consumeRate > 0) ? RateLimiter.create(this.consumeRate) : null;
-            while (this.numMessagesToConsume == 0 || numMessagesConsumed < this.numMessagesToConsume) {
-                if (limiter != null) {
-                    limiter.acquire();
-                }
-                String msg = consumerSocket.receive(5, TimeUnit.SECONDS);
-                if (msg == null) {
-                    LOG.debug("No message to consume after waiting for 5 seconds.");
-                } else {
-                    try {
-                        String output = interpretByteArray(displayHex, Base64.getDecoder().decode(msg));
-                        System.out.println(output); // print decode
-                    } catch (Exception e) {
-                        System.out.println(msg);
-                    }
-                    numMessagesConsumed += 1;
-                }
-            }
-            consumerSocket.awaitClose(2, TimeUnit.SECONDS);
-        } catch (Exception e) {
-            LOG.error("Error while consuming messages");
-            LOG.error(e.getMessage(), e);
-            returnCode = -1;
-        } finally {
-            LOG.info("{} messages successfully consumed", numMessagesConsumed);
-        }
-
-
-        try {
-            consumeClient.stop();
-        } catch (Exception e) {
-            LOG.error("Failed to stop websocket-client", e);
-        }
-        try {
-            httpClient.stop();
-        } catch (Exception e) {
-            LOG.error("Failed to stop http-client", e);
-        }
-        return returnCode;
-    }
-
 }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdConsumeV4.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdConsumeV4.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.cli;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import com.google.common.util.concurrent.RateLimiter;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import java.util.regex.Pattern;
+import org.apache.pulsar.client.api.Authentication;
+import org.apache.pulsar.client.api.ClientBuilder;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.ConsumerBuilder;
+import org.apache.pulsar.client.api.ConsumerCryptoFailureAction;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+/**
+ * The {@code consume} command driven by the v4 ({@code pulsar-client-original}) client.
+ *
+ * <p>This is the counterpart of {@link CmdConsume}: the CLI options and the WebSocket path come
+ * from {@link AbstractCmdConsumeCommand}, and only the client bindings differ. It restores the
+ * v4-only consumer capabilities: real {@code Exclusive} / {@code Failover} / {@code Key_Shared}
+ * subscription types, non-durable subscriptions, a real topic regex for {@code --regex},
+ * {@code --start-timestamp}, pooled messages, the chunked-message knobs, and the full message
+ * metadata rendering.
+ */
+@Command(name = "consume-v4", description = "Consume messages from a specified topic using the v4 client")
+public class CmdConsumeV4 extends AbstractCmdConsumeCommand {
+
+    @Option(names = { "-p", "--subscription-position" }, description = "Subscription position.")
+    private SubscriptionInitialPosition subscriptionInitialPosition = SubscriptionInitialPosition.Latest;
+
+    @Option(names = { "-ca", "--crypto-failure-action" }, description = "Crypto Failure Action")
+    private ConsumerCryptoFailureAction cryptoFailureAction = ConsumerCryptoFailureAction.FAIL;
+
+    @Option(names = { "-stp", "--start-timestamp" }, description = "Start timestamp for consuming messages")
+    private long startTimestamp = 0L;
+
+    private Supplier<ClientBuilder> clientBuilder;
+
+    public CmdConsumeV4() {
+        super();
+    }
+
+    /**
+     * Set client configuration. The builder is supplied lazily so that constructing it — which
+     * validates the service URL and parses the whole {@code client.conf} — only happens when this
+     * command actually runs, not on every {@code pulsar-client} invocation.
+     */
+    public void updateConfig(Supplier<ClientBuilder> clientBuilder, Authentication authentication,
+                             String serviceURL) {
+        this.clientBuilder = clientBuilder;
+        updateSharedConfig(authentication, serviceURL);
+    }
+
+    @Override
+    protected void validateArguments() {
+        if (this.startTimestamp < 0) {
+            throw new CommandLine.ParameterException(commandSpec.commandLine(),
+                    "start timestamp should be positive.");
+        }
+        if (this.endTimestamp < startTimestamp) {
+            throw new CommandLine.ParameterException(commandSpec.commandLine(),
+                    "end timestamp should be greater than start timestamp.");
+        }
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    protected int consume(String topic) {
+        int numMessagesConsumed = 0;
+        int returnCode = 0;
+
+        try (PulsarClient client = clientBuilder.get().build()) {
+            Schema<?> schema = poolMessages ? Schema.BYTEBUFFER : Schema.BYTES;
+            if ("auto_consume".equals(schemaType)) {
+                schema = Schema.AUTO_CONSUME();
+            } else if (!"bytes".equals(schemaType)) {
+                throw new IllegalArgumentException("schema type must be 'bytes' or 'auto_consume'");
+            }
+            ConsumerBuilder<?> builder = client.newConsumer(schema)
+                    .subscriptionName(this.subscriptionName)
+                    .subscriptionType(
+                            org.apache.pulsar.client.api.SubscriptionType.valueOf(subscriptionType.name()))
+                    .subscriptionMode(
+                            org.apache.pulsar.client.api.SubscriptionMode.valueOf(subscriptionMode.name()))
+                    .subscriptionInitialPosition(subscriptionInitialPosition)
+                    .poolMessages(poolMessages)
+                    .replicateSubscriptionState(replicateSubscriptionState);
+
+            if (isRegex) {
+                builder.topicsPattern(Pattern.compile(topic));
+            } else {
+                builder.topic(topic);
+            }
+
+            if (this.maxPendingChunkedMessage > 0) {
+                builder.maxPendingChunkedMessage(this.maxPendingChunkedMessage);
+            }
+            if (this.receiverQueueSize > 0) {
+                builder.receiverQueueSize(this.receiverQueueSize);
+            }
+
+            builder.autoAckOldestChunkedMessageOnQueueFull(this.autoAckOldestChunkedMessageOnQueueFull);
+            builder.cryptoFailureAction(cryptoFailureAction);
+
+            if (isNotBlank(this.encKeyValue)) {
+                builder.defaultCryptoKeyReader(this.encKeyValue);
+            }
+
+            try (Consumer<?> consumer = builder.subscribe()) {
+                if (startTimestamp > 0L) {
+                    consumer.seek(startTimestamp);
+                }
+                RateLimiter limiter = (this.consumeRate > 0) ? RateLimiter.create(this.consumeRate) : null;
+                while (this.numMessagesToConsume == 0 || numMessagesConsumed < this.numMessagesToConsume) {
+                    if (limiter != null) {
+                        limiter.acquire();
+                    }
+                    Message<?> msg = consumer.receive(5, TimeUnit.SECONDS);
+                    if (msg == null) {
+                        LOG.debug("No message to consume after waiting for 5 seconds.");
+                    } else {
+                        try {
+                            if (msg.getPublishTime() > endTimestamp) {
+                                break;
+                            }
+                            numMessagesConsumed += 1;
+                            if (!hideContent) {
+                                System.out.println(MESSAGE_BOUNDARY);
+                                System.out.println(
+                                        V4MessageSupport.interpretMessage(msg, displayHex, printMetadata));
+                            } else if (numMessagesConsumed % 1000 == 0) {
+                                System.out.println("Received " + numMessagesConsumed + " messages");
+                            }
+                            consumer.acknowledge(msg);
+                        } finally {
+                            msg.release();
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            LOG.error("Error while consuming messages");
+            LOG.error(e.getMessage(), e);
+            returnCode = -1;
+        } finally {
+            LOG.info("{} messages successfully consumed", numMessagesConsumed);
+        }
+
+        return returnCode;
+    }
+}

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdProduce.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdProduce.java
@@ -19,147 +19,35 @@
 package org.apache.pulsar.client.cli;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.RateLimiter;
-import com.google.gson.JsonParseException;
-import java.io.ByteArrayOutputStream;
-import java.io.EOFException;
-import java.io.IOException;
-import java.net.URI;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Base64;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Stream;
-import lombok.CustomLog;
-import org.apache.avro.generic.GenericDatumReader;
-import org.apache.avro.generic.GenericDatumWriter;
-import org.apache.avro.io.DecoderFactory;
-import org.apache.avro.io.Encoder;
-import org.apache.avro.io.EncoderFactory;
-import org.apache.avro.io.JsonDecoder;
 import org.apache.pulsar.client.api.Authentication;
-import org.apache.pulsar.client.api.AuthenticationDataProvider;
 import org.apache.pulsar.client.api.v5.MessageBuilder;
 import org.apache.pulsar.client.api.v5.Producer;
 import org.apache.pulsar.client.api.v5.ProducerBuilder;
 import org.apache.pulsar.client.api.v5.PulsarClient;
 import org.apache.pulsar.client.api.v5.PulsarClientBuilder;
-import org.apache.pulsar.client.api.v5.PulsarClientException;
+import org.apache.pulsar.client.api.v5.auth.PemFileKeyProvider;
 import org.apache.pulsar.client.api.v5.config.BatchingPolicy;
 import org.apache.pulsar.client.api.v5.config.ChunkingPolicy;
 import org.apache.pulsar.client.api.v5.config.ProducerEncryptionPolicy;
 import org.apache.pulsar.client.api.v5.schema.Schema;
 import org.apache.pulsar.client.api.v5.schema.SchemaInfo;
 import org.apache.pulsar.client.api.v5.schema.SchemaType;
-import org.apache.pulsar.common.naming.TopicName;
-import org.apache.pulsar.common.util.ObjectMapperFactory;
-import org.apache.pulsar.websocket.data.ProducerMessage;
-import org.eclipse.jetty.client.HttpClient;
-import org.eclipse.jetty.util.ssl.SslContextFactory;
-import org.eclipse.jetty.websocket.api.Callback;
-import org.eclipse.jetty.websocket.api.Session;
-import org.eclipse.jetty.websocket.api.annotations.OnWebSocketClose;
-import org.eclipse.jetty.websocket.api.annotations.OnWebSocketMessage;
-import org.eclipse.jetty.websocket.api.annotations.OnWebSocketOpen;
-import org.eclipse.jetty.websocket.api.annotations.WebSocket;
-import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
-import org.eclipse.jetty.websocket.client.WebSocketClient;
-import picocli.CommandLine;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.Model.CommandSpec;
-import picocli.CommandLine.Option;
-import picocli.CommandLine.Parameters;
-import picocli.CommandLine.Spec;
 
 /**
- * pulsar-client produce command implementation.
+ * pulsar-client produce command implementation, on the V5 client API.
+ *
+ * <p>Everything that is not V5-specific lives in {@link AbstractCmdProduce}; the v4 client is
+ * driven by {@link CmdProduceV4} under the {@code produce-v4} name.
  */
-@Command(description = "Produce messages to a specified topic")
-@CustomLog
-public class CmdProduce extends AbstractCmd {
-    private static final int MAX_MESSAGES = 1000;
-    static final String KEY_VALUE_ENCODING_TYPE_NOT_SET = "";
-
-    @Parameters(description = "TopicName", arity = "1")
-    private String topic;
-
-    @Option(names = { "-m", "--messages" },
-            description = "Messages to send, either -m or -f must be specified. Specify -m for each message.")
-    private List<String> messages = new ArrayList<>();
-
-    @Option(names = { "-f", "--files" },
-               description = "Comma separated file paths to send, either -m or -f must be specified.")
-    private List<String> messageFileNames = new ArrayList<>();
-
-    @Option(names = { "-n", "--num-produce" },
-               description = "Number of times to send message(s), the count of messages/files * num-produce "
-                       + "should below than " + MAX_MESSAGES + ".")
-    private int numTimesProduce = 1;
-
-    @Option(names = { "-r", "--rate" },
-               description = "Rate (in msg/sec) at which to produce,"
-                       + " value 0 means to produce messages as fast as possible.")
-    private double publishRate = 0;
-
-    @Option(names = { "-db", "--disable-batching" }, description = "Disable batch sending of messages")
-    private boolean disableBatching = false;
-
-    @Option(names = { "-c",
-            "--chunking" }, description = "Should split the message and publish in chunks if message size is "
-            + "larger than allowed max size")
-    private boolean chunkingAllowed = false;
-
-    @Option(names = { "-s", "--separator" },
-               description = "Character to split messages string on default is comma")
-    private String separator = ",";
-
-    @Option(names = { "-p", "--properties"}, description = "Properties to add, Comma separated "
-            + "key=value string, like k1=v1,k2=v2.")
-    private List<String> properties = new ArrayList<>();
-
-    @Option(names = { "-k", "--key"}, description = "Partitioning key to add to each message")
-    private String key;
-    @Option(names = { "-kvk", "--key-value-key"}, description = "Value to add as message key in KeyValue schema")
-    private String keyValueKey;
-    @Option(names = {"-kvkf", "--key-value-key-file"},
-            description = "Path to file containing the value to add as message key in KeyValue schema. "
-            + "JSON and AVRO files are supported.")
-    private String keyValueKeyFile;
-
-    @Option(names = { "-vs", "--value-schema"}, description = "Schema type (can be bytes,avro,json,string...)")
-    private String valueSchema = "bytes";
-
-    @Option(names = { "-ks", "--key-schema"}, description = "Schema type (can be bytes,avro,json,string...)")
-    private String keySchema = "string";
-
-    @Option(names = { "-kvet", "--key-value-encoding-type"},
-            description = "Key Value Encoding Type (it can be separated or inline)")
-    private String keyValueEncodingType = null;
-
-    @Option(names = { "-ekn", "--encryption-key-name" }, description = "The public key name to encrypt payload")
-    private String encKeyName = null;
-
-    @Option(names = { "-ekv",
-            "--encryption-key-value" }, description = "The URI of public key to encrypt payload, for example "
-                    + "file:///path/to/public.key or data:application/x-pem-file;base64,*****")
-    private String encKeyValue = null;
-
-    @Option(names = { "-dr",
-            "--disable-replication" }, description = "Disable geo-replication for messages.")
-    private boolean disableReplication = false;
+@Command(name = "produce", description = "Produce messages to a specified topic")
+public class CmdProduce extends AbstractCmdProduce {
 
     private PulsarClientBuilder clientBuilder;
-    private Authentication authentication;
-    private String serviceURL;
 
     public CmdProduce() {
         // Do nothing
@@ -170,122 +58,27 @@ public class CmdProduce extends AbstractCmd {
      */
     public void updateConfig(PulsarClientBuilder newBuilder, Authentication authentication, String serviceURL) {
         this.clientBuilder = newBuilder;
-        this.authentication = authentication;
-        this.serviceURL = serviceURL;
+        updateSharedConfig(authentication, serviceURL);
     }
 
-    /*
-     * Generate a list of message bodies which can be used to build messages
-     *
-     * @param stringMessages List of strings to send
-     *
-     * @param messageFileNames List of file names to read and send
-     *
-     * @return list of message bodies
-     */
-    static List<byte[]> generateMessageBodies(List<String> stringMessages, List<String> messageFileNames,
-                                              org.apache.avro.Schema avroSchema) {
-        List<byte[]> messageBodies = new ArrayList<>();
-
-        for (String m : stringMessages) {
-            if (avroSchema != null) {
-                // JSON TO AVRO — the V5 Schema does not expose the native Avro schema, so the
-                // caller passes the parsed Avro definition directly.
-                messageBodies.add(jsonToAvro(m, avroSchema));
-            } else {
-                messageBodies.add(m.getBytes());
-            }
-        }
-
-        try {
-            for (String filename : messageFileNames) {
-                byte[] fileBytes = Files.readAllBytes(Paths.get(filename));
-                messageBodies.add(fileBytes);
-            }
-        } catch (Exception e) {
-            log.error().exception(e).log(e.getMessage());
-        }
-
-        return messageBodies;
-    }
-
-    private static byte[] jsonToAvro(String m, org.apache.avro.Schema avroSchema) {
-        try {
-            GenericDatumReader<Object> reader = new GenericDatumReader<>(avroSchema);
-            JsonDecoder jsonDecoder = DecoderFactory.get().jsonDecoder(avroSchema, m);
-            GenericDatumWriter<Object> writer = new GenericDatumWriter<>(avroSchema);
-            ByteArrayOutputStream out = new ByteArrayOutputStream();
-            Encoder e = EncoderFactory.get().binaryEncoder(out, null);
-            Object datum = null;
-            while (true) {
-                try {
-                    datum = reader.read(datum, jsonDecoder);
-                } catch (EOFException eofException) {
-                    break;
-                }
-                writer.write(datum, e);
-                e.flush();
-            }
-            return out.toByteArray();
-        } catch (IOException e) {
-            throw new RuntimeException("Cannot convert " + m + " to AVRO " + e.getMessage(), e);
-        }
-    }
-
-    @Spec
-    private CommandSpec commandSpec;
-
-    /**
-     * Run the producer.
-     *
-     * @return 0 for success, < 0 otherwise
-     * @throws Exception
-     */
-    @SuppressWarnings({"rawtypes", "unchecked"})
-    public int run() throws PulsarClientException {
-        if (this.numTimesProduce <= 0) {
-            throw new CommandLine.ParameterException(commandSpec.commandLine(),
-                    "Number of times need to be positive number.");
-        }
-
-        if (messages.size() > 0) {
-            messages = messages.stream().map(str -> str.split(separator)).flatMap(Stream::of).toList();
-        }
-
-        if (messages.size() == 0 && messageFileNames.size() == 0) {
-            throw new CommandLine.ParameterException(commandSpec.commandLine(),
-                    "Please supply message content with either --messages or --files");
-        }
-
-        if (keyValueEncodingType == null) {
-            keyValueEncodingType = KEY_VALUE_ENCODING_TYPE_NOT_SET;
-        } else if (!KEY_VALUE_ENCODING_TYPE_NOT_SET.equals(keyValueEncodingType)) {
+    @Override
+    protected void validateSchemaOptions() {
+        if (keyValueEncodingType != null && !KEY_VALUE_ENCODING_TYPE_NOT_SET.equals(keyValueEncodingType)) {
             // KeyValue schemas are not yet supported by the V5-based pulsar-client.
             throw new IllegalArgumentException("KeyValue schemas (--key-value-encoding-type) are not "
                     + "supported by this version of pulsar-client; produce with a plain value schema "
-                    + "(-vs bytes|string|avro:<def>|json:<def>) instead.");
-        }
-
-        int totalMessages = (messages.size() + messageFileNames.size()) * numTimesProduce;
-        if (totalMessages > MAX_MESSAGES) {
-            String msg = "Attempting to send " + totalMessages + " messages. Please do not send more than "
-                    + MAX_MESSAGES + " messages";
-            throw new IllegalArgumentException(msg);
-        }
-
-        if (this.serviceURL.startsWith("ws")) {
-            return publishToWebSocket(topic);
-        } else {
-            return publish(topic);
+                    + "(-vs bytes|string|avro:<def>|json:<def>) instead, or use produce-v4.");
         }
     }
 
-    private int publish(String topic) {
+    @Override
+    protected int publish(String topic) {
         int numMessagesSent = 0;
         int returnCode = 0;
 
         if (this.disableReplication) {
-            log.warn("--disable-replication has no effect on this version of pulsar-client and is ignored.");
+            log.warn("--disable-replication has no effect on this version of pulsar-client and is ignored. "
+                    + "Use produce-v4 to disable replication per message.");
         }
 
         try (PulsarClient client = clientBuilder.build()) {
@@ -305,11 +98,7 @@ public class CmdProduce extends AbstractCmd {
                         vs.avroNative);
                 RateLimiter limiter = (this.publishRate > 0) ? RateLimiter.create(this.publishRate) : null;
 
-                Map<String, String> kvMap = new HashMap<>();
-                for (String property : properties) {
-                    String[] kv = property.split("=");
-                    kvMap.put(kv[0], kv[1]);
-                }
+                Map<String, String> kvMap = propertiesMap();
 
                 for (int i = 0; i < this.numTimesProduce; i++) {
                     for (byte[] content : messageBodies) {
@@ -372,168 +161,10 @@ public class CmdProduce extends AbstractCmd {
 
     private static ProducerEncryptionPolicy buildEncryptionPolicy(String keyName, String keyUri) {
         return ProducerEncryptionPolicy.builder()
-                .publicKeyProvider(org.apache.pulsar.client.api.v5.auth.PemFileKeyProvider.builder()
+                .publicKeyProvider(PemFileKeyProvider.builder()
                         .publicKey(keyName, fileUriToPath(keyUri))
                         .build())
                 .keyName(keyName)
                 .build();
-    }
-
-    @VisibleForTesting
-    public String getWebSocketProduceUri(String topic) {
-        String serviceURLWithoutTrailingSlash = serviceURL.substring(0,
-                serviceURL.endsWith("/") ? serviceURL.length() - 1 : serviceURL.length());
-
-        TopicName topicName = TopicName.get(topic);
-        String wsTopic = String.format("%s/%s/%s/%s", topicName.getDomain(), topicName.getTenant(),
-                topicName.getNamespacePortion(), topicName.getLocalName());
-
-        return String.format("%s/ws/v2/producer/%s", serviceURLWithoutTrailingSlash, wsTopic);
-    }
-
-    @SuppressWarnings("deprecation")
-    private int publishToWebSocket(String topic) {
-        int numMessagesSent = 0;
-        int returnCode = 0;
-
-        URI produceUri = URI.create(getWebSocketProduceUri(topic));
-
-        HttpClient httpClient = new HttpClient();
-        httpClient.setSslContextFactory(new SslContextFactory.Client(true));
-        WebSocketClient produceClient = new WebSocketClient(httpClient);
-        produceClient.setMaxTextMessageSize(64 * 1024);
-
-        ClientUpgradeRequest produceRequest = new ClientUpgradeRequest(produceUri);
-        try {
-            if (authentication != null) {
-                authentication.start();
-                AuthenticationDataProvider authData = authentication.getAuthData(produceUri.getHost());
-                if (authData.hasDataForHttp()) {
-                    for (Map.Entry<String, String> kv : authData.getHttpHeaders()) {
-                        produceRequest.setHeader(kv.getKey(), kv.getValue());
-                    }
-                }
-            }
-        } catch (Exception e) {
-            log.error().exceptionMessage(e).log("Authentication plugin error");
-            return -1;
-        }
-
-        CompletableFuture<Void> connected = new CompletableFuture<>();
-        ProducerSocket produceSocket = new ProducerSocket(connected);
-        try {
-            produceClient.start();
-        } catch (Exception e) {
-            log.error().exception(e).log("Failed to start websocket-client");
-            return -1;
-        }
-
-        try {
-            log.info().attr("uri", produceUri).attr("request", produceRequest)
-                    .log("Trying to create websocket session");
-            produceClient.connect(produceSocket, produceRequest);
-            connected.get();
-        } catch (Exception e) {
-            log.error().exception(e).log("Failed to create web-socket session");
-            return -1;
-        }
-
-        try {
-            List<byte[]> messageBodies = generateMessageBodies(this.messages, this.messageFileNames, null);
-            RateLimiter limiter = (this.publishRate > 0) ? RateLimiter.create(this.publishRate) : null;
-            for (int i = 0; i < this.numTimesProduce; i++) {
-                int index = i * 10;
-                for (byte[] content : messageBodies) {
-                    if (limiter != null) {
-                        limiter.acquire();
-                    }
-                    produceSocket.send(index++, content).get(30, TimeUnit.SECONDS);
-                    numMessagesSent++;
-                }
-            }
-            produceSocket.close();
-        } catch (Exception e) {
-            log.error().exception(e).log("Error while producing messages");
-            returnCode = -1;
-        } finally {
-            log.infof("%d messages successfully produced", numMessagesSent);
-        }
-
-        try {
-            produceClient.stop();
-        } catch (Exception e) {
-            log.error().exception(e).log("Failed to stop websocket-client");
-        }
-        try {
-            httpClient.stop();
-        } catch (Exception e) {
-            log.error().exception(e).log("Failed to stop http-client");
-        }
-
-        return returnCode;
-    }
-
-    @WebSocket
-    @CustomLog
-    public static class ProducerSocket {
-
-        private final CountDownLatch closeLatch;
-        private Session session;
-        private CompletableFuture<Void> connected;
-        private volatile CompletableFuture<Void> result;
-
-        public ProducerSocket(CompletableFuture<Void> connected) {
-            this.closeLatch = new CountDownLatch(1);
-            this.connected = connected;
-        }
-
-        public CompletableFuture<Void> send(int index, byte[] content) throws Exception {
-            this.session.sendText(getTestJsonPayload(index, content), Callback.NOOP);
-            this.result = new CompletableFuture<>();
-            return result;
-        }
-
-        private static String getTestJsonPayload(int index, byte[] content) throws JsonProcessingException {
-            ProducerMessage msg = new ProducerMessage();
-            msg.payload = Base64.getEncoder().encodeToString(content);
-            msg.key = Integer.toString(index);
-            return ObjectMapperFactory.getMapper().writer().writeValueAsString(msg);
-        }
-
-        public boolean awaitClose(int duration, TimeUnit unit) throws InterruptedException {
-            return this.closeLatch.await(duration, unit);
-        }
-
-        @OnWebSocketClose
-        public void onClose(int statusCode, String reason) {
-            log.info().attr("statusCode", statusCode).attr("reason", reason)
-                    .log("Connection closed");
-            this.session = null;
-            this.closeLatch.countDown();
-        }
-
-        @OnWebSocketOpen
-        public void onConnect(Session session) {
-            log.info().attr("session", session).log("Got connect");
-            this.session = session;
-            this.connected.complete(null);
-        }
-
-        @OnWebSocketMessage
-        public synchronized void onMessage(String msg) throws JsonParseException {
-            log.info().attr("ack", msg).log("Received ack");
-            if (this.result != null) {
-                this.result.complete(null);
-            }
-        }
-
-        public Session getSession() {
-            return this.session;
-        }
-
-        public void close() {
-            this.session.close();
-        }
-
     }
 }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdProduceV4.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdProduceV4.java
@@ -185,12 +185,20 @@ public class CmdProduceV4 extends AbstractCmdProduce {
         }
     }
 
-    /** The parsed Avro definition behind an {@code avro:} schema, or null for any other type. */
+    /**
+     * The parsed Avro definition behind an {@code avro:} schema, or null for any other type. An
+     * Avro schema that exposes no native definition is an error rather than a fallback: without it
+     * the JSON text would be shipped verbatim as the payload under an Avro schema.
+     */
     private static org.apache.avro.Schema nativeAvroSchemaOrNull(Schema<?> schema) {
         if (schema.getSchemaInfo().getType() != SchemaType.AVRO) {
             return null;
         }
-        return (org.apache.avro.Schema) schema.getNativeSchema().orElse(null);
+        return (org.apache.avro.Schema) schema.getNativeSchema()
+                .orElseThrow(() -> new IllegalStateException(
+                        "No native Avro definition available for schema '"
+                                + schema.getSchemaInfo().getName()
+                                + "', so the message cannot be encoded from JSON"));
     }
 
     static Schema<?> buildSchema(String keySchema, String schema, String keyValueEncodingType) {

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdProduceV4.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdProduceV4.java
@@ -1,0 +1,243 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.cli;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import com.google.common.util.concurrent.RateLimiter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import org.apache.pulsar.client.api.Authentication;
+import org.apache.pulsar.client.api.ClientBuilder;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.ProducerBuilder;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.TypedMessageBuilder;
+import org.apache.pulsar.client.api.schema.KeyValueSchema;
+import org.apache.pulsar.client.impl.schema.SchemaInfoImpl;
+import org.apache.pulsar.common.schema.KeyValue;
+import org.apache.pulsar.common.schema.KeyValueEncodingType;
+import org.apache.pulsar.common.schema.SchemaType;
+import picocli.CommandLine.Command;
+
+/**
+ * The {@code produce} command driven by the v4 ({@code pulsar-client-original}) client.
+ *
+ * <p>This is the counterpart of {@link CmdProduce}: the CLI options, the message bodies and the
+ * WebSocket path come from {@link AbstractCmdProduce}, and only the client bindings differ. It
+ * restores the v4-only producer capabilities: KeyValue schemas ({@code --key-value-encoding-type}
+ * with {@code --key-value-key} / {@code --key-value-key-file} and {@code --key-schema}),
+ * {@code --disable-replication}, and {@code data:} URI encryption keys.
+ */
+@Command(name = "produce-v4", description = "Produce messages to a specified topic using the v4 client")
+public class CmdProduceV4 extends AbstractCmdProduce {
+
+    private static final String KEY_VALUE_ENCODING_TYPE_SEPARATED = "separated";
+    private static final String KEY_VALUE_ENCODING_TYPE_INLINE = "inline";
+
+    private Supplier<ClientBuilder> clientBuilder;
+
+    public CmdProduceV4() {
+        // Do nothing
+    }
+
+    /**
+     * Set Pulsar client configuration. The builder is supplied lazily so that constructing it —
+     * which validates the service URL and parses the whole {@code client.conf} — only happens when
+     * this command actually runs, not on every {@code pulsar-client} invocation.
+     */
+    public void updateConfig(Supplier<ClientBuilder> newBuilder, Authentication authentication, String serviceURL) {
+        this.clientBuilder = newBuilder;
+        updateSharedConfig(authentication, serviceURL);
+    }
+
+    @Override
+    protected void validateSchemaOptions() {
+        // An absent flag is fine; an explicitly-supplied value must name a real encoding type —
+        // including the empty string, which the pre-migration v4 command also rejected.
+        if (keyValueEncodingType == null) {
+            return;
+        }
+        switch (keyValueEncodingType) {
+            case KEY_VALUE_ENCODING_TYPE_SEPARATED:
+            case KEY_VALUE_ENCODING_TYPE_INLINE:
+                break;
+            default:
+                throw new IllegalArgumentException("--key-value-encoding-type "
+                        + keyValueEncodingType + " is not valid, only 'separated' or 'inline'");
+        }
+    }
+
+    @Override
+    @SuppressWarnings({"unchecked", "rawtypes", "deprecation"})
+    protected int publish(String topic) {
+        int numMessagesSent = 0;
+        int returnCode = 0;
+
+        try (PulsarClient client = clientBuilder.get().build()) {
+            Schema<?> schema = buildSchema(this.keySchema, this.valueSchema, this.keyValueEncodingType);
+            ProducerBuilder<?> producerBuilder = client.newProducer(schema).topic(topic);
+            if (this.chunkingAllowed) {
+                producerBuilder.enableChunking(true);
+                producerBuilder.enableBatching(false);
+            } else if (this.disableBatching) {
+                producerBuilder.enableBatching(false);
+            }
+            if (isNotBlank(this.encKeyName) && isNotBlank(this.encKeyValue)) {
+                producerBuilder.addEncryptionKey(this.encKeyName);
+                producerBuilder.defaultCryptoKeyReader(this.encKeyValue);
+            }
+            try (Producer<?> producer = producerBuilder.create()) {
+                Schema<?> schemaForPayload = schema.getSchemaInfo().getType() == SchemaType.KEY_VALUE
+                        ? ((KeyValueSchema) schema).getValueSchema() : schema;
+                List<byte[]> messageBodies = generateMessageBodies(this.messages, this.messageFileNames,
+                        nativeAvroSchemaOrNull(schemaForPayload));
+                RateLimiter limiter = (this.publishRate > 0) ? RateLimiter.create(this.publishRate) : null;
+
+                Map<String, String> kvMap = propertiesMap();
+                final byte[] keyValueKeyBytes = resolveKeyValueKeyBytes();
+
+                for (int i = 0; i < this.numTimesProduce; i++) {
+                    for (byte[] content : messageBodies) {
+                        if (limiter != null) {
+                            limiter.acquire();
+                        }
+
+                        TypedMessageBuilder<Object> message =
+                                (TypedMessageBuilder<Object>) producer.newMessage();
+
+                        if (!kvMap.isEmpty()) {
+                            message.properties(kvMap);
+                        }
+
+                        if (KEY_VALUE_ENCODING_TYPE_NOT_SET.equals(keyValueEncodingType)) {
+                            if (key != null && !key.isEmpty()) {
+                                message.key(key);
+                            }
+                            message.value(content);
+                        } else {
+                            message.value(new KeyValue<>(keyValueKeyBytes, content));
+                        }
+
+                        if (disableReplication) {
+                            message.disableReplication();
+                        }
+
+                        message.send();
+                        numMessagesSent++;
+                    }
+                }
+            }
+        } catch (Exception e) {
+            log.error().exception(e).log("Error while producing messages");
+            returnCode = -1;
+        } finally {
+            log.infof("%d messages successfully produced", numMessagesSent);
+        }
+
+        return returnCode;
+    }
+
+    /**
+     * The key bytes of a KeyValue message, from {@code --key-value-key},
+     * {@code --key-value-key-file} or, failing both, {@code --key}.
+     */
+    private byte[] resolveKeyValueKeyBytes() throws Exception {
+        if (this.keyValueKey != null) {
+            requireKeyValueEncodingType("--key-value-key");
+            return this.keyValueKey.getBytes(StandardCharsets.UTF_8);
+        }
+        if (this.keyValueKeyFile != null) {
+            requireKeyValueEncodingType("--key-value-key-file");
+            return Files.readAllBytes(Paths.get(this.keyValueKeyFile));
+        }
+        if (this.key != null) {
+            return this.key.getBytes(StandardCharsets.UTF_8);
+        }
+        return null;
+    }
+
+    private void requireKeyValueEncodingType(String flag) {
+        if (KEY_VALUE_ENCODING_TYPE_NOT_SET.equals(keyValueEncodingType)) {
+            throw new IllegalArgumentException(
+                    "Key value encoding type must be set when using " + flag);
+        }
+    }
+
+    /** The parsed Avro definition behind an {@code avro:} schema, or null for any other type. */
+    private static org.apache.avro.Schema nativeAvroSchemaOrNull(Schema<?> schema) {
+        if (schema.getSchemaInfo().getType() != SchemaType.AVRO) {
+            return null;
+        }
+        return (org.apache.avro.Schema) schema.getNativeSchema().orElse(null);
+    }
+
+    static Schema<?> buildSchema(String keySchema, String schema, String keyValueEncodingType) {
+        if (KEY_VALUE_ENCODING_TYPE_NOT_SET.equals(keyValueEncodingType)) {
+            return buildComponentSchema(schema);
+        }
+        switch (keyValueEncodingType) {
+            case KEY_VALUE_ENCODING_TYPE_SEPARATED:
+                return Schema.KeyValue(buildComponentSchema(keySchema), buildComponentSchema(schema),
+                        KeyValueEncodingType.SEPARATED);
+            case KEY_VALUE_ENCODING_TYPE_INLINE:
+                return Schema.KeyValue(buildComponentSchema(keySchema), buildComponentSchema(schema),
+                        KeyValueEncodingType.INLINE);
+            default:
+                throw new IllegalArgumentException("Invalid KeyValueEncodingType "
+                        + keyValueEncodingType + ", only: 'none','separated' and 'inline");
+        }
+    }
+
+    private static Schema<?> buildComponentSchema(String schema) {
+        Schema<?> base;
+        switch (schema) {
+            case "string":
+                base = Schema.STRING;
+                break;
+            case "bytes":
+                // no need for wrappers
+                return Schema.BYTES;
+            default:
+                if (schema.startsWith("avro:")) {
+                    base = buildGenericSchema(SchemaType.AVRO, schema.substring(5));
+                } else if (schema.startsWith("json:")) {
+                    base = buildGenericSchema(SchemaType.JSON, schema.substring(5));
+                } else {
+                    throw new IllegalArgumentException("Invalid schema type: " + schema);
+                }
+        }
+        return Schema.AUTO_PRODUCE_BYTES(base);
+    }
+
+    private static Schema<?> buildGenericSchema(SchemaType type, String definition) {
+        return Schema.generic(SchemaInfoImpl
+                .builder()
+                .schema(definition.getBytes(StandardCharsets.UTF_8))
+                .name("client")
+                .properties(new HashMap<>())
+                .type(type)
+                .build());
+    }
+}

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdRead.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdRead.java
@@ -19,42 +19,31 @@
 package org.apache.pulsar.client.cli;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.RateLimiter;
-import java.io.IOException;
-import java.net.URI;
 import java.time.Duration;
-import java.util.Base64;
-import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
-import org.apache.pulsar.client.api.AuthenticationDataProvider;
+import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.v5.Checkpoint;
 import org.apache.pulsar.client.api.v5.CheckpointConsumer;
 import org.apache.pulsar.client.api.v5.CheckpointConsumerBuilder;
 import org.apache.pulsar.client.api.v5.Message;
 import org.apache.pulsar.client.api.v5.PulsarClient;
-import org.apache.pulsar.client.api.v5.PulsarClientException;
+import org.apache.pulsar.client.api.v5.PulsarClientBuilder;
 import org.apache.pulsar.client.api.v5.auth.ConsumerCryptoFailureAction;
 import org.apache.pulsar.client.api.v5.config.ConsumerEncryptionPolicy;
 import org.apache.pulsar.client.api.v5.schema.Schema;
-import org.apache.pulsar.common.naming.TopicName;
-import org.eclipse.jetty.client.HttpClient;
-import org.eclipse.jetty.util.ssl.SslContextFactory;
-import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
-import org.eclipse.jetty.websocket.client.WebSocketClient;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
-import picocli.CommandLine.Parameters;
 
 /**
- * pulsar-client read command implementation.
+ * pulsar-client read command implementation, on the V5 client API.
+ *
+ * <p>V5 has no {@code Reader}; the closest equivalent is the {@code CheckpointConsumer}, which is
+ * what this command drives. Everything that is not V5-specific lives in
+ * {@link AbstractCmdReadCommand}; the v4 {@code Reader} is driven by {@link CmdReadV4} under the
+ * {@code read-v4} name.
  */
-@Command(description = "Read messages from a specified topic")
-public class CmdRead extends AbstractCmdConsume {
-
-    @Parameters(description = "TopicName", arity = "1")
-    private String topic;
+@Command(name = "read", description = "Read messages from a specified topic")
+public class CmdRead extends AbstractCmdReadCommand {
 
     @Option(names = { "-m", "--start-message-id" },
             description = "Initial reader position, it can be 'latest' or 'earliest'")
@@ -64,78 +53,45 @@ public class CmdRead extends AbstractCmdConsume {
             description = "Whether to include the position specified by -m option.")
     private boolean startMessageIdInclusive = false;
 
-    @Option(names = { "-n",
-            "--num-messages" }, description = "Number of messages to read, 0 means to read forever.")
-    private int numMessagesToRead = 1;
-
-    @Option(names = { "--hex" }, description = "Display binary messages in hex.")
-    private boolean displayHex = false;
-
-    @Option(names = { "--hide-content" }, description = "Do not write the message to console.")
-    private boolean hideContent = false;
-
-    @Option(names = { "-r", "--rate" }, description = "Rate (in msg/sec) at which to read, "
-            + "value 0 means to read messages as fast as possible.")
-    private double readRate = 0;
-
-    @Option(names = { "-q", "--queue-size" }, description = "Reader receiver queue size.")
-    private int receiverQueueSize = 0;
-
-    @Option(names = { "-mc", "--max_chunked_msg" }, description = "Max pending chunk messages")
-    private int maxPendingChunkedMessage = 0;
-
-    @Option(names = { "-ac",
-            "--auto_ack_chunk_q_full" }, description = "Auto ack for oldest message on queue is full")
-    private boolean autoAckOldestChunkedMessageOnQueueFull = false;
-
-    @Option(names = { "-ekv",
-            "--encryption-key-value" }, description = "The URI of private key to decrypt payload, for example "
-            + "file:///path/to/private.key or data:application/x-pem-file;base64,*****")
-    private String encKeyValue;
-
-    @Option(names = { "-st", "--schema-type" },
-            description = "Set a schema type on the reader, it can be 'bytes' or 'auto_consume'")
-    private String schemaType = "bytes";
-
-    @Option(names = { "-pm", "--pool-messages" }, description = "Use the pooled message", arity = "1")
-    private boolean poolMessages = true;
-
     @Option(names = { "-ca", "--crypto-failure-action" }, description = "Crypto Failure Action")
     private ConsumerCryptoFailureAction cryptoFailureAction = ConsumerCryptoFailureAction.FAIL;
 
-    private static final String START_EARLIEST = "earliest";
-    private static final String START_LATEST = "latest";
-
-    @Option(names = { "-mp", "--print-metadata" }, description = "Message metadata")
-    private boolean printMetadata = false;
+    private PulsarClientBuilder clientBuilder;
 
     public CmdRead() {
-        // Do nothing
         super();
     }
 
     /**
-     * Run the read command.
-     *
-     * @return 0 for success, < 0 otherwise
+     * Set client configuration.
      */
-    public int run() throws PulsarClientException, IOException {
-        if (this.numMessagesToRead < 0) {
-            throw (new IllegalArgumentException("Number of messages should be zero or positive."));
-        }
+    public void updateConfig(PulsarClientBuilder clientBuilder, Authentication authentication, String serviceURL) {
+        this.clientBuilder = clientBuilder;
+        updateSharedConfig(authentication, serviceURL);
+    }
+
+    @Override
+    protected String startMessageId() {
+        return startMessageId;
+    }
+
+    @Override
+    protected String webSocketStartMessageId() {
+        // Only 'latest' / 'earliest' are accepted (validated in validateArguments()).
+        return startMessageId;
+    }
+
+    @Override
+    protected void validateArguments() {
         if (!START_LATEST.equals(startMessageId) && !START_EARLIEST.equals(startMessageId)) {
             throw new IllegalArgumentException("--start-message-id must be 'latest' or 'earliest'; the "
-                    + "'<ledgerId>:<entryId>' form is not supported by this version of pulsar-client.");
-        }
-
-        if (this.serviceURL.startsWith("ws")) {
-            return readFromWebSocket(topic);
-        } else {
-            return read(topic);
+                    + "'<ledgerId>:<entryId>' form is not supported by this version of pulsar-client. "
+                    + "Use read-v4, which does support it.");
         }
     }
 
-    private int read(String topic) {
+    @Override
+    protected int read(String topic) {
         int numMessagesRead = 0;
         int returnCode = 0;
 
@@ -152,6 +108,9 @@ public class CmdRead extends AbstractCmdConsume {
         }
         if (this.startMessageIdInclusive) {
             LOG.warn("--start-message-id-inclusive has no effect on this version of pulsar-client.");
+        }
+        if (this.receiverQueueSize > 0) {
+            LOG.info("--queue-size has no effect on this version of pulsar-client's read command.");
         }
         if (maxPendingChunkedMessage > 0 || autoAckOldestChunkedMessageOnQueueFull) {
             LOG.warn("Chunked-message knobs (--max_chunked_msg / --auto_ack_chunk_q_full) have no effect "
@@ -183,7 +142,8 @@ public class CmdRead extends AbstractCmdConsume {
                         numMessagesRead += 1;
                         if (!hideContent) {
                             System.out.println(MESSAGE_BOUNDARY);
-                            System.out.println(this.interpretMessage(msg, displayHex, printMetadata));
+                            System.out.println(
+                                    V5MessageSupport.interpretMessage(msg, displayHex, printMetadata));
                         } else if (numMessagesRead % 1000 == 0) {
                             System.out.println("Received " + numMessagesRead + " messages");
                         }
@@ -202,106 +162,6 @@ public class CmdRead extends AbstractCmdConsume {
     }
 
     private ConsumerEncryptionPolicy buildConsumerEncryptionPolicy() {
-        return buildFileDecryptionPolicy(this.encKeyValue, cryptoFailureAction);
+        return V5MessageSupport.buildFileDecryptionPolicy(this.encKeyValue, cryptoFailureAction);
     }
-
-    @VisibleForTesting
-    public String getWebSocketReadUri(String topic) {
-        String serviceURLWithoutTrailingSlash = serviceURL.substring(0,
-                serviceURL.endsWith("/") ? serviceURL.length() - 1 : serviceURL.length());
-
-        TopicName topicName = TopicName.get(topic);
-        String wsTopic = String.format("%s/%s/%s/%s", topicName.getDomain(), topicName.getTenant(),
-                topicName.getNamespacePortion(), topicName.getLocalName());
-
-        // Only 'latest' / 'earliest' are accepted (validated in run()).
-        return String.format("%s/ws/v2/reader/%s?messageId=%s", serviceURLWithoutTrailingSlash, wsTopic,
-                startMessageId);
-    }
-
-    @SuppressWarnings("deprecation")
-    private int readFromWebSocket(String topic) {
-        int numMessagesRead = 0;
-        int returnCode = 0;
-
-        URI readerUri = URI.create(getWebSocketReadUri(topic));
-
-        HttpClient httpClient = new HttpClient();
-        httpClient.setSslContextFactory(new SslContextFactory.Client(true));
-        WebSocketClient readClient = new WebSocketClient(httpClient);
-        ClientUpgradeRequest readRequest = new ClientUpgradeRequest(readerUri);
-        try {
-            if (authentication != null) {
-                authentication.start();
-                AuthenticationDataProvider authData = authentication.getAuthData(readerUri.getHost());
-                if (authData.hasDataForHttp()) {
-                    for (Map.Entry<String, String> kv : authData.getHttpHeaders()) {
-                        readRequest.setHeader(kv.getKey(), kv.getValue());
-                    }
-                }
-            }
-        } catch (Exception e) {
-            LOG.error("Authentication plugin error: " + e.getMessage());
-            return -1;
-        }
-        CompletableFuture<Void> connected = new CompletableFuture<>();
-        ConsumerSocket readerSocket = new ConsumerSocket(connected);
-        try {
-            readClient.start();
-        } catch (Exception e) {
-            LOG.error("Failed to start websocket-client", e);
-            return -1;
-        }
-
-        try {
-            LOG.info("Trying to create websocket session..{}", readerUri);
-            readClient.connect(readerSocket, readRequest);
-            connected.get();
-        } catch (Exception e) {
-            LOG.error("Failed to create web-socket session", e);
-            return -1;
-        }
-
-        try {
-            RateLimiter limiter = (this.readRate > 0) ? RateLimiter.create(this.readRate) : null;
-            while (this.numMessagesToRead == 0 || numMessagesRead < this.numMessagesToRead) {
-                if (limiter != null) {
-                    limiter.acquire();
-                }
-                String msg = readerSocket.receive(5, TimeUnit.SECONDS);
-                if (msg == null) {
-                    LOG.debug("No message to read after waiting for 5 seconds.");
-                } else {
-                    try {
-                        String output = interpretByteArray(displayHex, Base64.getDecoder().decode(msg));
-                        System.out.println(output); // print decode
-                    } catch (Exception e) {
-                        System.out.println(msg);
-                    }
-                    numMessagesRead += 1;
-                }
-            }
-            readerSocket.awaitClose(2, TimeUnit.SECONDS);
-        } catch (Exception e) {
-            LOG.error("Error while reading messages");
-            LOG.error(e.getMessage(), e);
-            returnCode = -1;
-        } finally {
-            LOG.info("{} messages successfully read", numMessagesRead);
-        }
-
-        try {
-            readClient.stop();
-        } catch (Exception e) {
-            LOG.error("Failed to stop websocket-client", e);
-        }
-        try {
-            httpClient.stop();
-        } catch (Exception e) {
-            LOG.error("Failed to stop http-client", e);
-        }
-
-        return returnCode;
-    }
-
 }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdRead.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdRead.java
@@ -71,11 +71,6 @@ public class CmdRead extends AbstractCmdReadCommand {
     }
 
     @Override
-    protected String startMessageId() {
-        return startMessageId;
-    }
-
-    @Override
     protected String webSocketStartMessageId() {
         // Only 'latest' / 'earliest' are accepted (validated in validateArguments()).
         return startMessageId;

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdReadV4.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdReadV4.java
@@ -83,11 +83,6 @@ public class CmdReadV4 extends AbstractCmdReadCommand {
     }
 
     @Override
-    protected String startMessageId() {
-        return startMessageId;
-    }
-
-    @Override
     protected void validateArguments() {
         // Fail fast on a malformed id rather than at reader creation.
         parseMessageId(startMessageId);

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdReadV4.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdReadV4.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.cli;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.util.concurrent.RateLimiter;
+import java.util.Base64;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.pulsar.client.api.Authentication;
+import org.apache.pulsar.client.api.ClientBuilder;
+import org.apache.pulsar.client.api.ConsumerCryptoFailureAction;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.Reader;
+import org.apache.pulsar.client.api.ReaderBuilder;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.impl.MessageIdImpl;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+/**
+ * The {@code read} command driven by the v4 ({@code pulsar-client-original}) client.
+ *
+ * <p>This is the counterpart of {@link CmdRead}, which drives a V5 {@code CheckpointConsumer} — a
+ * different broker-side entity — so without this command nothing in {@code pulsar-client} exercises
+ * the v4 {@code Reader}. It also restores the v4-only reader capabilities: a
+ * {@code <ledgerId>:<entryId>} start message id (also over WebSocket),
+ * {@code --start-message-id-inclusive}, {@code --queue-size}, pooled messages, the chunked-message
+ * knobs, and the full message metadata rendering.
+ */
+@Command(name = "read-v4", description = "Read messages from a specified topic using the v4 client")
+public class CmdReadV4 extends AbstractCmdReadCommand {
+
+    private static final Pattern MSG_ID_PATTERN = Pattern.compile("^(-?[1-9][0-9]*|0):(-?[1-9][0-9]*|0)$");
+
+    @Option(names = { "-m", "--start-message-id" },
+            description = "Initial reader position, it can be 'latest', 'earliest' or '<ledgerId>:<entryId>'")
+    private String startMessageId = "latest";
+
+    @Option(names = { "-i", "--start-message-id-inclusive" },
+            description = "Whether to include the position specified by -m option.")
+    private boolean startMessageIdInclusive = false;
+
+    @Option(names = { "-ca", "--crypto-failure-action" }, description = "Crypto Failure Action")
+    private ConsumerCryptoFailureAction cryptoFailureAction = ConsumerCryptoFailureAction.FAIL;
+
+    private Supplier<ClientBuilder> clientBuilder;
+
+    public CmdReadV4() {
+        super();
+    }
+
+    /**
+     * Set client configuration. The builder is supplied lazily so that constructing it — which
+     * validates the service URL and parses the whole {@code client.conf} — only happens when this
+     * command actually runs, not on every {@code pulsar-client} invocation.
+     */
+    public void updateConfig(Supplier<ClientBuilder> clientBuilder, Authentication authentication,
+                             String serviceURL) {
+        this.clientBuilder = clientBuilder;
+        updateSharedConfig(authentication, serviceURL);
+    }
+
+    @Override
+    protected String startMessageId() {
+        return startMessageId;
+    }
+
+    @Override
+    protected void validateArguments() {
+        // Fail fast on a malformed id rather than at reader creation.
+        parseMessageId(startMessageId);
+    }
+
+    @Override
+    protected String webSocketStartMessageId() {
+        if (START_LATEST.equals(startMessageId) || START_EARLIEST.equals(startMessageId)) {
+            return startMessageId;
+        }
+        return Base64.getEncoder().encodeToString(parseMessageId(startMessageId).toByteArray());
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    protected int read(String topic) {
+        int numMessagesRead = 0;
+        int returnCode = 0;
+
+        try (PulsarClient client = clientBuilder.get().build()) {
+            Schema<?> schema = poolMessages ? Schema.BYTEBUFFER : Schema.BYTES;
+            if ("auto_consume".equals(schemaType)) {
+                schema = Schema.AUTO_CONSUME();
+            } else if (!"bytes".equals(schemaType)) {
+                throw new IllegalArgumentException("schema type must be 'bytes' or 'auto_consume'");
+            }
+            ReaderBuilder<?> builder = client.newReader(schema)
+                    .topic(topic)
+                    .startMessageId(parseMessageId(startMessageId))
+                    .poolMessages(poolMessages);
+
+            if (this.startMessageIdInclusive) {
+                builder.startMessageIdInclusive();
+            }
+            if (this.maxPendingChunkedMessage > 0) {
+                builder.maxPendingChunkedMessage(this.maxPendingChunkedMessage);
+            }
+            if (this.receiverQueueSize > 0) {
+                builder.receiverQueueSize(this.receiverQueueSize);
+            }
+
+            builder.autoAckOldestChunkedMessageOnQueueFull(this.autoAckOldestChunkedMessageOnQueueFull);
+            builder.cryptoFailureAction(cryptoFailureAction);
+
+            if (isNotBlank(this.encKeyValue)) {
+                builder.defaultCryptoKeyReader(this.encKeyValue);
+            }
+
+            try (Reader<?> reader = builder.create()) {
+                RateLimiter limiter = (this.readRate > 0) ? RateLimiter.create(this.readRate) : null;
+                while (this.numMessagesToRead == 0 || numMessagesRead < this.numMessagesToRead) {
+                    if (limiter != null) {
+                        limiter.acquire();
+                    }
+
+                    Message<?> msg = reader.readNext(5, TimeUnit.SECONDS);
+                    if (msg == null) {
+                        LOG.debug("No message to read after waiting for 5 seconds.");
+                    } else {
+                        try {
+                            numMessagesRead += 1;
+                            if (!hideContent) {
+                                System.out.println(MESSAGE_BOUNDARY);
+                                System.out.println(
+                                        V4MessageSupport.interpretMessage(msg, displayHex, printMetadata));
+                            } else if (numMessagesRead % 1000 == 0) {
+                                System.out.println("Received " + numMessagesRead + " messages");
+                            }
+                        } finally {
+                            msg.release();
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            LOG.error("Error while reading messages");
+            LOG.error(e.getMessage(), e);
+            returnCode = -1;
+        } finally {
+            LOG.info("{} messages successfully read", numMessagesRead);
+        }
+
+        return returnCode;
+    }
+
+    @VisibleForTesting
+    static MessageId parseMessageId(String msgIdStr) {
+        MessageId msgId;
+        if (START_LATEST.equals(msgIdStr)) {
+            msgId = MessageId.latest;
+        } else if (START_EARLIEST.equals(msgIdStr)) {
+            msgId = MessageId.earliest;
+        } else {
+            Matcher matcher = MSG_ID_PATTERN.matcher(msgIdStr);
+            if (matcher.find()) {
+                msgId = new MessageIdImpl(Long.parseLong(matcher.group(1)), Long.parseLong(matcher.group(2)), -1);
+            } else {
+                throw new IllegalArgumentException("Message ID must be 'latest', 'earliest' or '<ledgerId>:<entryId>'");
+            }
+        }
+        return msgId;
+    }
+}

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/PulsarClientTool.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/PulsarClientTool.java
@@ -22,14 +22,19 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.FileInputStream;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
+import java.util.function.Supplier;
 import lombok.Getter;
 import lombok.SneakyThrows;
 import org.apache.pulsar.cli.converters.picocli.ByteUnitToLongConverter;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.AuthenticationFactory;
+import org.apache.pulsar.client.api.ClientBuilder;
 import org.apache.pulsar.client.api.ProxyProtocol;
 import org.apache.pulsar.client.api.PulsarClientException.UnsupportedAuthenticationException;
+import org.apache.pulsar.client.api.SizeUnit;
 import org.apache.pulsar.client.api.v5.PulsarClient;
 import org.apache.pulsar.client.api.v5.PulsarClientBuilder;
 import org.apache.pulsar.client.api.v5.config.ConnectionPolicy;
@@ -103,6 +108,9 @@ public class PulsarClientTool implements CommandHook {
     protected CmdProduce produceCommand;
     protected CmdConsume consumeCommand;
     protected CmdRead readCommand;
+    protected CmdProduceV4 produceV4Command;
+    protected CmdConsumeV4 consumeV4Command;
+    protected CmdReadV4 readV4Command;
     CmdGenerateDocumentation generateDocumentation;
 
     public PulsarClientTool(Properties properties) {
@@ -122,6 +130,9 @@ public class PulsarClientTool implements CommandHook {
         produceCommand = new CmdProduce();
         consumeCommand = new CmdConsume();
         readCommand = new CmdRead();
+        produceV4Command = new CmdProduceV4();
+        consumeV4Command = new CmdConsumeV4();
+        readV4Command = new CmdReadV4();
         generateDocumentation = new CmdGenerateDocumentation();
 
         pulsarClientPropertiesProvider = PulsarClientPropertiesProvider.create(properties);
@@ -129,6 +140,13 @@ public class PulsarClientTool implements CommandHook {
         commander.addSubcommand("produce", produceCommand);
         commander.addSubcommand("consume", consumeCommand);
         commander.addSubcommand("read", readCommand);
+        // The same commands driven by the v4 (pulsar-client-original) client, for the capabilities
+        // the V5 client cannot express: KeyValue schemas, non-durable subscriptions, a real topic
+        // regex, --start-timestamp, the v4 Reader with a <ledgerId>:<entryId> start position, and
+        // the client.conf keys that have no dedicated CLI flag.
+        commander.addSubcommand("produce-v4", produceV4Command);
+        commander.addSubcommand("consume-v4", consumeV4Command);
+        commander.addSubcommand("read-v4", readV4Command);
         commander.addSubcommand("generate_documentation", generateDocumentation);
         enableCaseInsensitiveEnums();
     }
@@ -155,7 +173,7 @@ public class PulsarClientTool implements CommandHook {
     }
 
     private int updateConfig() throws UnsupportedAuthenticationException {
-        Properties properties = pulsarClientPropertiesProvider.getProperties();
+        final Properties properties = pulsarClientPropertiesProvider.getProperties();
 
         PulsarClientBuilder clientBuilder = PulsarClient.builder()
                 .memoryLimit(MemorySize.ofBytes(rootParams.memoryLimit));
@@ -200,7 +218,50 @@ public class PulsarClientTool implements CommandHook {
         this.produceCommand.updateConfig(clientBuilder, authentication, this.rootParams.serviceURL);
         this.consumeCommand.updateConfig(clientBuilder, authentication, this.rootParams.serviceURL);
         this.readCommand.updateConfig(clientBuilder, authentication, this.rootParams.serviceURL);
+
+        // Deliberately a supplier rather than a built builder: this method is the preRun() hook and
+        // runs for every invocation, including `--help`, `generate_documentation` and the V5
+        // commands. Building the v4 builder here would make all of them depend on a service URL and
+        // on client.conf keys that only the v4 client parses. It is resolved when a *-v4 command
+        // actually runs.
+        final Authentication v4Authentication = authentication;
+        Supplier<ClientBuilder> v4ClientBuilder = () -> buildV4ClientBuilder(properties, v4Authentication);
+        this.produceV4Command.updateConfig(v4ClientBuilder, authentication, this.rootParams.serviceURL);
+        this.consumeV4Command.updateConfig(v4ClientBuilder, authentication, this.rootParams.serviceURL);
+        this.readV4Command.updateConfig(v4ClientBuilder, authentication, this.rootParams.serviceURL);
         return 0;
+    }
+
+    /**
+     * Build the v4 client for the {@code *-v4} subcommands. Unlike the V5 builder this one keeps
+     * {@code loadConf}, so every {@code client.conf} key still applies without a hand-written
+     * translation, and it accepts {@code http://} / {@code https://} service URLs.
+     */
+    @VisibleForTesting
+    ClientBuilder buildV4ClientBuilder(Properties properties, Authentication authentication) {
+        Map<String, Object> conf = new HashMap<>();
+        for (String key : properties.stringPropertyNames()) {
+            conf.put(key, properties.getProperty(key));
+        }
+
+        // Fully qualified: the unqualified PulsarClient in this file is the V5 one.
+        ClientBuilder clientBuilder = org.apache.pulsar.client.api.PulsarClient.builder().loadConf(conf)
+                .memoryLimit(rootParams.memoryLimit, SizeUnit.BYTES);
+        if (authentication != null) {
+            clientBuilder.authentication(authentication);
+        }
+        if (isNotBlank(this.rootParams.listenerName)) {
+            clientBuilder.listenerName(this.rootParams.listenerName);
+        }
+        clientBuilder.serviceUrl(rootParams.serviceURL);
+        clientBuilder.tlsTrustCertsFilePath(this.rootParams.tlsTrustCertsFilePath);
+        if (isNotBlank(rootParams.proxyServiceURL)) {
+            if (rootParams.proxyProtocol == null) {
+                throw new IllegalArgumentException("proxy-protocol must be provided with proxy-url");
+            }
+            clientBuilder.proxyServiceUrl(rootParams.proxyServiceURL, rootParams.proxyProtocol);
+        }
+        return clientBuilder;
     }
 
     /**

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/PulsarClientTool.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/PulsarClientTool.java
@@ -253,12 +253,19 @@ public class PulsarClientTool implements CommandHook {
         if (isNotBlank(this.rootParams.listenerName)) {
             clientBuilder.listenerName(this.rootParams.listenerName);
         }
+        // Both are applied unconditionally on purpose. rootParams is itself populated from these
+        // same properties (each option declares the client.conf key as its descriptionKey, and the
+        // commander's default-value provider is a PropertiesDefaultProvider over them), so this
+        // rewrites the value loadConf already applied, or applies the CLI override. serviceUrl is
+        // additionally load-bearing: loadConf only reads the `serviceUrl` key, while client.conf
+        // supplies `brokerServiceUrl` / `webServiceUrl`.
         clientBuilder.serviceUrl(rootParams.serviceURL);
         clientBuilder.tlsTrustCertsFilePath(this.rootParams.tlsTrustCertsFilePath);
+        // A missing proxy protocol is already rejected by updateConfig(), the preRun() hook that
+        // creates this supplier, and again by ClientBuilderImpl.proxyServiceUrl(). The blank check
+        // stays because that same re-check rejects a null protocol: without a proxy configured at
+        // all, calling through would throw rather than leave the proxy unset.
         if (isNotBlank(rootParams.proxyServiceURL)) {
-            if (rootParams.proxyProtocol == null) {
-                throw new IllegalArgumentException("proxy-protocol must be provided with proxy-url");
-            }
             clientBuilder.proxyServiceUrl(rootParams.proxyServiceURL, rootParams.proxyProtocol);
         }
         return clientBuilder;

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/V4MessageSupport.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/V4MessageSupport.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.cli;
+
+import static org.apache.pulsar.client.cli.AbstractCmdConsume.interpretByteArray;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.schema.Field;
+import org.apache.pulsar.client.api.schema.GenericObject;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.apache.pulsar.common.api.EncryptionContext;
+import org.apache.pulsar.common.schema.KeyValue;
+import org.apache.pulsar.common.util.DateFormatter;
+
+/**
+ * Message rendering for the v4-client consume and read commands. Keeps the metadata the v4 tool
+ * printed and the V5 {@code Message} interface does not expose: the encryption context, the
+ * formatted broker publish and event times, the ordering key, the schema version and the index.
+ */
+final class V4MessageSupport {
+
+    private V4MessageSupport() {
+    }
+
+    /**
+     * Interprets the message to create a string representation.
+     *
+     * @param message the message to interpret
+     * @param displayHex whether to display BytesMessages in hexdump style, ignored for simple text messages
+     * @param printMetadata whether to append the message metadata
+     * @return String representation of the message
+     */
+    static String interpretMessage(Message<?> message, boolean displayHex, boolean printMetadata)
+            throws IOException {
+        StringBuilder sb = new StringBuilder();
+
+        String properties = Arrays.toString(message.getProperties().entrySet().toArray());
+
+        String data;
+        Object value = message.getValue();
+        if (value == null) {
+            data = "null";
+        } else if (value instanceof byte[]) {
+            data = interpretByteArray(displayHex, (byte[]) value);
+        } else if (value instanceof GenericObject) {
+            data = genericObjectToMap((GenericObject) value, displayHex).toString();
+        } else if (value instanceof ByteBuffer) {
+            data = new String(getBytes((ByteBuffer) value));
+        } else {
+            data = value.toString();
+        }
+
+        sb.append("publishTime:[").append(message.getPublishTime()).append("], ");
+        sb.append("eventTime:[").append(message.getEventTime()).append("], ");
+
+        String key = null;
+        if (message.hasKey()) {
+            key = message.getKey();
+        }
+
+        sb.append("key:[").append(key).append("], ");
+        if (!properties.isEmpty()) {
+            sb.append("properties:").append(properties).append(", ");
+        }
+        sb.append("content:").append(data);
+
+        if (printMetadata) {
+            appendEncryptionContext(sb, message);
+            if (message.hasBrokerPublishTime()) {
+                sb.append(", ").append("publish-time:").append(DateFormatter.format(message.getPublishTime()));
+            }
+            sb.append(", ").append("event-time:").append(DateFormatter.format(message.getEventTime()));
+            sb.append(", ").append("message-id:").append(message.getMessageId());
+            sb.append(", ").append("producer-name:").append(message.getProducerName());
+            sb.append(", ").append("sequence-id:").append(message.getSequenceId());
+            sb.append(", ").append("replicated-from:").append(message.getReplicatedFrom());
+            sb.append(", ").append("redelivery-count:").append(message.getRedeliveryCount());
+            sb.append(", ").append("ordering-key:")
+                    .append(message.getOrderingKey() != null ? new String(message.getOrderingKey()) : "");
+            sb.append(", ").append("schema-version:")
+                    .append(message.getSchemaVersion() != null ? new String(message.getSchemaVersion()) : "");
+            if (message.hasIndex()) {
+                sb.append(", ").append("index:").append(message.getIndex());
+            }
+        }
+
+        return sb.toString();
+    }
+
+    private static void appendEncryptionContext(StringBuilder sb, Message<?> message) {
+        if (message.getEncryptionCtx().isEmpty()) {
+            return;
+        }
+        EncryptionContext encContext = message.getEncryptionCtx().get();
+        if (encContext.getKeys() == null || encContext.getKeys().isEmpty()) {
+            return;
+        }
+        sb.append(", ");
+        sb.append("encryption-keys:").append(", ");
+        encContext.getKeys().forEach((keyName, keyInfo) -> {
+            String metadata = Arrays.toString(keyInfo.getMetadata().entrySet().toArray());
+            sb.append("name:").append(keyName).append(", ").append("key-value:")
+                    .append(Base64.getEncoder().encodeToString(keyInfo.getKeyValue())).append(", ")
+                    .append("metadata:").append(metadata).append(", ");
+        });
+        sb.append(", ").append("param:").append(Base64.getEncoder().encodeToString(encContext.getParam()))
+                .append(", ").append("algorithm:").append(encContext.getAlgorithm()).append(", ")
+                .append("compression-type:").append(encContext.getCompressionType()).append(", ")
+                .append("uncompressed-size").append(encContext.getUncompressedMessageSize()).append(", ")
+                .append("batch-size")
+                .append(encContext.getBatchSize().isPresent() ? encContext.getBatchSize().get() : 1);
+    }
+
+    static byte[] getBytes(ByteBuffer buffer) {
+        buffer = buffer.duplicate();
+        byte[] bytes = new byte[buffer.remaining()];
+        buffer.get(bytes);
+        return bytes;
+    }
+
+    static Map<String, Object> genericObjectToMap(GenericObject value, boolean displayHex)
+            throws IOException {
+        switch (value.getSchemaType()) {
+            case AVRO:
+            case JSON:
+            case PROTOBUF_NATIVE:
+                return genericRecordToMap((GenericRecord) value, displayHex);
+            case KEY_VALUE:
+                return keyValueToMap((KeyValue<?, ?>) value.getNativeObject(), displayHex);
+            default:
+                return primitiveValueToMap(value.getNativeObject(), displayHex);
+        }
+    }
+
+    static Map<String, Object> keyValueToMap(KeyValue<?, ?> value, boolean displayHex) throws IOException {
+        if (value == null) {
+            return Map.of("value", "NULL");
+        }
+        return Map.of("key", primitiveValueToMap(value.getKey(), displayHex),
+                "value", primitiveValueToMap(value.getValue(), displayHex));
+    }
+
+    static Map<String, Object> primitiveValueToMap(Object value, boolean displayHex) throws IOException {
+        if (value == null) {
+            return Map.of("value", "NULL");
+        }
+        if (value instanceof GenericObject) {
+            return genericObjectToMap((GenericObject) value, displayHex);
+        }
+        if (value instanceof byte[]) {
+            value = interpretByteArray(displayHex, (byte[]) value);
+        }
+        return Map.of("value", value.toString(), "type", value.getClass());
+    }
+
+    static Map<String, Object> genericRecordToMap(GenericRecord value, boolean displayHex)
+            throws IOException {
+        Map<String, Object> res = new HashMap<>();
+        for (Field f : value.getFields()) {
+            Object fieldValue = value.getField(f);
+            if (fieldValue instanceof GenericRecord) {
+                fieldValue = genericRecordToMap((GenericRecord) fieldValue, displayHex);
+            } else if (fieldValue == null) {
+                fieldValue = "NULL";
+            } else if (fieldValue instanceof byte[]) {
+                fieldValue = interpretByteArray(displayHex, (byte[]) fieldValue);
+            }
+            res.put(f.getName(), fieldValue);
+        }
+        return res;
+    }
+}

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/V5MessageSupport.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/V5MessageSupport.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.cli;
+
+import static org.apache.pulsar.client.cli.AbstractCmd.fileUriToPath;
+import static org.apache.pulsar.client.cli.AbstractCmdConsume.interpretByteArray;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import org.apache.pulsar.client.api.v5.Message;
+import org.apache.pulsar.client.api.v5.auth.ConsumerCryptoFailureAction;
+import org.apache.pulsar.client.api.v5.auth.EncryptionKey;
+import org.apache.pulsar.client.api.v5.auth.PrivateKeyProvider;
+import org.apache.pulsar.client.api.v5.config.ConsumerEncryptionPolicy;
+import org.apache.pulsar.client.api.v5.schema.Field;
+import org.apache.pulsar.client.api.v5.schema.GenericRecord;
+import org.apache.pulsar.client.api.v5.schema.KeyValue;
+
+/**
+ * Message rendering and decryption wiring for the V5-client consume and read commands.
+ */
+final class V5MessageSupport {
+
+    private V5MessageSupport() {
+    }
+
+    /**
+     * Interprets the message to create a string representation.
+     *
+     * @param message the message to interpret
+     * @param displayHex whether to display BytesMessages in hexdump style, ignored for simple text messages
+     * @param printMetadata whether to append the message metadata
+     * @return String representation of the message
+     */
+    static String interpretMessage(Message<?> message, boolean displayHex, boolean printMetadata)
+            throws IOException {
+        StringBuilder sb = new StringBuilder();
+
+        String properties = Arrays.toString(message.properties().entrySet().toArray());
+
+        Object value = message.value();
+        String data;
+        if (value == null) {
+            data = "null";
+        } else if (value instanceof byte[]) {
+            data = interpretByteArray(displayHex, (byte[]) value);
+        } else if (value instanceof GenericRecord) {
+            data = genericObjectToMap((GenericRecord) value, displayHex).toString();
+        } else {
+            data = value.toString();
+        }
+
+        sb.append("publishTime:[").append(message.publishTime()).append("], ");
+        sb.append("eventTime:[").append(message.eventTime().orElse(null)).append("], ");
+        sb.append("key:[").append(message.key().orElse(null)).append("], ");
+        if (!properties.isEmpty()) {
+            sb.append("properties:").append(properties).append(", ");
+        }
+        sb.append("content:").append(data);
+
+        if (printMetadata) {
+            sb.append(", ").append("message-id:").append(message.id());
+            sb.append(", ").append("producer-name:").append(message.producerName().orElse(null));
+            sb.append(", ").append("sequence-id:").append(message.sequenceId());
+            sb.append(", ").append("replicated-from:").append(message.replicatedFrom().orElse(null));
+            sb.append(", ").append("redelivery-count:").append(message.redeliveryCount());
+        }
+
+        return sb.toString();
+    }
+
+    /**
+     * Render an {@code auto_consume} {@link GenericRecord} value into a {@link Map} for display.
+     * The shape is dispatched on the record's runtime schema type: structured records become a map
+     * of their fields, key/value records become a {@code {key, value}} map, and primitives are
+     * wrapped in a single {@code value} entry.
+     */
+    static Map<String, Object> genericObjectToMap(GenericRecord value, boolean displayHex)
+            throws IOException {
+        switch (value.schemaType()) {
+            case AVRO:
+            case JSON:
+            case PROTOBUF_NATIVE:
+                return genericRecordToMap(value, displayHex);
+            case KEY_VALUE:
+                return keyValueToMap((KeyValue<?, ?>) value.nativeObject(), displayHex);
+            default:
+                return primitiveValueToMap(value.nativeObject(), displayHex);
+        }
+    }
+
+    static Map<String, Object> keyValueToMap(KeyValue<?, ?> value, boolean displayHex)
+            throws IOException {
+        if (value == null) {
+            return Map.of("value", "NULL");
+        }
+        return Map.of("key", primitiveValueToMap(value.key(), displayHex),
+                "value", primitiveValueToMap(value.value(), displayHex));
+    }
+
+    static Map<String, Object> primitiveValueToMap(Object value, boolean displayHex)
+            throws IOException {
+        if (value == null) {
+            return Map.of("value", "NULL");
+        }
+        if (value instanceof GenericRecord) {
+            return genericObjectToMap((GenericRecord) value, displayHex);
+        }
+        if (value instanceof byte[]) {
+            value = interpretByteArray(displayHex, (byte[]) value);
+        }
+        return Map.of("value", value.toString(), "type", value.getClass());
+    }
+
+    static Map<String, Object> genericRecordToMap(GenericRecord value, boolean displayHex)
+            throws IOException {
+        Map<String, Object> res = new HashMap<>();
+        for (Field f : value.fields()) {
+            Object fieldValue = value.field(f);
+            if (fieldValue instanceof GenericRecord) {
+                fieldValue = genericRecordToMap((GenericRecord) fieldValue, displayHex);
+            } else if (fieldValue == null) {
+                fieldValue = "NULL";
+            } else if (fieldValue instanceof byte[]) {
+                fieldValue = interpretByteArray(displayHex, (byte[]) fieldValue);
+            }
+            res.put(f.name(), fieldValue);
+        }
+        return res;
+    }
+
+    /**
+     * Build a consumer-side decryption policy from a {@code file://} key URI, mirroring the v4
+     * {@code defaultCryptoKeyReader(uri)} semantics: the private key is loaded once and returned
+     * for any key name. (The producer's logical key name travels in the message metadata, so a
+     * name-keyed provider would not resolve it; the CLI's file-based flow has a single key.)
+     */
+    static ConsumerEncryptionPolicy buildFileDecryptionPolicy(
+            String keyUri, ConsumerCryptoFailureAction failureAction) {
+        final byte[] keyBytes;
+        try {
+            keyBytes = Files.readAllBytes(fileUriToPath(keyUri));
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Failed to read decryption key from " + keyUri, e);
+        }
+        PrivateKeyProvider provider = (keyName, metadata) ->
+                CompletableFuture.completedFuture(EncryptionKey.of(keyBytes));
+        return ConsumerEncryptionPolicy.builder()
+                .privateKeyProvider(provider)
+                .failureAction(failureAction)
+                .build();
+    }
+}

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/client/cli/CmdV4CommandsTest.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/client/cli/CmdV4CommandsTest.java
@@ -21,9 +21,12 @@ package org.apache.pulsar.client.cli;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
+import java.util.TreeSet;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.impl.MessageIdImpl;
@@ -228,10 +231,10 @@ public class CmdV4CommandsTest {
                 .hasMessageContaining("start timestamp should be positive");
     }
 
-    private static java.util.Set<String> optionNames(CommandLine commander, String subcommand) {
-        java.util.Set<String> names = new java.util.TreeSet<>();
+    private static Set<String> optionNames(CommandLine commander, String subcommand) {
+        Set<String> names = new TreeSet<>();
         commander.getSubcommands().get(subcommand).getCommandSpec().options()
-                .forEach(option -> names.addAll(java.util.Arrays.asList(option.names())));
+                .forEach(option -> names.addAll(Arrays.asList(option.names())));
         return names;
     }
 }

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/client/cli/CmdV4CommandsTest.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/client/cli/CmdV4CommandsTest.java
@@ -1,0 +1,237 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.cli;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import java.util.Base64;
+import java.util.Map;
+import java.util.Properties;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.impl.MessageIdImpl;
+import org.apache.pulsar.common.schema.KeyValueEncodingType;
+import org.apache.pulsar.common.schema.SchemaType;
+import org.testng.annotations.Test;
+import picocli.CommandLine;
+
+/**
+ * The {@code produce-v4} / {@code consume-v4} / {@code read-v4} subcommands and the v4-only
+ * capabilities they restore.
+ */
+public class CmdV4CommandsTest {
+
+    @Test
+    public void testAllSubcommandsAreRegisteredUnderTheirOwnName() {
+        CommandLine commander = new PulsarClientTool(new Properties()).getCommander();
+
+        Map<String, CommandLine> subcommands = commander.getSubcommands();
+        assertThat(subcommands.keySet()).contains(
+                "produce", "consume", "read", "produce-v4", "consume-v4", "read-v4",
+                "generate_documentation");
+
+        subcommands.forEach((name, cmd) -> {
+            assertThat(cmd.getCommandSpec().name())
+                    .as("spec name of subcommand '%s'", name)
+                    .isEqualTo(name);
+            assertThat(cmd.getCommandSpec().usageMessage().description())
+                    .as("description of subcommand '%s'", name)
+                    .isNotEmpty();
+        });
+    }
+
+    /** The v4 commands must offer at least the flags of their V5 counterpart. */
+    @Test
+    public void testV4CommandsOfferTheirV5CounterpartsFlags() {
+        CommandLine commander = new PulsarClientTool(new Properties()).getCommander();
+
+        assertThat(optionNames(commander, "produce-v4"))
+                .containsAll(optionNames(commander, "produce"));
+        assertThat(optionNames(commander, "consume-v4"))
+                .containsAll(optionNames(commander, "consume"))
+                // v4-only: the V5 QueueConsumer cannot seek to a timestamp.
+                .contains("--start-timestamp");
+        assertThat(optionNames(commander, "read-v4"))
+                .containsAll(optionNames(commander, "read"));
+    }
+
+    /** Case-insensitive enum parsing must reach the v4 subcommands too. */
+    @Test
+    public void testCaseInsensitiveEnumsOnV4Subcommands() {
+        CommandLine commander = new PulsarClientTool(new Properties()).getCommander();
+        commander.parseArgs("consume-v4", "-s", "sub", "-t", "key_shared", "-m", "nondurable",
+                "-p", "earliest", "my-topic");
+
+        CmdConsumeV4 cmd = commander.getSubcommands().get("consume-v4").getCommand();
+        assertThat(cmd.subscriptionType).isEqualTo(AbstractCmdConsumeCommand.SubscriptionType.Key_Shared);
+        assertThat(cmd.subscriptionMode).isEqualTo(AbstractCmdConsumeCommand.SubscriptionMode.NonDurable);
+    }
+
+    /** KeyValue schemas are the headline capability {@code produce} lost and {@code produce-v4} keeps. */
+    @Test
+    public void testProduceV4BuildsKeyValueSchemas() {
+        Schema<?> separated = CmdProduceV4.buildSchema("string", "bytes", "separated");
+        assertThat(separated.getSchemaInfo().getType()).isEqualTo(SchemaType.KEY_VALUE);
+        assertThat(KeyValueEncodingType.valueOf(
+                separated.getSchemaInfo().getProperties().get("kv.encoding.type")))
+                .isEqualTo(KeyValueEncodingType.SEPARATED);
+
+        Schema<?> inline = CmdProduceV4.buildSchema("string", "bytes", "inline");
+        assertThat(inline.getSchemaInfo().getType()).isEqualTo(SchemaType.KEY_VALUE);
+        assertThat(KeyValueEncodingType.valueOf(
+                inline.getSchemaInfo().getProperties().get("kv.encoding.type")))
+                .isEqualTo(KeyValueEncodingType.INLINE);
+
+        // No encoding type: a plain value schema, as before.
+        assertThat(CmdProduceV4.buildSchema("string", "bytes", "").getSchemaInfo().getType())
+                .isEqualTo(SchemaType.BYTES);
+    }
+
+    /**
+     * The v4 client builder must be built only when a {@code *-v4} command actually runs. It is
+     * resolved from {@code preRun()}, which runs for every invocation, and building it validates
+     * the service URL and parses the whole {@code client.conf} — so an eager build would make
+     * {@code --help}, {@code generate_documentation} and the V5 commands fail on configurations
+     * they never needed a v4 client for.
+     */
+    @Test
+    public void testCommandsThatNeedNoV4ClientRunWithoutAServiceUrl() {
+        // No brokerServiceUrl / webServiceUrl / serviceUrl anywhere: rootParams.serviceURL stays null.
+        PulsarClientTool tool = new PulsarClientTool(new Properties());
+        assertThat(tool.run(new String[]{"--help"})).isZero();
+        assertThat(tool.run(new String[]{"generate_documentation", "-n", "produce"})).isZero();
+    }
+
+    /**
+     * Only the v4 client parses these {@code client.conf} keys, so they must not reach any other
+     * command: {@code sslFactoryPlugin} is rejected outright by the v4 configuration loader
+     * (PIP-478 removed it) and {@code tlsProtocols} is a typed {@code Set} field that a plain
+     * string fails to deserialize into.
+     */
+    @Test
+    public void testV4OnlyConfKeysDoNotBreakTheOtherCommands() {
+        Properties properties = new Properties();
+        properties.setProperty("brokerServiceUrl", "pulsar://localhost:6650");
+        properties.setProperty("sslFactoryPlugin", "com.acme.MyCustomSslFactory");
+        properties.setProperty("tlsProtocols", "TLSv1.3");
+
+        PulsarClientTool tool = new PulsarClientTool(properties);
+        assertThat(tool.run(new String[]{"--help"})).isZero();
+        assertThat(tool.run(new String[]{"generate_documentation", "-n", "produce"})).isZero();
+    }
+
+    @Test
+    public void testProduceRejectsKeyValueEncodingTypeAndProduceV4AcceptsIt() {
+        CmdProduce v5 = new CmdProduce();
+        new CommandLine(v5).parseArgs("-kvet", "separated", "-m", "a", "my-topic");
+        assertThatThrownBy(v5::validateSchemaOptions)
+                .hasMessageContaining("KeyValue schemas");
+
+        CmdProduceV4 v4 = new CmdProduceV4();
+        new CommandLine(v4).parseArgs("-kvet", "separated", "-m", "a", "my-topic");
+        assertThatCode(v4::validateSchemaOptions).doesNotThrowAnyException();
+
+        CmdProduceV4 invalid = new CmdProduceV4();
+        new CommandLine(invalid).parseArgs("-kvet", "nonsense", "-m", "a", "my-topic");
+        assertThatThrownBy(invalid::validateSchemaOptions)
+                .hasMessageContaining("only 'separated' or 'inline'");
+
+        // An explicitly-empty value is a supplied value, not an absent flag: the pre-migration v4
+        // command rejected it, and producing a plain BYTES message instead would silently give a
+        // KeyValue-schema consumer the wrong message shape.
+        CmdProduceV4 empty = new CmdProduceV4();
+        new CommandLine(empty).parseArgs("-kvet", "", "-m", "a", "my-topic");
+        assertThatThrownBy(empty::validateSchemaOptions)
+                .hasMessageContaining("only 'separated' or 'inline'");
+
+        // ... while an absent flag is fine on both.
+        CmdProduceV4 absent = new CmdProduceV4();
+        new CommandLine(absent).parseArgs("-m", "a", "my-topic");
+        assertThatCode(absent::validateSchemaOptions).doesNotThrowAnyException();
+        CmdProduce absentV5 = new CmdProduce();
+        new CommandLine(absentV5).parseArgs("-m", "a", "my-topic");
+        assertThatCode(absentV5::validateSchemaOptions).doesNotThrowAnyException();
+    }
+
+    @Test
+    public void testReadV4ParsesASpecificMessageId() {
+        assertThat(CmdReadV4.parseMessageId("latest")).isEqualTo(MessageId.latest);
+        assertThat(CmdReadV4.parseMessageId("earliest")).isEqualTo(MessageId.earliest);
+
+        MessageIdImpl parsed = (MessageIdImpl) CmdReadV4.parseMessageId("12:34");
+        assertThat(parsed.getLedgerId()).isEqualTo(12L);
+        assertThat(parsed.getEntryId()).isEqualTo(34L);
+
+        assertThatThrownBy(() -> CmdReadV4.parseMessageId("nope"))
+                .hasMessageContaining("'<ledgerId>:<entryId>'");
+    }
+
+    @Test
+    public void testReadRejectsASpecificMessageIdAndReadV4AcceptsIt() {
+        CmdRead v5 = new CmdRead();
+        new CommandLine(v5).parseArgs("-m", "12:34", "my-topic");
+        assertThatThrownBy(v5::validateArguments)
+                .hasMessageContaining("<ledgerId>:<entryId>");
+
+        CmdReadV4 v4 = new CmdReadV4();
+        new CommandLine(v4).parseArgs("-m", "12:34", "my-topic");
+        assertThatCode(v4::validateArguments).doesNotThrowAnyException();
+    }
+
+    /** Over WebSocket the v4 reader encodes a specific message id; the V5 one only has the names. */
+    @Test
+    public void testReadV4WebSocketUriCarriesTheEncodedMessageId() {
+        CmdReadV4 v4 = new CmdReadV4();
+        new CommandLine(v4).parseArgs("-m", "12:34", "persistent://public/default/t");
+        v4.updateConfig(null, null, "ws://localhost:8080/");
+
+        String expectedId = Base64.getEncoder()
+                .encodeToString(new MessageIdImpl(12, 34, -1).toByteArray());
+        assertThat(v4.getWebSocketReadUri("persistent://public/default/t"))
+                .isEqualTo("ws://localhost:8080/ws/v2/reader/persistent/public/default/t"
+                        + "?messageId=" + expectedId);
+
+        CmdReadV4 earliest = new CmdReadV4();
+        new CommandLine(earliest).parseArgs("-m", "earliest", "persistent://public/default/t");
+        earliest.updateConfig(null, null, "ws://localhost:8080/");
+        assertThat(earliest.getWebSocketReadUri("persistent://public/default/t"))
+                .endsWith("?messageId=earliest");
+    }
+
+    @Test
+    public void testConsumeV4RejectsAnInconsistentTimestampRange() {
+        CmdConsumeV4 cmd = new CmdConsumeV4();
+        new CommandLine(cmd).parseArgs("-s", "sub", "-stp", "100", "-etp", "50", "my-topic");
+        assertThatThrownBy(cmd::validateArguments)
+                .hasMessageContaining("end timestamp should be greater than start timestamp");
+
+        CmdConsumeV4 negative = new CmdConsumeV4();
+        new CommandLine(negative).parseArgs("-s", "sub", "-stp", "-1", "my-topic");
+        assertThatThrownBy(negative::validateArguments)
+                .hasMessageContaining("start timestamp should be positive");
+    }
+
+    private static java.util.Set<String> optionNames(CommandLine commander, String subcommand) {
+        java.util.Set<String> names = new java.util.TreeSet<>();
+        commander.getSubcommands().get(subcommand).getCommandSpec().options()
+                .forEach(option -> names.addAll(java.util.Arrays.asList(option.names())));
+        return names;
+    }
+}

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/client/cli/TestCmdConsume.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/client/cli/TestCmdConsume.java
@@ -33,7 +33,7 @@ public class TestCmdConsume {
     public void setUp() throws Exception {
         cmdConsume = new CmdConsume();
         cmdConsume.updateConfig(null, null, "ws://localhost:8080/");
-        Field subscriptionNameField = CmdConsume.class.getDeclaredField("subscriptionName");
+        Field subscriptionNameField = AbstractCmdConsumeCommand.class.getDeclaredField("subscriptionName");
         subscriptionNameField.setAccessible(true);
         subscriptionNameField.set(cmdConsume, "my-sub");
     }

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/client/cli/TestCmdConsume.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/client/cli/TestCmdConsume.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.client.cli;
 
 import static org.testng.Assert.assertEquals;
-import java.lang.reflect.Field;
 import java.util.Properties;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
@@ -30,12 +29,10 @@ public class TestCmdConsume {
     CmdConsume cmdConsume;
 
     @BeforeMethod
-    public void setUp() throws Exception {
+    public void setUp() {
         cmdConsume = new CmdConsume();
         cmdConsume.updateConfig(null, null, "ws://localhost:8080/");
-        Field subscriptionNameField = AbstractCmdConsumeCommand.class.getDeclaredField("subscriptionName");
-        subscriptionNameField.setAccessible(true);
-        subscriptionNameField.set(cmdConsume, "my-sub");
+        cmdConsume.subscriptionName = "my-sub";
     }
 
     @Test

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/CmdGenerateDocumentation.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/CmdGenerateDocumentation.java
@@ -49,6 +49,10 @@ public class CmdGenerateDocumentation extends CmdBase{
         cmdClassMap.put("consume", PerformanceConsumer.class);
         cmdClassMap.put("transaction", PerformanceTransaction.class);
         cmdClassMap.put("read", PerformanceReader.class);
+        cmdClassMap.put("produce-v4", PerformanceProducerV4.class);
+        cmdClassMap.put("consume-v4", PerformanceConsumerV4.class);
+        cmdClassMap.put("transaction-v4", PerformanceTransactionV4.class);
+        cmdClassMap.put("read-v4", PerformanceReaderV4.class);
         cmdClassMap.put("monitor-brokers", BrokerMonitor.class);
         cmdClassMap.put("websocket-producer", PerformanceClient.class);
         cmdClassMap.put("managed-ledger", ManagedLedgerWriter.class);

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerfClientUtils.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerfClientUtils.java
@@ -57,9 +57,9 @@ public class PerfClientUtils {
      *
      * <p>HdrHistogram sizes a fixed-range histogram's counts array proportionally to
      * {@code 2^ceil(log2(2 * 10^digits))}, so every extra digit multiplies the allocation by
-     * roughly 10. At 5 digits (HdrHistogram's maximum) a single {@code Recorder} over the
-     * ranges used here costs 11-22 MB, and since these recorders are static fields the JVM
-     * pays for every perf subcommand, not just the one being run.
+     * roughly 10. At 5 digits (HdrHistogram's maximum) a single {@code Recorder} over the ranges
+     * used here costs 14-16 MB, and a command holds several of them (a live and a cumulative
+     * recorder per measured latency), so the running subcommand pays a multiple of that.
      *
      * <p>3 digits bounds the error of a reported percentile at 0.1%. That is far below the
      * run-to-run variance of a benchmark, and finer than the reports resolve anyway: the

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerfClientUtils.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerfClientUtils.java
@@ -40,6 +40,7 @@ import org.apache.pulsar.client.api.v5.PulsarClientBuilder;
 import org.apache.pulsar.client.api.v5.config.ConnectionPolicy;
 import org.apache.pulsar.client.api.v5.config.MemorySize;
 import org.apache.pulsar.client.api.v5.config.ProxyProtocol;
+import org.apache.pulsar.client.impl.ClientBuilderImpl;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.common.util.DirectMemoryUtils;
 import org.apache.pulsar.tls.TlsPolicy;
@@ -128,6 +129,22 @@ public class PerfClientUtils {
 
         if (isNotBlank(arguments.listenerName)) {
             clientBuilder.listenerName(arguments.listenerName);
+        }
+
+        // PIP-478: pin the same two provider axes the V5 builder and the admin builder pin, so that
+        // `pulsar-perf produce-v4 --jsse-provider/--jca-provider` really runs on those providers
+        // rather than silently falling back to the JVM provider search order. ClientBuilder has no
+        // fluent setter for either, so this mirrors createAdminBuilderFromArguments and writes them
+        // onto the underlying configuration.
+        if (clientBuilder instanceof ClientBuilderImpl clientBuilderImpl
+                && (isNotBlank(arguments.jsseProvider) || isNotBlank(arguments.jcaProvider))) {
+            ClientConfigurationData conf = clientBuilderImpl.getClientConfigurationData();
+            if (isNotBlank(arguments.jsseProvider)) {
+                conf.setJsseProvider(arguments.jsseProvider);
+            }
+            if (isNotBlank(arguments.jcaProvider)) {
+                conf.setJcaProvider(arguments.jcaProvider);
+            }
         }
         return clientBuilder;
     }

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
@@ -19,34 +19,19 @@
 package org.apache.pulsar.testclient;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
-import static org.apache.pulsar.testclient.PerfClientUtils.LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectWriter;
-import com.google.common.util.concurrent.RateLimiter;
 import io.netty.util.concurrent.DefaultThreadFactory;
-import java.io.FileOutputStream;
-import java.io.PrintStream;
 import java.nio.file.Path;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.atomic.LongAdder;
-import lombok.CustomLog;
-import org.HdrHistogram.Histogram;
-import org.HdrHistogram.HistogramLogWriter;
-import org.HdrHistogram.Recorder;
 import org.apache.pulsar.client.api.v5.Message;
 import org.apache.pulsar.client.api.v5.MessageId;
 import org.apache.pulsar.client.api.v5.PulsarClient;
 import org.apache.pulsar.client.api.v5.PulsarClientBuilder;
+import org.apache.pulsar.client.api.v5.PulsarClientException;
 import org.apache.pulsar.client.api.v5.QueueConsumer;
 import org.apache.pulsar.client.api.v5.QueueConsumerBuilder;
 import org.apache.pulsar.client.api.v5.StreamConsumer;
@@ -57,27 +42,18 @@ import org.apache.pulsar.client.api.v5.config.ConsumerEncryptionPolicy;
 import org.apache.pulsar.client.api.v5.config.SubscriptionInitialPosition;
 import org.apache.pulsar.client.api.v5.config.TransactionPolicy;
 import org.apache.pulsar.client.api.v5.schema.Schema;
-import org.apache.pulsar.common.naming.TopicName;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
+/**
+ * A client program to test pulsar consumer performance with the V5 client API.
+ *
+ * <p>Everything that is not V5-specific lives in {@link PerformanceConsumerBase}; the v4 client is
+ * driven by {@link PerformanceConsumerV4} under the {@code consume-v4} name.
+ */
 @Command(name = "consume", description = "Test pulsar consumer performance.")
-@CustomLog
-public class PerformanceConsumer extends PerformanceTopicListArguments{
-
-    /**
-     * Subscription type flag values. V5 has no single user-facing SubscriptionType enum
-     * (StreamConsumer / QueueConsumer / CheckpointConsumer are separate APIs); we accept
-     * the v4 names for back-compat and map them all to {@link QueueConsumer}, which gives
-     * Shared work-distribution semantics. {@code Exclusive} / {@code Failover} log a
-     * warning at run time — they are not exactly emulated.
-     */
-    public enum SubscriptionType {
-        Exclusive,
-        Shared,
-        Failover,
-        Key_Shared
-    }
+public class PerformanceConsumer
+        extends PerformanceConsumerBase<PulsarClient, PerformanceConsumer.PerfConsumer, Message<byte[]>, Transaction> {
 
     /**
      * Which V5 scalable-topic consumer API to drive. {@code Queue} gives unordered,
@@ -91,49 +67,6 @@ public class PerformanceConsumer extends PerformanceTopicListArguments{
         Stream
     }
 
-    private final LongAdder messagesReceived = new LongAdder();
-    private final LongAdder bytesReceived = new LongAdder();
-
-    private final LongAdder totalMessagesReceived = new LongAdder();
-    private final LongAdder totalBytesReceived = new LongAdder();
-
-    private final LongAdder totalNumTxnOpenFail = new LongAdder();
-    private final LongAdder totalNumTxnOpenSuccess = new LongAdder();
-
-    private final LongAdder totalMessageAck = new LongAdder();
-    private final LongAdder totalMessageAckFailed = new LongAdder();
-    private final LongAdder messageAck = new LongAdder();
-
-    private final LongAdder totalEndTxnOpFailNum = new LongAdder();
-    private final LongAdder totalEndTxnOpSuccessNum = new LongAdder();
-    private final LongAdder numTxnOpSuccess = new LongAdder();
-
-    private static final long MAX_LATENCY_MILLIS = TimeUnit.DAYS.toMillis(10);
-    private final Recorder recorder = new Recorder(MAX_LATENCY_MILLIS, LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS);
-    private final Recorder cumulativeRecorder =
-            new Recorder(MAX_LATENCY_MILLIS, LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS);
-
-    @Option(names = { "-n", "--num-consumers" }, description = "Number of consumers (per subscription), only "
-            + "one consumer is allowed when subscriptionType is Exclusive",
-            converter = PositiveNumberParameterConvert.class
-    )
-    public int numConsumers = 1;
-
-    @Option(names = { "-ns", "--num-subscriptions" }, description = "Number of subscriptions (per topic)",
-            converter = PositiveNumberParameterConvert.class
-    )
-    public int numSubscriptions = 1;
-
-    @Option(names = { "-s", "--subscriber-name" }, description = "Subscriber name prefix", hidden = true)
-    public String subscriberName;
-
-    @Option(names = { "-ss", "--subscriptions" },
-            description = "A list of subscriptions to consume (for example, sub1,sub2)")
-    public List<String> subscriptions = Collections.singletonList("sub");
-
-    @Option(names = { "-st", "--subscription-type" }, description = "Subscription type")
-    public SubscriptionType subscriptionType = SubscriptionType.Exclusive;
-
     @Option(names = { "-sct", "--scalable-consumer-type" },
             description = "V5 scalable-topic consumer API to use: Queue (unordered, individual ack) "
                     + "or Stream (ordered, cumulative ack, 1:1 segment assignment). Use Stream with "
@@ -143,125 +76,22 @@ public class PerformanceConsumer extends PerformanceTopicListArguments{
     @Option(names = { "-sp", "--subscription-position" }, description = "Subscription position")
     private SubscriptionInitialPosition subscriptionInitialPosition = SubscriptionInitialPosition.LATEST;
 
-    @Option(names = { "-r", "--rate" }, description = "Simulate a slow message consumer (rate in msg/s)")
-    public double rate = 0;
-
-    @Option(names = { "-q", "--receiver-queue-size" }, description = "Size of the receiver queue")
-    public int receiverQueueSize = 1000;
-
-    @Option(names = { "-p", "--receiver-queue-size-across-partitions" },
-            description = "Max total size of the receiver queue across partitions")
-    public int maxTotalReceiverQueueSizeAcrossPartitions = 50000;
-
-    @Option(names = {"-aq", "--auto-scaled-receiver-queue-size"},
-            description = "Enable autoScaledReceiverQueueSize")
-    public boolean autoScaledReceiverQueueSize = false;
-
-    @Option(names = {"-rs", "--replicated" },
-            description = "Whether the subscription status should be replicated")
-    public boolean replicatedSubscription = false;
-
-    @Option(names = { "--acks-delay-millis" }, description = "Acknowledgements grouping delay in millis")
-    public int acknowledgmentsGroupingDelayMillis = 100;
-
-    @Option(names = {"-m",
-            "--num-messages"},
-            description = "Number of messages to consume in total. If <= 0, it will keep consuming")
-    public long numMessages = 0;
-
-    @Option(names = { "-mc", "--max_chunked_msg" }, description = "Max pending chunk messages")
-    private int maxPendingChunkedMessage = 0;
-
-    @Option(names = { "-ac",
-            "--auto_ack_chunk_q_full" }, description = "Auto ack for oldest message on queue is full")
-    private boolean autoAckOldestChunkedMessageOnQueueFull = false;
-
-    @Option(names = { "-e",
-            "--expire_time_incomplete_chunked_messages" },
-            description = "Expire time in ms for incomplete chunk messages")
-    private long expireTimeOfIncompleteChunkedMessageMs = 0;
-
-    @Option(names = { "-v",
-            "--encryption-key-value-file" },
-            description = "The file which contains the private key to decrypt payload")
-    public String encKeyFile = null;
-
-    @Option(names = { "-time",
-            "--test-duration" }, description = "Test duration in secs. If <= 0, it will keep consuming")
-    public long testTime = 0;
-
-    @Option(names = {"--batch-index-ack" }, description = "Enable or disable the batch index acknowledgment")
-    public boolean batchIndexAck = false;
-
-    @Option(names = { "-pm", "--pool-messages" }, description = "Use the pooled message", arity = "1")
-    private boolean poolMessages = true;
-
-    @Option(names = {"-tto", "--txn-timeout"},  description = "Set the time value of transaction timeout,"
-            + " and the time unit is second. (After --txn-enable setting to true, --txn-timeout takes effect)")
-    public long transactionTimeout = 10;
-
-    @Option(names = {"-nmt", "--numMessage-perTransaction"},
-            description = "The number of messages acknowledged by a transaction. "
-                    + "(After --txn-enable setting to true, -numMessage-perTransaction takes effect")
-    public int numMessagesPerTransaction = 50;
-
-    @Option(names = {"-txn", "--txn-enable"}, description = "Enable or disable the transaction")
-    public boolean isEnableTransaction = false;
-
-    @Option(names = {"-ntxn"}, description = "The number of opened transactions, 0 means keeping open."
-            + "(After --txn-enable setting to true, -ntxn takes effect.)")
-    public long totalNumTxn = 0;
-
-    @Option(names = {"-abort"}, description = "Abort the transaction. (After --txn-enable "
-            + "setting to true, -abort takes effect)")
-    public boolean isAbortTransaction = false;
-
-    @Option(names = { "--histogram-file" }, description = "HdrHistogram output file")
-    public String histogramFile = null;
+    private ConsumerEncryptionPolicy encryptionPolicy;
+    private ExecutorService consumerExec;
 
     public PerformanceConsumer() {
         super("consume");
     }
 
-
     @Override
-    public void validate() throws Exception {
-        super.validate();
-        if (subscriptionType == SubscriptionType.Exclusive && numConsumers > 1) {
-            throw new Exception("Only one consumer is allowed when subscriptionType is Exclusive");
-        }
-
-        if (subscriptions != null && subscriptions.size() != numSubscriptions) {
-            // keep compatibility with the previous version
-            if (subscriptions.size() == 1) {
-                if (subscriberName == null) {
-                    subscriberName = subscriptions.get(0);
-                }
-                List<String> defaultSubscriptions = new ArrayList<>();
-                for (int i = 0; i < numSubscriptions; i++) {
-                    defaultSubscriptions.add(String.format("%s-%d", subscriberName, i));
-                }
-                subscriptions = defaultSubscriptions;
-            } else {
-                throw new Exception("The size of subscriptions list should be equal to --num-subscriptions");
-            }
-        }
-    }
-    @Override
-    public void run() throws Exception {
-
-        // Dump config variables
-        PerfClientUtils.printJVMInformation(log);
-        ObjectMapper m = new ObjectMapper();
-        ObjectWriter w = m.writerWithDefaultPrettyPrinter();
-        log.info().attr("config", w.writeValueAsString(this)).log("Starting Pulsar performance consumer with config");
-
+    protected void prepareRun() {
+        log.info().attr("consumerType", this.scalableConsumerType).log("Using V5 scalable-topic consumer API");
         if (this.subscriptionType == SubscriptionType.Exclusive
                 || this.subscriptionType == SubscriptionType.Failover) {
             log.warn().attr("type", this.subscriptionType)
                     .log("V5 has no exclusive/failover subscription type. Falling back to QueueConsumer "
                             + "(Shared-style work distribution). Latency/throughput numbers may not be "
-                            + "directly comparable with the v4 client.");
+                            + "directly comparable with the v4 client. Use consume-v4 for the v4 client.");
         }
         if (this.autoScaledReceiverQueueSize) {
             log.warn("--auto-scaled-receiver-queue-size has no V5 equivalent and will be ignored.");
@@ -281,345 +111,28 @@ public class PerformanceConsumer extends PerformanceTopicListArguments{
         if (this.maxTotalReceiverQueueSizeAcrossPartitions != 50000) {
             log.info("--receiver-queue-size-across-partitions has no V5 equivalent and will be ignored.");
         }
+        this.encryptionPolicy = buildEncryptionPolicyOrNull();
+    }
 
-        final RateLimiter limiter = this.rate > 0 ? RateLimiter.create(this.rate) : null;
-        long startTime = System.nanoTime();
-        long testEndTime = startTime + (long) (this.testTime * 1e9);
-
+    @Override
+    protected PulsarClient createClient() throws PulsarClientException {
         PulsarClientBuilder clientBuilder = PerfClientUtils.createV5ClientBuilderFromArguments(this);
         if (this.isEnableTransaction) {
             clientBuilder.transactionPolicy(TransactionPolicy.builder()
                     .timeout(Duration.ofSeconds(this.transactionTimeout))
                     .build());
         }
-        PulsarClient pulsarClient = clientBuilder.build();
-
-        AtomicReference<Transaction> atomicReference;
-        if (this.isEnableTransaction) {
-            atomicReference = new AtomicReference<>(PerfClientUtils.newTransactionWithRetry(pulsarClient));
-        } else {
-            atomicReference = new AtomicReference<>(null);
-        }
-
-        AtomicLong messageAckedCount = new AtomicLong();
-        Semaphore messageReceiveLimiter = new Semaphore(this.numMessagesPerTransaction);
-        Thread thread = Thread.currentThread();
-
-        final ConsumerEncryptionPolicy encryptionPolicy = buildEncryptionPolicyOrNull();
-
-        List<CompletableFuture<PerfConsumer>> futures = new ArrayList<>();
-        for (int i = 0; i < this.numTopics; i++) {
-            final TopicName topicName = TopicName.get(this.topics.get(i));
-
-            log.info()
-                    .attr("adding", this.numConsumers)
-                    .attr("topic", topicName)
-                    .attr("consumerType", this.scalableConsumerType)
-                    .log("Adding consumers per subscription on topic");
-
-            for (int j = 0; j < this.numSubscriptions; j++) {
-                String subscriberName = this.subscriptions.get(j);
-                for (int k = 0; k < this.numConsumers; k++) {
-                    futures.add(subscribeAsync(pulsarClient, topicName.toString(), subscriberName,
-                            encryptionPolicy));
-                }
-            }
-        }
-        final List<PerfConsumer> consumers = new ArrayList<>(futures.size());
-        for (CompletableFuture<PerfConsumer> future : futures) {
-            consumers.add(future.get());
-        }
-
-        // V5 has no MessageListener — drive each consumer from a dedicated poll thread that calls
-        // receive(timeout) and runs the same per-message handler the v4 listener did. One thread
-        // per consumer mirrors the v4 dispatch concurrency closely enough for the perf workload.
-        ExecutorService consumerExec = Executors.newCachedThreadPool(
-                new DefaultThreadFactory("pulsar-perf-consumer-poll"));
-        for (PerfConsumer consumer : consumers) {
-            consumerExec.submit(() -> pollLoop(consumer, atomicReference, messageAckedCount,
-                    messageReceiveLimiter, limiter, testEndTime, thread, pulsarClient));
-        }
-        log.info()
-                .attr("receiving", this.numConsumers)
-                .attr("subscription", this.numTopics)
-                .log("Start receiving from consumers per subscription on topics");
-
-        long start = System.nanoTime();
-
-        Thread shutdownHookThread = PerfClientUtils.addShutdownHook(() -> {
-            printAggregatedThroughput(start);
-            printAggregatedStats();
-        });
-
-        long oldTime = System.nanoTime();
-
-        Histogram reportHistogram = null;
-        HistogramLogWriter histogramLogWriter = null;
-
-        if (this.histogramFile != null) {
-            String statsFileName = this.histogramFile;
-            log.info().attr("stats", statsFileName).log("Dumping latency stats to");
-
-            PrintStream histogramLog = new PrintStream(new FileOutputStream(statsFileName), false);
-            histogramLogWriter = new HistogramLogWriter(histogramLog);
-
-            // Some log header bits
-            histogramLogWriter.outputLogFormatVersion();
-            histogramLogWriter.outputLegend();
-        }
-
-        while (!Thread.currentThread().isInterrupted()) {
-            try {
-                Thread.sleep(10000);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                break;
-            }
-
-            long now = System.nanoTime();
-            double elapsed = (now - oldTime) / 1e9;
-            long total = totalMessagesReceived.sum();
-            double rate = messagesReceived.sumThenReset() / elapsed;
-            double throughput = bytesReceived.sumThenReset() / elapsed * 8 / 1024 / 1024;
-            double rateAck = messageAck.sumThenReset() / elapsed;
-            long totalTxnOpSuccessNum = 0;
-            long totalTxnOpFailNum = 0;
-            double rateOpenTxn = 0;
-            reportHistogram = recorder.getIntervalHistogram(reportHistogram);
-
-            if (this.isEnableTransaction) {
-                totalTxnOpSuccessNum = totalEndTxnOpSuccessNum.sum();
-                totalTxnOpFailNum = totalEndTxnOpFailNum.sum();
-                rateOpenTxn = numTxnOpSuccess.sumThenReset() / elapsed;
-                log.infof("--- Transaction: %d transaction end successfully"
-                                + " --- %d transaction end failed"
-                                + " --- %.3f Txn/s --- AckRate: %.3f msg/s",
-                        totalTxnOpSuccessNum, totalTxnOpFailNum, rateOpenTxn, rateAck);
-            }
-            log.infof("Throughput received: %7d msg --- %.3f msg/s --- %.3f Mbit/s"
-                            + " --- Latency: mean: %.3f ms - med: %d"
-                            + " - 95pct: %d - 99pct: %d"
-                            + " - 99.9pct: %d - 99.99pct: %d - Max: %d",
-                    total, rate, throughput,
-                    reportHistogram.getMean(),
-                    reportHistogram.getValueAtPercentile(50),
-                    reportHistogram.getValueAtPercentile(95),
-                    reportHistogram.getValueAtPercentile(99),
-                    reportHistogram.getValueAtPercentile(99.9),
-                    reportHistogram.getValueAtPercentile(99.99),
-                    reportHistogram.getMaxValue());
-
-            if (histogramLogWriter != null) {
-                histogramLogWriter.outputIntervalHistogram(reportHistogram);
-            }
-
-            reportHistogram.reset();
-            oldTime = now;
-
-            if (this.testTime > 0) {
-                if (now > testEndTime) {
-                    log.info("------------------- DONE -----------------------");
-                    PerfClientUtils.exit(0);
-                    thread.interrupt();
-                }
-            }
-        }
-        // Stop the poll threads before closing the client so receive() does not race with close.
-        consumerExec.shutdownNow();
-        try {
-            if (!consumerExec.awaitTermination(10, TimeUnit.SECONDS)) {
-                log.warn("Consumer poll executor did not terminate within timeout");
-            }
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
-        PerfClientUtils.closeClient(pulsarClient);
-        PerfClientUtils.removeAndRunShutdownHook(shutdownHookThread);
+        return clientBuilder.build();
     }
 
-    /**
-     * Per-consumer poll loop replacing the v4 {@code MessageListener}. Each consumer gets one
-     * dedicated thread that drives {@code receive(timeout)} and runs the same per-message
-     * handler the v4 listener did (latency record, rate-limit, ack, transaction commit/rollover).
-     */
-    private void pollLoop(PerfConsumer consumer,
-                          AtomicReference<Transaction> atomicReference,
-                          AtomicLong messageAckedCount,
-                          Semaphore messageReceiveLimiter,
-                          RateLimiter limiter,
-                          long testEndTime,
-                          Thread mainThread,
-                          PulsarClient pulsarClient) {
-        while (!Thread.currentThread().isInterrupted()) {
-            // Termination conditions that don't depend on having just received a message. With
-            // asynchronous transaction commits the final commit can land after the last available
-            // message is consumed, so the transaction count must be re-checked on idle receives too;
-            // otherwise the consumer waits forever for a message that will never arrive.
-            if (this.testTime > 0 && System.nanoTime() > testEndTime) {
-                log.info("------------------- DONE -----------------------");
-                PerfClientUtils.exit(0);
-                mainThread.interrupt();
-                return;
-            }
-            if (this.totalNumTxn > 0
-                    && totalEndTxnOpFailNum.sum() + totalEndTxnOpSuccessNum.sum() >= this.totalNumTxn) {
-                log.info("------------------- DONE -----------------------");
-                PerfClientUtils.exit(0);
-                mainThread.interrupt();
-                return;
-            }
-
-            Message<byte[]> msg;
-            try {
-                msg = consumer.receive(Duration.ofSeconds(1));
-            } catch (Exception e) {
-                if (PerfClientUtils.hasInterruptedException(e)) {
-                    Thread.currentThread().interrupt();
-                    return;
-                }
-                log.warn().exception(e).log("receive failed; retrying");
-                continue;
-            }
-            if (msg == null) {
-                continue;
-            }
-
-            messagesReceived.increment();
-            bytesReceived.add(msg.size());
-            totalMessagesReceived.increment();
-            totalBytesReceived.add(msg.size());
-
-            if (this.numMessages > 0 && totalMessagesReceived.sum() >= this.numMessages) {
-                log.info("------------------- DONE -----------------------");
-                PerfClientUtils.exit(0);
-                mainThread.interrupt();
-                return;
-            }
-
-            if (limiter != null) {
-                limiter.acquire();
-            }
-
-            long latencyMillis = System.currentTimeMillis() - msg.publishTime().toEpochMilli();
-            if (latencyMillis >= 0) {
-                if (latencyMillis >= MAX_LATENCY_MILLIS) {
-                    latencyMillis = MAX_LATENCY_MILLIS;
-                }
-                recorder.recordValue(latencyMillis);
-                cumulativeRecorder.recordValue(latencyMillis);
-            }
-
-            // Ack — V5 acknowledge is synchronous void. Catch any failure into the existing counter.
-            if (this.isEnableTransaction) {
-                try {
-                    messageReceiveLimiter.acquire();
-                } catch (InterruptedException e) {
-                    log.error().exception(e).log("Got error");
-                    Thread.currentThread().interrupt();
-                }
-                Transaction txn = atomicReference.get();
-                try {
-                    consumer.ackTxn(msg.id(), txn);
-                    totalMessageAck.increment();
-                    messageAck.increment();
-                } catch (Exception e) {
-                    if (PerfClientUtils.hasInterruptedException(e)) {
-                        Thread.currentThread().interrupt();
-                    } else {
-                        log.error().exception(e).log("Ack message failed with exception");
-                        totalMessageAckFailed.increment();
-                    }
-                }
-            } else {
-                try {
-                    consumer.ack(msg.id());
-                    totalMessageAck.increment();
-                    messageAck.increment();
-                } catch (Exception e) {
-                    if (PerfClientUtils.hasInterruptedException(e)) {
-                        Thread.currentThread().interrupt();
-                    } else {
-                        log.error().exception(e).log("Ack message failed with exception");
-                        totalMessageAckFailed.increment();
-                    }
-                }
-            }
-
-            // Transaction commit / rollover after numMessagesPerTransaction acks.
-            if (this.isEnableTransaction
-                    && messageAckedCount.incrementAndGet() == this.numMessagesPerTransaction) {
-                Transaction transaction = atomicReference.get();
-                if (!this.isAbortTransaction) {
-                    transaction.async().commit()
-                            .thenRun(() -> {
-                                log.debug().log("Commit transaction");
-                                totalEndTxnOpSuccessNum.increment();
-                                numTxnOpSuccess.increment();
-                            })
-                            .exceptionally(exception -> {
-                                if (PerfClientUtils.hasInterruptedException(exception)) {
-                                    Thread.currentThread().interrupt();
-                                    return null;
-                                }
-                                log.error().exception(exception).log("Commit transaction failed with exception");
-                                totalEndTxnOpFailNum.increment();
-                                return null;
-                            });
-                } else {
-                    transaction.async().abort()
-                            .thenRun(() -> {
-                                log.debug().log("Abort transaction");
-                                totalEndTxnOpSuccessNum.increment();
-                                numTxnOpSuccess.increment();
-                            })
-                            .exceptionally(exception -> {
-                                if (PerfClientUtils.hasInterruptedException(exception)) {
-                                    Thread.currentThread().interrupt();
-                                    return null;
-                                }
-                                log.error().exception(exception)
-                                        .log("Abort transaction failed with exception");
-                                totalEndTxnOpFailNum.increment();
-                                return null;
-                            });
-                }
-                while (!Thread.currentThread().isInterrupted()) {
-                    try {
-                        Transaction newTransaction = pulsarClient.newTransaction();
-                        atomicReference.compareAndSet(transaction, newTransaction);
-                        totalNumTxnOpenSuccess.increment();
-                        messageAckedCount.set(0);
-                        messageReceiveLimiter.release(this.numMessagesPerTransaction);
-                        break;
-                    } catch (Exception e) {
-                        if (PerfClientUtils.hasInterruptedException(e)) {
-                            Thread.currentThread().interrupt();
-                        } else {
-                            log.error().exception(e).log("Failed to new transaction with exception");
-                            totalNumTxnOpenFail.increment();
-                        }
-                    }
-                }
-            }
-        }
+    @Override
+    protected void closeClient(PulsarClient client) {
+        PerfClientUtils.closeClient(client);
     }
 
-    /**
-     * Minimal common view over the V5 {@link QueueConsumer} / {@link StreamConsumer} APIs so the
-     * poll loop is independent of which scalable-topic consumer type was selected. The ack methods
-     * map to {@code acknowledge} for Queue and {@code acknowledgeCumulative} for Stream.
-     */
-    private interface PerfConsumer {
-        Message<byte[]> receive(Duration timeout) throws Exception;
-
-        void ack(MessageId messageId) throws Exception;
-
-        void ackTxn(MessageId messageId, Transaction txn) throws Exception;
-    }
-
-    private CompletableFuture<PerfConsumer> subscribeAsync(PulsarClient client, String topic,
-                                                           String subscription,
-                                                           ConsumerEncryptionPolicy encryptionPolicy) {
+    @Override
+    protected CompletableFuture<PerfConsumer> subscribeAsync(PulsarClient client, String topic,
+                                                             String subscription) {
         if (this.scalableConsumerType == ScalableConsumerType.Stream) {
             // StreamConsumer has no receiverQueueSize knob; the rest carries over. Deliberately
             // do NOT set a consumerName: the controller keys group membership by consumer name,
@@ -649,6 +162,122 @@ public class PerformanceConsumer extends PerformanceTopicListArguments{
             b.encryptionPolicy(encryptionPolicy);
         }
         return b.subscribeAsync().thenApply(PerformanceConsumer::wrap);
+    }
+
+    @Override
+    protected Transaction newTransaction(PulsarClient client) throws PulsarClientException {
+        return client.newTransaction();
+    }
+
+    @Override
+    protected Transaction openFirstTransaction(PulsarClient client)
+            throws PulsarClientException, InterruptedException {
+        return PerfClientUtils.newTransactionWithRetry(client);
+    }
+
+    @Override
+    protected CompletableFuture<Void> commitTransaction(Transaction transaction) {
+        return transaction.async().commit();
+    }
+
+    @Override
+    protected CompletableFuture<Void> abortTransaction(Transaction transaction) {
+        return transaction.async().abort();
+    }
+
+    @Override
+    protected int messageSize(Message<byte[]> msg) {
+        return msg.size();
+    }
+
+    @Override
+    protected long publishTimeMillis(Message<byte[]> msg) {
+        return msg.publishTime().toEpochMilli();
+    }
+
+    @Override
+    protected void acknowledge(PerfConsumer consumer, Message<byte[]> msg, Transaction transaction) {
+        // V5 acknowledge is synchronous void. Catch any failure into the shared counter.
+        try {
+            if (transaction != null) {
+                consumer.ackTxn(msg.id(), transaction);
+            } else {
+                consumer.ack(msg.id());
+            }
+            ackSucceeded();
+        } catch (Exception e) {
+            ackFailed(e);
+        }
+    }
+
+    /**
+     * V5 has no MessageListener — drive each consumer from a dedicated poll thread that calls
+     * receive(timeout) and runs the same per-message handler the v4 listener does. One thread per
+     * consumer mirrors the v4 dispatch concurrency closely enough for the perf workload.
+     */
+    @Override
+    protected void startConsuming(List<PerfConsumer> consumers) {
+        consumerExec = Executors.newCachedThreadPool(
+                new DefaultThreadFactory("pulsar-perf-consumer-poll"));
+        for (PerfConsumer consumer : consumers) {
+            consumerExec.submit(() -> pollLoop(consumer));
+        }
+    }
+
+    @Override
+    protected void stopConsuming() {
+        if (consumerExec == null) {
+            return;
+        }
+        consumerExec.shutdownNow();
+        try {
+            if (!consumerExec.awaitTermination(10, TimeUnit.SECONDS)) {
+                log.warn("Consumer poll executor did not terminate within timeout");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    /** Per-consumer poll loop replacing the v4 {@code MessageListener}. */
+    private void pollLoop(PerfConsumer consumer) {
+        while (!Thread.currentThread().isInterrupted()) {
+            if (checkDone()) {
+                return;
+            }
+
+            Message<byte[]> msg;
+            try {
+                msg = consumer.receive(Duration.ofSeconds(1));
+            } catch (Exception e) {
+                if (PerfClientUtils.hasInterruptedException(e)) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+                log.warn().exception(e).log("receive failed; retrying");
+                continue;
+            }
+            if (msg == null) {
+                continue;
+            }
+
+            if (handleMessage(consumer, msg)) {
+                return;
+            }
+        }
+    }
+
+    /**
+     * Minimal common view over the V5 {@link QueueConsumer} / {@link StreamConsumer} APIs so the
+     * poll loop is independent of which scalable-topic consumer type was selected. The ack methods
+     * map to {@code acknowledge} for Queue and {@code acknowledgeCumulative} for Stream.
+     */
+    public interface PerfConsumer {
+        Message<byte[]> receive(Duration timeout) throws Exception;
+
+        void ack(MessageId messageId) throws Exception;
+
+        void ackTxn(MessageId messageId, Transaction txn) throws Exception;
     }
 
     private ConsumerEncryptionPolicy buildEncryptionPolicyOrNull() {
@@ -703,53 +332,5 @@ public class PerformanceConsumer extends PerformanceTopicListArguments{
                 consumer.acknowledgeCumulative(messageId, txn);
             }
         };
-    }
-
-    private void printAggregatedThroughput(long start) {
-        double elapsed = (System.nanoTime() - start) / 1e9;
-        double rate = totalMessagesReceived.sum() / elapsed;
-        double throughput = totalBytesReceived.sum() / elapsed * 8 / 1024 / 1024;
-        long totalEndTxnSuccess = 0;
-        long totalEndTxnFail = 0;
-        long numTransactionOpenFailed = 0;
-        long numTransactionOpenSuccess = 0;
-        long totalnumMessageAckFailed = 0;
-        double rateAck = totalMessageAck.sum() / elapsed;
-        double rateOpenTxn = 0;
-        if (this.isEnableTransaction) {
-            totalEndTxnSuccess = totalEndTxnOpSuccessNum.sum();
-            totalEndTxnFail = totalEndTxnOpFailNum.sum();
-            rateOpenTxn = (totalEndTxnSuccess + totalEndTxnFail) / elapsed;
-            totalnumMessageAckFailed = totalMessageAckFailed.sum();
-            numTransactionOpenFailed = totalNumTxnOpenFail.sum();
-            numTransactionOpenSuccess = totalNumTxnOpenSuccess.sum();
-            log.infof("-- Transaction: %d transaction end successfully"
-                            + " --- %d transaction end failed"
-                            + " --- %d transaction open successfully"
-                            + " --- %d transaction open failed --- %.3f Txn/s",
-                    totalEndTxnSuccess, totalEndTxnFail,
-                    numTransactionOpenSuccess, numTransactionOpenFailed, rateOpenTxn);
-        }
-        log.infof("Aggregated throughput stats --- %d records received"
-                        + " --- %.3f msg/s --- %.3f Mbit/s"
-                        + " --- AckRate: %.1f msg/s --- ack failed %d msg",
-                totalMessagesReceived.sum(), rate, throughput, rateAck, totalnumMessageAckFailed);
-    }
-
-    private void printAggregatedStats() {
-        Histogram reportHistogram = cumulativeRecorder.getIntervalHistogram();
-
-        log.infof("Aggregated latency stats --- Latency: mean: %.3f ms"
-                        + " - med: %d - 95pct: %d - 99pct: %d"
-                        + " - 99.9pct: %d - 99.99pct: %d"
-                        + " - 99.999pct: %d - Max: %d",
-                reportHistogram.getMean(),
-                reportHistogram.getValueAtPercentile(50),
-                reportHistogram.getValueAtPercentile(95),
-                reportHistogram.getValueAtPercentile(99),
-                reportHistogram.getValueAtPercentile(99.9),
-                reportHistogram.getValueAtPercentile(99.99),
-                reportHistogram.getValueAtPercentile(99.999),
-                reportHistogram.getMaxValue());
     }
 }

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
@@ -84,6 +84,11 @@ public class PerformanceConsumer
     }
 
     @Override
+    protected Object consumerTypeForLog() {
+        return this.scalableConsumerType;
+    }
+
+    @Override
     protected void prepareRun() {
         log.info().attr("consumerType", this.scalableConsumerType).log("Using V5 scalable-topic consumer API");
         if (this.subscriptionType == SubscriptionType.Exclusive

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumerBase.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumerBase.java
@@ -225,6 +225,14 @@ public abstract class PerformanceConsumerBase<ClientT, ConsumerT, MessageT, TxnT
                                                                    String subscription);
 
     /**
+     * The consumer kind reported on the per-topic "Adding consumers" line. The v4 client subscribes
+     * by {@code --subscription-type}; V5 picks a consumer API instead and overrides this.
+     */
+    protected Object consumerTypeForLog() {
+        return this.subscriptionType;
+    }
+
+    /**
      * Open a new transaction, honouring {@code --txn-timeout}. Used for every rollover, which has
      * its own retry loop and counts each failure, so this must surface a failed open rather than
      * retrying internally.
@@ -348,6 +356,7 @@ public abstract class PerformanceConsumerBase<ClientT, ConsumerT, MessageT, TxnT
             log.info()
                     .attr("adding", this.numConsumers)
                     .attr("topic", topicName)
+                    .attr("consumerType", consumerTypeForLog())
                     .log("Adding consumers per subscription on topic");
 
             for (int j = 0; j < this.numSubscriptions; j++) {

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumerBase.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumerBase.java
@@ -1,0 +1,647 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.testclient;
+
+import static org.apache.pulsar.testclient.PerfClientUtils.LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.google.common.util.concurrent.RateLimiter;
+import io.github.merlimat.slog.Logger;
+import java.io.FileOutputStream;
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.LongAdder;
+import org.HdrHistogram.Histogram;
+import org.HdrHistogram.HistogramLogWriter;
+import org.HdrHistogram.Recorder;
+import org.apache.pulsar.common.naming.TopicName;
+import picocli.CommandLine.Option;
+
+/**
+ * Client-agnostic implementation of the {@code pulsar-perf} consumer benchmark.
+ *
+ * <p>The CLI options, the throughput and latency accounting, the subscription fan-out, the
+ * transaction lifecycle and the periodic and aggregated reports live here. Concrete subclasses
+ * bind the client types and implement the seams below: {@link PerformanceConsumer} drives the V5
+ * Queue/Stream consumers from dedicated poll threads, and {@link PerformanceConsumerV4} drives a
+ * v4 {@code Consumer} through a {@code MessageListener}.
+ *
+ * @param <ClientT> the client type ({@code PulsarClient} of the respective API generation)
+ * @param <ConsumerT> the subscribed consumer handle
+ * @param <MessageT> the received message type
+ * @param <TxnT> the transaction type used when {@code --txn-enable} is set
+ */
+public abstract class PerformanceConsumerBase<ClientT, ConsumerT, MessageT, TxnT>
+        extends PerformanceTopicListArguments {
+
+    /**
+     * Logger named after the <em>concrete</em> command class rather than this base, so that the
+     * report lines keep identifying the subcommand that produced them (the integration tests in
+     * {@code PerfToolTest} match on {@code PerformanceConsumer - Aggregated ...}).
+     */
+    protected final Logger log = Logger.get(getClass());
+
+    /**
+     * Subscription type flag values, shared by both commands so the CLI surface does not depend on
+     * which client is driving. The names are the v4 ones: {@link PerformanceConsumerV4} maps them
+     * straight onto {@code org.apache.pulsar.client.api.SubscriptionType}, while V5 has no single
+     * user-facing subscription-type enum (StreamConsumer / QueueConsumer / CheckpointConsumer are
+     * separate APIs) and maps them all to a QueueConsumer.
+     */
+    public enum SubscriptionType {
+        Exclusive,
+        Shared,
+        Failover,
+        Key_Shared
+    }
+
+    private final LongAdder messagesReceived = new LongAdder();
+    private final LongAdder bytesReceived = new LongAdder();
+
+    private final LongAdder totalMessagesReceived = new LongAdder();
+    private final LongAdder totalBytesReceived = new LongAdder();
+
+    private final LongAdder totalNumTxnOpenFail = new LongAdder();
+    private final LongAdder totalNumTxnOpenSuccess = new LongAdder();
+
+    private final LongAdder totalMessageAck = new LongAdder();
+    private final LongAdder totalMessageAckFailed = new LongAdder();
+    private final LongAdder messageAck = new LongAdder();
+
+    private final LongAdder totalEndTxnOpFailNum = new LongAdder();
+    private final LongAdder totalEndTxnOpSuccessNum = new LongAdder();
+    private final LongAdder numTxnOpSuccess = new LongAdder();
+
+    protected static final long MAX_LATENCY_MILLIS = TimeUnit.DAYS.toMillis(10);
+    private final Recorder recorder = new Recorder(MAX_LATENCY_MILLIS, LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS);
+    private final Recorder cumulativeRecorder =
+            new Recorder(MAX_LATENCY_MILLIS, LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS);
+
+    /** Run state shared between {@code run()} and the message handler. */
+    private ClientT client;
+    private AtomicReference<TxnT> transactionRef;
+    private AtomicLong messageAckedCount;
+    private Semaphore messageReceiveLimiter;
+    private RateLimiter limiter;
+    private long testEndTime;
+    private Thread mainThread;
+
+    @Option(names = { "-n", "--num-consumers" }, description = "Number of consumers (per subscription), only "
+            + "one consumer is allowed when subscriptionType is Exclusive",
+            converter = PositiveNumberParameterConvert.class
+    )
+    public int numConsumers = 1;
+
+    @Option(names = { "-ns", "--num-subscriptions" }, description = "Number of subscriptions (per topic)",
+            converter = PositiveNumberParameterConvert.class
+    )
+    public int numSubscriptions = 1;
+
+    @Option(names = { "-s", "--subscriber-name" }, description = "Subscriber name prefix", hidden = true)
+    public String subscriberName;
+
+    @Option(names = { "-ss", "--subscriptions" },
+            description = "A list of subscriptions to consume (for example, sub1,sub2)")
+    public List<String> subscriptions = Collections.singletonList("sub");
+
+    @Option(names = { "-st", "--subscription-type" }, description = "Subscription type")
+    public SubscriptionType subscriptionType = SubscriptionType.Exclusive;
+
+    @Option(names = { "-r", "--rate" }, description = "Simulate a slow message consumer (rate in msg/s)")
+    public double rate = 0;
+
+    @Option(names = { "-q", "--receiver-queue-size" }, description = "Size of the receiver queue")
+    public int receiverQueueSize = 1000;
+
+    @Option(names = { "-p", "--receiver-queue-size-across-partitions" },
+            description = "Max total size of the receiver queue across partitions")
+    public int maxTotalReceiverQueueSizeAcrossPartitions = 50000;
+
+    @Option(names = {"-aq", "--auto-scaled-receiver-queue-size"},
+            description = "Enable autoScaledReceiverQueueSize")
+    public boolean autoScaledReceiverQueueSize = false;
+
+    @Option(names = {"-rs", "--replicated" },
+            description = "Whether the subscription status should be replicated")
+    public boolean replicatedSubscription = false;
+
+    @Option(names = { "--acks-delay-millis" }, description = "Acknowledgements grouping delay in millis")
+    public int acknowledgmentsGroupingDelayMillis = 100;
+
+    @Option(names = {"-m",
+            "--num-messages"},
+            description = "Number of messages to consume in total. If <= 0, it will keep consuming")
+    public long numMessages = 0;
+
+    @Option(names = { "-mc", "--max_chunked_msg" }, description = "Max pending chunk messages")
+    protected int maxPendingChunkedMessage = 0;
+
+    @Option(names = { "-ac",
+            "--auto_ack_chunk_q_full" }, description = "Auto ack for oldest message on queue is full")
+    protected boolean autoAckOldestChunkedMessageOnQueueFull = false;
+
+    @Option(names = { "-e",
+            "--expire_time_incomplete_chunked_messages" },
+            description = "Expire time in ms for incomplete chunk messages")
+    protected long expireTimeOfIncompleteChunkedMessageMs = 0;
+
+    @Option(names = { "-v",
+            "--encryption-key-value-file" },
+            description = "The file which contains the private key to decrypt payload")
+    public String encKeyFile = null;
+
+    @Option(names = { "-time",
+            "--test-duration" }, description = "Test duration in secs. If <= 0, it will keep consuming")
+    public long testTime = 0;
+
+    @Option(names = {"--batch-index-ack" }, description = "Enable or disable the batch index acknowledgment")
+    public boolean batchIndexAck = false;
+
+    @Option(names = { "-pm", "--pool-messages" }, description = "Use the pooled message", arity = "1")
+    protected boolean poolMessages = true;
+
+    @Option(names = {"-tto", "--txn-timeout"},  description = "Set the time value of transaction timeout,"
+            + " and the time unit is second. (After --txn-enable setting to true, --txn-timeout takes effect)")
+    public long transactionTimeout = 10;
+
+    @Option(names = {"-nmt", "--numMessage-perTransaction"},
+            description = "The number of messages acknowledged by a transaction. "
+                    + "(After --txn-enable setting to true, -numMessage-perTransaction takes effect")
+    public int numMessagesPerTransaction = 50;
+
+    @Option(names = {"-txn", "--txn-enable"}, description = "Enable or disable the transaction")
+    public boolean isEnableTransaction = false;
+
+    @Option(names = {"-ntxn"}, description = "The number of opened transactions, 0 means keeping open."
+            + "(After --txn-enable setting to true, -ntxn takes effect.)")
+    public long totalNumTxn = 0;
+
+    @Option(names = {"-abort"}, description = "Abort the transaction. (After --txn-enable "
+            + "setting to true, -abort takes effect)")
+    public boolean isAbortTransaction = false;
+
+    @Option(names = { "--histogram-file" }, description = "HdrHistogram output file")
+    public String histogramFile = null;
+
+    protected PerformanceConsumerBase(String cmdName) {
+        super(cmdName);
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // Client-specific seams
+    // ------------------------------------------------------------------------------------------
+
+    /** Build and connect the client, enabling transactions when {@code --txn-enable} is set. */
+    protected abstract ClientT createClient() throws Exception;
+
+    /** Close a client built by {@link #createClient()}; must tolerate a {@code null} argument. */
+    protected abstract void closeClient(ClientT client);
+
+    /** Subscribe one consumer to {@code topic} under {@code subscription}. */
+    protected abstract CompletableFuture<ConsumerT> subscribeAsync(ClientT client, String topic,
+                                                                   String subscription);
+
+    /**
+     * Open a new transaction, honouring {@code --txn-timeout}. Used for every rollover, which has
+     * its own retry loop and counts each failure, so this must surface a failed open rather than
+     * retrying internally.
+     */
+    protected abstract TxnT newTransaction(ClientT client) throws Exception;
+
+    /**
+     * Open the first transaction, before any consumer exists. Separate from
+     * {@link #newTransaction} because the V5 client needs to wait out its transaction-coordinator
+     * handler's asynchronous connect here, whereas the rollover path must see each failure.
+     */
+    protected TxnT openFirstTransaction(ClientT client) throws Exception {
+        return newTransaction(client);
+    }
+
+    /** Commit a transaction. */
+    protected abstract CompletableFuture<Void> commitTransaction(TxnT transaction);
+
+    /** Abort a transaction. */
+    protected abstract CompletableFuture<Void> abortTransaction(TxnT transaction);
+
+    /** Payload size of a received message, in bytes. */
+    protected abstract int messageSize(MessageT msg);
+
+    /** Publish timestamp of a received message, in milliseconds since the epoch. */
+    protected abstract long publishTimeMillis(MessageT msg);
+
+    /**
+     * Acknowledge one message, individually or under {@code transaction} when it is non-null, and
+     * count the outcome with {@link #ackSucceeded()} / {@link #ackFailed(Throwable)}. Doing the
+     * counting here rather than in the base lets each client ack in its natural style — the v4
+     * client's {@code acknowledgeAsync} completes a future, V5's {@code acknowledge} is a
+     * synchronous void.
+     */
+    protected abstract void acknowledge(ConsumerT consumer, MessageT msg, TxnT transaction);
+
+    /**
+     * Start driving the subscribed consumers. A no-op where the client pushes messages itself (the
+     * v4 {@code MessageListener}); V5 has no listener, so it starts one poll thread per consumer.
+     */
+    protected void startConsuming(List<ConsumerT> consumers) throws Exception {
+    }
+
+    /** Stop whatever {@link #startConsuming(List)} started, before the client is closed. */
+    protected void stopConsuming() {
+    }
+
+    /** Release a pooled message once it has been accounted for and acknowledged. */
+    protected void releaseMessage(MessageT msg) {
+    }
+
+    /** Called for every received message before it is accounted for, with its consumer. */
+    protected void onMessageDequeued(ConsumerT consumer) {
+    }
+
+    /** Hook for per-client run preparation: option warnings, extra recorders. */
+    protected void prepareRun() {
+    }
+
+    /** Hook for extra lines in the periodic report. */
+    protected void reportIntervalExtras(List<ConsumerT> consumers) throws Exception {
+    }
+
+    // ------------------------------------------------------------------------------------------
+
+    @Override
+    public void validate() throws Exception {
+        super.validate();
+        if (subscriptionType == SubscriptionType.Exclusive && numConsumers > 1) {
+            throw new Exception("Only one consumer is allowed when subscriptionType is Exclusive");
+        }
+
+        if (subscriptions != null && subscriptions.size() != numSubscriptions) {
+            // keep compatibility with the previous version
+            if (subscriptions.size() == 1) {
+                if (subscriberName == null) {
+                    subscriberName = subscriptions.get(0);
+                }
+                List<String> defaultSubscriptions = new ArrayList<>();
+                for (int i = 0; i < numSubscriptions; i++) {
+                    defaultSubscriptions.add(String.format("%s-%d", subscriberName, i));
+                }
+                subscriptions = defaultSubscriptions;
+            } else {
+                throw new Exception("The size of subscriptions list should be equal to --num-subscriptions");
+            }
+        }
+    }
+
+    @Override
+    public void run() throws Exception {
+
+        // Dump config variables
+        PerfClientUtils.printJVMInformation(log);
+        ObjectMapper m = new ObjectMapper();
+        ObjectWriter w = m.writerWithDefaultPrettyPrinter();
+        log.info().attr("config", w.writeValueAsString(this)).log("Starting Pulsar performance consumer with config");
+
+        prepareRun();
+
+        this.limiter = this.rate > 0 ? RateLimiter.create(this.rate) : null;
+        long startTime = System.nanoTime();
+        this.testEndTime = startTime + (long) (this.testTime * 1e9);
+        this.mainThread = Thread.currentThread();
+
+        this.client = createClient();
+
+        if (this.isEnableTransaction) {
+            this.transactionRef = new AtomicReference<>(openFirstTransaction(client));
+        } else {
+            this.transactionRef = new AtomicReference<>(null);
+        }
+
+        this.messageAckedCount = new AtomicLong();
+        this.messageReceiveLimiter = new Semaphore(this.numMessagesPerTransaction);
+
+        List<CompletableFuture<ConsumerT>> futures = new ArrayList<>();
+        for (int i = 0; i < this.numTopics; i++) {
+            final TopicName topicName = TopicName.get(this.topics.get(i));
+
+            log.info()
+                    .attr("adding", this.numConsumers)
+                    .attr("topic", topicName)
+                    .log("Adding consumers per subscription on topic");
+
+            for (int j = 0; j < this.numSubscriptions; j++) {
+                String subscription = this.subscriptions.get(j);
+                for (int k = 0; k < this.numConsumers; k++) {
+                    futures.add(subscribeAsync(client, topicName.toString(), subscription));
+                }
+            }
+        }
+        final List<ConsumerT> consumers = new ArrayList<>(futures.size());
+        for (CompletableFuture<ConsumerT> future : futures) {
+            consumers.add(future.get());
+        }
+
+        startConsuming(consumers);
+
+        log.info()
+                .attr("receiving", this.numConsumers)
+                .attr("subscription", this.numTopics)
+                .log("Start receiving from consumers per subscription on topics");
+
+        long start = System.nanoTime();
+
+        Thread shutdownHookThread = PerfClientUtils.addShutdownHook(() -> {
+            printAggregatedThroughput(start);
+            printAggregatedStats();
+        });
+
+        long oldTime = System.nanoTime();
+
+        Histogram reportHistogram = null;
+        HistogramLogWriter histogramLogWriter = null;
+
+        if (this.histogramFile != null) {
+            String statsFileName = this.histogramFile;
+            log.info().attr("stats", statsFileName).log("Dumping latency stats to");
+
+            PrintStream histogramLog = new PrintStream(new FileOutputStream(statsFileName), false);
+            histogramLogWriter = new HistogramLogWriter(histogramLog);
+
+            // Some log header bits
+            histogramLogWriter.outputLogFormatVersion();
+            histogramLogWriter.outputLegend();
+        }
+
+        while (!Thread.currentThread().isInterrupted()) {
+            try {
+                Thread.sleep(10000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+
+            long now = System.nanoTime();
+            double elapsed = (now - oldTime) / 1e9;
+            long total = totalMessagesReceived.sum();
+            double rate = messagesReceived.sumThenReset() / elapsed;
+            double throughput = bytesReceived.sumThenReset() / elapsed * 8 / 1024 / 1024;
+            double rateAck = messageAck.sumThenReset() / elapsed;
+            long totalTxnOpSuccessNum = 0;
+            long totalTxnOpFailNum = 0;
+            double rateOpenTxn = 0;
+            reportHistogram = recorder.getIntervalHistogram(reportHistogram);
+
+            if (this.isEnableTransaction) {
+                totalTxnOpSuccessNum = totalEndTxnOpSuccessNum.sum();
+                totalTxnOpFailNum = totalEndTxnOpFailNum.sum();
+                rateOpenTxn = numTxnOpSuccess.sumThenReset() / elapsed;
+                log.infof("--- Transaction: %d transaction end successfully"
+                                + " --- %d transaction end failed"
+                                + " --- %.3f Txn/s --- AckRate: %.3f msg/s",
+                        totalTxnOpSuccessNum, totalTxnOpFailNum, rateOpenTxn, rateAck);
+            }
+            log.infof("Throughput received: %7d msg --- %.3f msg/s --- %.3f Mbit/s"
+                            + " --- Latency: mean: %.3f ms - med: %d"
+                            + " - 95pct: %d - 99pct: %d"
+                            + " - 99.9pct: %d - 99.99pct: %d - Max: %d",
+                    total, rate, throughput,
+                    reportHistogram.getMean(),
+                    reportHistogram.getValueAtPercentile(50),
+                    reportHistogram.getValueAtPercentile(95),
+                    reportHistogram.getValueAtPercentile(99),
+                    reportHistogram.getValueAtPercentile(99.9),
+                    reportHistogram.getValueAtPercentile(99.99),
+                    reportHistogram.getMaxValue());
+
+            reportIntervalExtras(consumers);
+
+            if (histogramLogWriter != null) {
+                histogramLogWriter.outputIntervalHistogram(reportHistogram);
+            }
+
+            reportHistogram.reset();
+            oldTime = now;
+
+            if (this.testTime > 0) {
+                if (now > testEndTime) {
+                    log.info("------------------- DONE -----------------------");
+                    PerfClientUtils.exit(0);
+                    mainThread.interrupt();
+                }
+            }
+        }
+        // Stop driving the consumers before closing the client so receives do not race with close.
+        stopConsuming();
+        closeClient(client);
+        PerfClientUtils.removeAndRunShutdownHook(shutdownHookThread);
+    }
+
+    /**
+     * Termination conditions that do not depend on having just received a message. With
+     * asynchronous transaction commits the final commit can land after the last available message is
+     * consumed, so the transaction count must be re-checked on idle receives too; otherwise the
+     * consumer waits forever for a message that will never arrive.
+     *
+     * @return whether the run is done and the caller should stop consuming
+     */
+    protected final boolean checkDone() {
+        if (this.testTime > 0 && System.nanoTime() > testEndTime) {
+            reportDone();
+            return true;
+        }
+        if (this.totalNumTxn > 0
+                && totalEndTxnOpFailNum.sum() + totalEndTxnOpSuccessNum.sum() >= this.totalNumTxn) {
+            reportDone();
+            return true;
+        }
+        return false;
+    }
+
+    private void reportDone() {
+        log.info("------------------- DONE -----------------------");
+        PerfClientUtils.exit(0);
+        mainThread.interrupt();
+    }
+
+    /**
+     * The per-message handler shared by the v4 message listener and the V5 poll loop: accounting,
+     * rate limiting, latency recording, acknowledgement and the transaction rollover.
+     *
+     * @return whether the run is done and the caller should stop consuming
+     */
+    protected final boolean handleMessage(ConsumerT consumer, MessageT msg) {
+        onMessageDequeued(consumer);
+
+        int size = messageSize(msg);
+        messagesReceived.increment();
+        bytesReceived.add(size);
+        totalMessagesReceived.increment();
+        totalBytesReceived.add(size);
+
+        if (this.numMessages > 0 && totalMessagesReceived.sum() >= this.numMessages) {
+            reportDone();
+            // The run is over, so the message that tripped the limit is not acknowledged, but its
+            // buffer is still returned in case messages are pooled.
+            releaseMessage(msg);
+            return true;
+        }
+
+        if (limiter != null) {
+            limiter.acquire();
+        }
+
+        long latencyMillis = System.currentTimeMillis() - publishTimeMillis(msg);
+        if (latencyMillis >= 0) {
+            if (latencyMillis >= MAX_LATENCY_MILLIS) {
+                latencyMillis = MAX_LATENCY_MILLIS;
+            }
+            recorder.recordValue(latencyMillis);
+            cumulativeRecorder.recordValue(latencyMillis);
+        }
+
+        if (this.isEnableTransaction) {
+            try {
+                messageReceiveLimiter.acquire();
+            } catch (InterruptedException e) {
+                log.error().exception(e).log("Got error");
+                Thread.currentThread().interrupt();
+            }
+            acknowledge(consumer, msg, transactionRef.get());
+        } else {
+            acknowledge(consumer, msg, null);
+        }
+
+        releaseMessage(msg);
+
+        if (this.isEnableTransaction
+                && messageAckedCount.incrementAndGet() == this.numMessagesPerTransaction) {
+            endAndReopenTransaction();
+        }
+        return false;
+    }
+
+    /** Count a successful acknowledgement. Called by {@link #acknowledge}. */
+    protected final void ackSucceeded() {
+        totalMessageAck.increment();
+        messageAck.increment();
+    }
+
+    /** Count a failed acknowledgement. Called by {@link #acknowledge}. */
+    protected final void ackFailed(Throwable throwable) {
+        if (PerfClientUtils.hasInterruptedException(throwable)) {
+            Thread.currentThread().interrupt();
+            return;
+        }
+        log.error().exception(throwable).log("Ack message failed with exception");
+        totalMessageAckFailed.increment();
+    }
+
+    /** End the in-flight transaction according to {@code -abort} and open its replacement. */
+    private void endAndReopenTransaction() {
+        final TxnT transaction = transactionRef.get();
+        final boolean abort = this.isAbortTransaction;
+        CompletableFuture<Void> endFuture = abort ? abortTransaction(transaction) : commitTransaction(transaction);
+        endFuture.thenRun(() -> {
+            log.debug().log(abort ? "Abort transaction" : "Commit transaction");
+            totalEndTxnOpSuccessNum.increment();
+            numTxnOpSuccess.increment();
+        }).exceptionally(exception -> {
+            if (PerfClientUtils.hasInterruptedException(exception)) {
+                Thread.currentThread().interrupt();
+                return null;
+            }
+            log.error().exception(exception)
+                    .log(abort ? "Abort transaction failed with exception"
+                            : "Commit transaction failed with exception");
+            totalEndTxnOpFailNum.increment();
+            return null;
+        });
+
+        while (!Thread.currentThread().isInterrupted()) {
+            try {
+                TxnT newTransaction = newTransaction(client);
+                transactionRef.compareAndSet(transaction, newTransaction);
+                totalNumTxnOpenSuccess.increment();
+                messageAckedCount.set(0);
+                messageReceiveLimiter.release(this.numMessagesPerTransaction);
+                break;
+            } catch (Exception e) {
+                if (PerfClientUtils.hasInterruptedException(e)) {
+                    Thread.currentThread().interrupt();
+                } else {
+                    log.error().exception(e).log("Failed to new transaction with exception");
+                    totalNumTxnOpenFail.increment();
+                }
+            }
+        }
+    }
+
+    private void printAggregatedThroughput(long start) {
+        double elapsed = (System.nanoTime() - start) / 1e9;
+        double rate = totalMessagesReceived.sum() / elapsed;
+        double throughput = totalBytesReceived.sum() / elapsed * 8 / 1024 / 1024;
+        long totalEndTxnSuccess = 0;
+        long totalEndTxnFail = 0;
+        long numTransactionOpenFailed = 0;
+        long numTransactionOpenSuccess = 0;
+        long totalnumMessageAckFailed = 0;
+        double rateAck = totalMessageAck.sum() / elapsed;
+        double rateOpenTxn = 0;
+        if (this.isEnableTransaction) {
+            totalEndTxnSuccess = totalEndTxnOpSuccessNum.sum();
+            totalEndTxnFail = totalEndTxnOpFailNum.sum();
+            rateOpenTxn = (totalEndTxnSuccess + totalEndTxnFail) / elapsed;
+            totalnumMessageAckFailed = totalMessageAckFailed.sum();
+            numTransactionOpenFailed = totalNumTxnOpenFail.sum();
+            numTransactionOpenSuccess = totalNumTxnOpenSuccess.sum();
+            log.infof("-- Transaction: %d transaction end successfully"
+                            + " --- %d transaction end failed"
+                            + " --- %d transaction open successfully"
+                            + " --- %d transaction open failed --- %.3f Txn/s",
+                    totalEndTxnSuccess, totalEndTxnFail,
+                    numTransactionOpenSuccess, numTransactionOpenFailed, rateOpenTxn);
+        }
+        log.infof("Aggregated throughput stats --- %d records received"
+                        + " --- %.3f msg/s --- %.3f Mbit/s"
+                        + " --- AckRate: %.1f msg/s --- ack failed %d msg",
+                totalMessagesReceived.sum(), rate, throughput, rateAck, totalnumMessageAckFailed);
+    }
+
+    private void printAggregatedStats() {
+        Histogram reportHistogram = cumulativeRecorder.getIntervalHistogram();
+
+        log.infof("Aggregated latency stats --- Latency: mean: %.3f ms"
+                        + " - med: %d - 95pct: %d - 99pct: %d"
+                        + " - 99.9pct: %d - 99.99pct: %d"
+                        + " - 99.999pct: %d - Max: %d",
+                reportHistogram.getMean(),
+                reportHistogram.getValueAtPercentile(50),
+                reportHistogram.getValueAtPercentile(95),
+                reportHistogram.getValueAtPercentile(99),
+                reportHistogram.getValueAtPercentile(99.9),
+                reportHistogram.getValueAtPercentile(99.99),
+                reportHistogram.getValueAtPercentile(99.999),
+                reportHistogram.getMaxValue());
+    }
+}

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumerV4.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumerV4.java
@@ -1,0 +1,226 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.testclient;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.apache.pulsar.testclient.PerfClientUtils.LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS;
+import java.nio.ByteBuffer;
+import java.text.DecimalFormat;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.HdrHistogram.Histogram;
+import org.HdrHistogram.Recorder;
+import org.apache.pulsar.client.api.ClientBuilder;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.ConsumerBuilder;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageListener;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
+import org.apache.pulsar.client.api.transaction.Transaction;
+import org.apache.pulsar.client.impl.ConsumerBase;
+import org.apache.pulsar.client.impl.ConsumerImpl;
+import org.apache.pulsar.client.impl.MultiTopicsConsumerImpl;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+/**
+ * The {@code consume} benchmark driven by the v4 ({@code pulsar-client-original}) client.
+ *
+ * <p>This is the counterpart of {@link PerformanceConsumer}: the benchmark itself — options,
+ * accounting, subscription fan-out, transaction lifecycle and reports — comes from
+ * {@link PerformanceConsumerBase}, and only the client bindings differ. It exists so the v4 client
+ * and v4 (non-scalable) topics can be measured without the V5 SDK in the path, and it keeps the
+ * v4-only consumer behaviour working: real {@code Exclusive}/{@code Failover}/{@code Key_Shared}
+ * subscription types, {@code MessageListener} dispatch on the client's listener threads, pooled
+ * messages, batch-index acknowledgment, the chunked-message knobs, the receiver-queue limits and
+ * the auto-scaled receiver-queue reporting.
+ */
+@Command(name = "consume-v4", description = "Test pulsar consumer performance using the v4 client.")
+public class PerformanceConsumerV4
+        extends PerformanceConsumerBase<PulsarClient, Consumer<ByteBuffer>, Message<ByteBuffer>, Transaction> {
+
+    private static final DecimalFormat DEC = new DecimalFormat("0.000");
+
+    @Option(names = { "-sp", "--subscription-position" }, description = "Subscription position")
+    private SubscriptionInitialPosition subscriptionInitialPosition = SubscriptionInitialPosition.Latest;
+
+    /** Receiver-queue depth samples, only allocated when {@code --auto-scaled-receiver-queue-size} is on. */
+    private Recorder qRecorder;
+    private Histogram qHistogram;
+    private MessageListener<ByteBuffer> listener;
+
+    public PerformanceConsumerV4() {
+        super("consume-v4");
+    }
+
+    @Override
+    protected void prepareRun() {
+        if (this.autoScaledReceiverQueueSize) {
+            // The queue-depth histogram is bounded by the receiver queue size, and the digit count
+            // is what dominates an HdrHistogram's footprint, so it uses the same precision as the
+            // latency recorders rather than a hardcoded one. See LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS.
+            // HdrHistogram rejects a highest-trackable value below 2, which `-aq -q 0` would
+            // otherwise hit at startup.
+            qRecorder = new Recorder(Math.max(2, this.receiverQueueSize), LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS);
+        }
+        this.listener = (consumer, msg) -> {
+            if (checkDone()) {
+                // The run is over. Nothing else will look at this message, but with pooled messages
+                // the listener owns the buffer, so it still has to go back to the arena.
+                releaseMessage(msg);
+                return;
+            }
+            handleMessage(consumer, msg);
+        };
+    }
+
+    @Override
+    protected PulsarClient createClient() throws PulsarClientException {
+        ClientBuilder clientBuilder = PerfClientUtils.createClientBuilderFromArguments(this)
+                .enableTransaction(this.isEnableTransaction);
+        return clientBuilder.build();
+    }
+
+    @Override
+    protected void closeClient(PulsarClient client) {
+        PerfClientUtils.closeClient(client);
+    }
+
+    @Override
+    protected CompletableFuture<Consumer<ByteBuffer>> subscribeAsync(PulsarClient client, String topic,
+                                                                     String subscription) {
+        ConsumerBuilder<ByteBuffer> consumerBuilder = client.newConsumer(Schema.BYTEBUFFER)
+                .messageListener(this.listener)
+                .receiverQueueSize(this.receiverQueueSize)
+                .maxTotalReceiverQueueSizeAcrossPartitions(this.maxTotalReceiverQueueSizeAcrossPartitions)
+                .acknowledgmentGroupTime(this.acknowledgmentsGroupingDelayMillis, TimeUnit.MILLISECONDS)
+                .subscriptionType(
+                        org.apache.pulsar.client.api.SubscriptionType.valueOf(this.subscriptionType.name()))
+                .subscriptionInitialPosition(this.subscriptionInitialPosition)
+                .autoAckOldestChunkedMessageOnQueueFull(this.autoAckOldestChunkedMessageOnQueueFull)
+                .enableBatchIndexAcknowledgment(this.batchIndexAck)
+                .poolMessages(this.poolMessages)
+                .replicateSubscriptionState(this.replicatedSubscription)
+                .autoScaledReceiverQueueSizeEnabled(this.autoScaledReceiverQueueSize)
+                .topic(topic)
+                .subscriptionName(subscription);
+        if (this.maxPendingChunkedMessage > 0) {
+            consumerBuilder.maxPendingChunkedMessage(this.maxPendingChunkedMessage);
+        }
+        if (this.expireTimeOfIncompleteChunkedMessageMs > 0) {
+            consumerBuilder.expireTimeOfIncompleteChunkedMessage(this.expireTimeOfIncompleteChunkedMessageMs,
+                    TimeUnit.MILLISECONDS);
+        }
+        if (isNotBlank(this.encKeyFile)) {
+            consumerBuilder.defaultCryptoKeyReader(this.encKeyFile);
+        }
+        return consumerBuilder.subscribeAsync();
+    }
+
+    @Override
+    protected Transaction newTransaction(PulsarClient client) throws Exception {
+        return client.newTransaction()
+                .withTransactionTimeout(this.transactionTimeout, TimeUnit.SECONDS)
+                .build()
+                .get();
+    }
+
+    @Override
+    protected CompletableFuture<Void> commitTransaction(Transaction transaction) {
+        return transaction.commit();
+    }
+
+    @Override
+    protected CompletableFuture<Void> abortTransaction(Transaction transaction) {
+        return transaction.abort();
+    }
+
+    @Override
+    protected int messageSize(Message<ByteBuffer> msg) {
+        return msg.size();
+    }
+
+    @Override
+    protected long publishTimeMillis(Message<ByteBuffer> msg) {
+        return msg.getPublishTime();
+    }
+
+    @Override
+    protected void acknowledge(Consumer<ByteBuffer> consumer, Message<ByteBuffer> msg, Transaction transaction) {
+        // The v4 acknowledge is asynchronous; count the outcome when the future completes.
+        CompletableFuture<Void> ackFuture = transaction != null
+                ? consumer.acknowledgeAsync(msg.getMessageId(), transaction)
+                : consumer.acknowledgeAsync(msg);
+        ackFuture.thenRun(this::ackSucceeded).exceptionally(throwable -> {
+            ackFailed(throwable);
+            return null;
+        });
+    }
+
+    @Override
+    protected void releaseMessage(Message<ByteBuffer> msg) {
+        if (this.poolMessages) {
+            msg.release();
+        }
+    }
+
+    @Override
+    protected void onMessageDequeued(Consumer<ByteBuffer> consumer) {
+        if (qRecorder != null) {
+            qRecorder.recordValue(((ConsumerBase<?>) consumer).getTotalIncomingMessages());
+        }
+    }
+
+    @Override
+    protected void reportIntervalExtras(List<Consumer<ByteBuffer>> consumers) {
+        if (qRecorder == null) {
+            return;
+        }
+        qHistogram = qRecorder.getIntervalHistogram(qHistogram);
+        log.debug()
+                .attr("cnt", qHistogram.getTotalCount())
+                .attr("mean", DEC.format(qHistogram.getMean()))
+                .attr("min", qHistogram.getMinValue())
+                .attr("max", qHistogram.getMaxValue())
+                .attr("pct", qHistogram.getValueAtPercentile(25))
+                .attr("pct2", qHistogram.getValueAtPercentile(50))
+                .attr("pct3", qHistogram.getValueAtPercentile(75))
+                .log("ReceiverQueueUsage: cnt= ,mean= , min= ,max= ,25pct= ,50pct= ,75pct");
+        qHistogram.reset();
+        for (Consumer<ByteBuffer> consumer : consumers) {
+            ConsumerBase<?> consumerBase = (ConsumerBase<?>) consumer;
+            log.debug()
+                    .attr("consumerName", consumerBase.getConsumerName())
+                    .attr("currentReceiverQueueSize", consumerBase.getCurrentReceiverQueueSize())
+                    .log("CurrentReceiverQueueSize");
+            if (consumerBase instanceof MultiTopicsConsumerImpl) {
+                for (ConsumerImpl<?> subConsumer : ((MultiTopicsConsumerImpl<?>) consumerBase).getConsumers()) {
+                    log.debug()
+                            .attr("consumerName", subConsumer.getConsumerName())
+                            .attr("currentReceiverQueueSize", subConsumer.getCurrentReceiverQueueSize())
+                            .log("SubConsumer.CurrentReceiverQueueSize");
+                }
+            }
+        }
+    }
+}

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
@@ -18,47 +18,11 @@
  */
 package org.apache.pulsar.testclient;
 
-import static java.util.Objects.requireNonNull;
-import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
-import static org.apache.pulsar.client.impl.conf.ProducerConfigurationData.DEFAULT_BATCHING_MAX_MESSAGES;
-import static org.apache.pulsar.client.impl.conf.ProducerConfigurationData.DEFAULT_MAX_PENDING_MESSAGES;
-import static org.apache.pulsar.client.impl.conf.ProducerConfigurationData.DEFAULT_MAX_PENDING_MESSAGES_ACROSS_PARTITIONS;
-import static org.apache.pulsar.testclient.PerfClientUtils.LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectWriter;
-import com.google.common.collect.Range;
-import com.google.common.util.concurrent.RateLimiter;
-import io.netty.util.concurrent.DefaultThreadFactory;
-import java.io.FileOutputStream;
-import java.io.PrintStream;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Random;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.Semaphore;
-import java.util.concurrent.ThreadLocalRandom;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.atomic.LongAdder;
-import lombok.CustomLog;
-import org.HdrHistogram.Histogram;
-import org.HdrHistogram.HistogramLogWriter;
-import org.HdrHistogram.Recorder;
-import org.apache.pulsar.client.admin.PulsarAdmin;
-import org.apache.pulsar.client.admin.PulsarAdminBuilder;
-import org.apache.pulsar.client.admin.PulsarAdminException;
+import java.util.concurrent.CompletableFuture;
 import org.apache.pulsar.client.api.v5.Producer;
 import org.apache.pulsar.client.api.v5.ProducerBuilder;
 import org.apache.pulsar.client.api.v5.PulsarClient;
@@ -77,394 +41,44 @@ import org.apache.pulsar.client.api.v5.config.ProducerAccessMode;
 import org.apache.pulsar.client.api.v5.config.ProducerEncryptionPolicy;
 import org.apache.pulsar.client.api.v5.config.TransactionPolicy;
 import org.apache.pulsar.client.api.v5.schema.Schema;
-import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
-import org.apache.pulsar.common.util.FutureUtil;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.ITypeConverter;
 import picocli.CommandLine.Option;
-import picocli.CommandLine.TypeConversionException;
 
 /**
- * A client program to test pulsar producer performance.
+ * A client program to test pulsar producer performance with the V5 client API.
+ *
+ * <p>The V5 client is used so the command works transparently against both regular and scalable
+ * topics. Everything that is not V5-specific lives in {@link PerformanceProducerBase}; the v4
+ * client is driven by {@link PerformanceProducerV4} under the {@code produce-v4} name.
  */
 @Command(name = "produce", description = "Test pulsar producer performance.")
-@CustomLog
-public class PerformanceProducer extends PerformanceTopicListArguments{
-    private final LongAdder messagesSent = new LongAdder();
-    private final LongAdder messagesFailed = new LongAdder();
-    private final LongAdder bytesSent = new LongAdder();
-
-    private final LongAdder totalNumTxnOpenTxnFail = new LongAdder();
-    private final LongAdder totalNumTxnOpenTxnSuccess = new LongAdder();
-
-    private final LongAdder totalMessagesSent = new LongAdder();
-    private final LongAdder totalBytesSent = new LongAdder();
-
-    // Publish latencies are recorded in microseconds. A send slower than this means the benchmark is
-    // broken rather than slow, so values are clamped to keep HdrHistogram in range.
-    private static final long MAX_LATENCY_MICROS = TimeUnit.HOURS.toMicros(1);
-
-    private final Recorder recorder =
-            new Recorder(MAX_LATENCY_MICROS, LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS);
-    private final Recorder cumulativeRecorder =
-            new Recorder(MAX_LATENCY_MICROS, LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS);
-
-    private final LongAdder totalEndTxnOpSuccessNum = new LongAdder();
-    private final LongAdder totalEndTxnOpFailNum = new LongAdder();
-    private final LongAdder numTxnOpSuccess = new LongAdder();
-
-    private static IMessageFormatter messageFormatter = null;
-
-    @Option(names = { "-threads", "--num-test-threads" }, description = "Number of test threads",
-            converter = PositiveNumberParameterConvert.class
-    )
-    public int numTestThreads = 1;
-
-    @Option(names = { "-r", "--rate" }, description = "Publish rate msg/s across topics")
-    public int msgRate = 100;
-
-    @Option(names = { "-s", "--size" }, description = "Message size (bytes)")
-    public int msgSize = 1024;
-
-    @Option(names = { "-n", "--num-producers" }, description = "Number of producers (per topic)",
-            converter = PositiveNumberParameterConvert.class
-    )
-    public int numProducers = 1;
-
-    @Option(names = {"--separator"}, description = "Separator between the topic and topic number")
-    public String separator = "-";
-
-    @Option(names = {"--send-timeout"}, description = "Set the sendTimeout value default 0 to keep "
-            + "compatibility with previous version of pulsar-perf")
-    public int sendTimeout = 0;
-
-    @Option(names = { "-pn", "--producer-name" }, description = "Producer Name")
-    public String producerName = null;
-
-    @Option(names = { "-au", "--admin-url" }, description = "Pulsar Admin URL", descriptionKey = "webServiceUrl")
-    public String adminURL;
-
-    @Option(names = { "-ch",
-            "--chunking" }, description = "Should split the message and publish in chunks if message size is "
-            + "larger than allowed max size")
-    private boolean chunkingAllowed = false;
-
-    @Option(names = { "-o", "--max-outstanding" }, description = "Max number of outstanding messages")
-    public int maxOutstanding = DEFAULT_MAX_PENDING_MESSAGES;
-
-    @Option(names = { "-p", "--max-outstanding-across-partitions" }, description = "Max number of outstanding "
-            + "messages across partitions")
-    public int maxPendingMessagesAcrossPartitions = DEFAULT_MAX_PENDING_MESSAGES_ACROSS_PARTITIONS;
-
-    @Option(names = { "-np", "--partitions" }, description = "Create partitioned topics with the given number "
-            + "of partitions, set 0 to not try to create the topic")
-    public Integer partitions = null;
-
-    @Option(names = { "-m",
-            "--num-messages" }, description = "Number of messages to publish in total. If <= 0, it will keep "
-            + "publishing")
-    public long numMessages = 0;
+public class PerformanceProducer
+        extends PerformanceProducerBase<PulsarClient, AsyncProducer<byte[]>, Transaction> {
 
     @Option(names = { "-z", "--compression" }, description = "Compress messages payload")
     public CompressionType compression = CompressionType.NONE;
 
-    @Option(names = { "-f", "--payload-file" }, description = "Use payload from an UTF-8 encoded text file and "
-            + "a payload will be randomly selected when publishing messages")
-    public String payloadFilename = null;
-
-    @Option(names = { "-e", "--payload-delimiter" }, description = "The delimiter used to split lines when "
-            + "using payload from a file")
-    // here escaping \n since default value will be printed with the help text
-    public String payloadDelimiter = "\\n";
-
-    @Option(names = { "-b",
-            "--batch-time-window" }, description = "Batch messages in 'x' ms window (Default: 1ms)")
-    public double batchTimeMillis = 1.0;
-
-    @Option(names = { "-db",
-            "--disable-batching" }, description = "Disable batching if true")
-    public boolean disableBatching;
-
-    @Option(names = {
-            "-bm", "--batch-max-messages"
-    }, description = "Maximum number of messages per batch")
-    public int batchMaxMessages = DEFAULT_BATCHING_MAX_MESSAGES;
-
-    @Option(names = {
-            "-bb", "--batch-max-bytes"
-    }, description = "Maximum number of bytes per batch")
-    public int batchMaxBytes = 4 * 1024 * 1024;
-
-    @Option(names = { "-time",
-            "--test-duration" }, description = "Test duration in secs. If <= 0, it will keep publishing")
-    public long testTime = 0;
-
-    @Option(names = "--warmup-time", description = "Warm-up time in seconds (Default: 1 sec)")
-    public double warmupTimeSeconds = 1.0;
-
-    @Option(names = { "-k", "--encryption-key-name" }, description = "The public key name to encrypt payload")
-    public String encKeyName = null;
-
-    @Option(names = { "-v",
-            "--encryption-key-value-file" },
-            description = "The file which contains the public key to encrypt payload")
-    public String encKeyFile = null;
-
-    @Option(names = { "-d",
-            "--delay" }, description = "Mark messages with a given delay in seconds")
-    public long delay = 0;
-
-    @Option(names = { "-dr", "--delay-range"}, description = "Mark messages with a given delay by a random"
-            + " number of seconds. this value between the specified origin (inclusive) and the specified bound"
-            + " (exclusive). e.g. 1,300", converter = RangeConvert.class)
-    public Range<Long> delayRange = null;
-
-    @Option(names = { "-set",
-            "--set-event-time" }, description = "Set the eventTime on messages")
-    public boolean setEventTime = false;
-
-    @Option(names = { "-ef",
-            "--exit-on-failure" }, description = "Exit from the process on publish failure (default: disable)")
-    public boolean exitOnFailure = false;
-
-    @Option(names = {"-mk", "--message-key-generation-mode"}, description = "The generation mode of message key"
-            + ", valid options are: [autoIncrement, random]", descriptionKey = "messageKeyGenerationMode")
-    public String messageKeyGenerationMode = null;
-
     @Option(names = { "-am", "--access-mode" }, description = "Producer access mode")
     public ProducerAccessMode producerAccessMode = ProducerAccessMode.SHARED;
-
-    @Option(names = { "-fp", "--format-payload" },
-            description = "Format %%i as a message index in the stream from producer and/or %%t as the timestamp"
-                    + " nanoseconds.")
-    public boolean formatPayload = false;
-
-    @Option(names = {"-fc", "--format-class"}, description = "Custom Formatter class name")
-    public String formatterClass = "org.apache.pulsar.testclient.DefaultMessageFormatter";
-
-    @Option(names = {"-tto", "--txn-timeout"}, description = "Set the time value of transaction timeout,"
-            + " and the time unit is second. (After --txn-enable setting to true, --txn-timeout takes effect)")
-    public long transactionTimeout = 10;
-
-    @Option(names = {"-nmt", "--numMessage-perTransaction"},
-            description = "The number of messages sent by a transaction. "
-                    + "(After --txn-enable setting to true, -nmt takes effect)")
-    public int numMessagesPerTransaction = 50;
-
-    @Option(names = {"-txn", "--txn-enable"}, description = "Enable or disable the transaction")
-    public boolean isEnableTransaction = false;
-
-    @Option(names = {"-abort"}, description = "Abort the transaction. (After --txn-enable "
-            + "setting to true, -abort takes effect)")
-    public boolean isAbortTransaction = false;
-
-    @Option(names = { "--histogram-file" }, description = "HdrHistogram output file")
-    public String histogramFile = null;
-
-    @Override
-    public void run() throws Exception {
-
-        // Dump config variables
-        PerfClientUtils.printJVMInformation(log);
-        ObjectMapper m = new ObjectMapper();
-        ObjectWriter w = m.writerWithDefaultPrettyPrinter();
-        log.info().attr("config", w.writeValueAsString(this)).log("Starting Pulsar perf producer with config");
-
-        // Read payload data from file if needed
-        final byte[] payloadBytes = new byte[msgSize];
-        Random random = new Random(0);
-        List<byte[]> payloadByteList = new ArrayList<>();
-        if (this.payloadFilename != null) {
-            Path payloadFilePath = Paths.get(this.payloadFilename);
-            if (Files.notExists(payloadFilePath) || Files.size(payloadFilePath) == 0)  {
-                throw new IllegalArgumentException("Payload file doesn't exist or it is empty.");
-            }
-            // here escaping the default payload delimiter to correct value
-            String delimiter = this.payloadDelimiter.equals("\\n") ? "\n" : this.payloadDelimiter;
-            String[] payloadList = new String(Files.readAllBytes(payloadFilePath),
-                    StandardCharsets.UTF_8).split(delimiter);
-            log.info()
-                    .attr("payloads", payloadFilePath.toAbsolutePath())
-                    .attr("length", payloadList.length)
-                    .log("Reading payloads from and records read");
-            for (String payload : payloadList) {
-                payloadByteList.add(payload.getBytes(StandardCharsets.UTF_8));
-            }
-
-            if (this.formatPayload) {
-                messageFormatter = getMessageFormatter(this.formatterClass);
-            }
-        } else {
-            for (int i = 0; i < payloadBytes.length; ++i) {
-                payloadBytes[i] = (byte) (random.nextInt(26) + 65);
-            }
-        }
-
-        long start = System.nanoTime();
-
-        ExecutorService executor = Executors
-                .newCachedThreadPool(new DefaultThreadFactory("pulsar-perf-producer-exec"));
-        Thread shutdownHookThread = PerfClientUtils.addShutdownHook(() -> {
-            executorShutdownNow(executor);
-            printAggregatedThroughput(start);
-            printAggregatedStats();
-        });
-
-        if (this.partitions  != null) {
-            final PulsarAdminBuilder adminBuilder = PerfClientUtils
-                    .createAdminBuilderFromArguments(this, this.adminURL);
-
-            try (PulsarAdmin adminClient = adminBuilder.build()) {
-                for (String topic : this.topics) {
-                    log.info()
-                            .attr("topic", topic)
-                            .attr("partitions", this.partitions)
-                            .log("Creating partitioned topic with partitions");
-                    try {
-                        adminClient.topics().createPartitionedTopic(topic, this.partitions);
-                    } catch (PulsarAdminException.ConflictException alreadyExists) {
-                        log.debug().attr("topic", topic).attr("exists", alreadyExists).log("Topic already exists");
-                        PartitionedTopicMetadata partitionedTopicMetadata = adminClient.topics()
-                                .getPartitionedTopicMetadata(topic);
-                        if (partitionedTopicMetadata.partitions != this.partitions) {
-                            log.error()
-                                    .attr("topic", topic)
-                                    .attr("partitions", partitionedTopicMetadata.partitions)
-                                    .attr("expecting", this.partitions)
-                                    .log("Topic  already exists but it has a wrong number of partitions: , expecting");
-                            PerfClientUtils.exit(1);
-                        }
-                    }
-                }
-            }
-        }
-
-        CountDownLatch doneLatch = new CountDownLatch(this.numTestThreads);
-
-        final long numMessagesPerThread = this.numMessages / this.numTestThreads;
-        final int msgRatePerThread = this.msgRate / this.numTestThreads;
-
-        for (int i = 0; i < this.numTestThreads; i++) {
-            final int threadIdx = i;
-            executor.submit(() -> {
-                log.info().attr("thread", threadIdx).log("Started performance test thread");
-                runProducer(
-                        threadIdx,
-                        this,
-                        numMessagesPerThread,
-                        msgRatePerThread,
-                        payloadByteList,
-                        payloadBytes,
-                        doneLatch
-                );
-            });
-        }
-
-        // Print report stats
-        long oldTime = System.nanoTime();
-
-        Histogram reportHistogram = null;
-        HistogramLogWriter histogramLogWriter = null;
-
-        if (this.histogramFile != null) {
-            String statsFileName = this.histogramFile;
-            log.info().attr("stats", statsFileName).log("Dumping latency stats to");
-
-            PrintStream histogramLog = new PrintStream(new FileOutputStream(statsFileName), false);
-            histogramLogWriter = new HistogramLogWriter(histogramLog);
-
-            // Some log header bits
-            histogramLogWriter.outputLogFormatVersion();
-            histogramLogWriter.outputLegend();
-        }
-
-        while (!Thread.currentThread().isInterrupted()) {
-            try {
-                Thread.sleep(10000);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                break;
-            }
-
-            if (doneLatch.getCount() <= 0) {
-                break;
-            }
-
-            long now = System.nanoTime();
-            double elapsed = (now - oldTime) / 1e9;
-            long total = totalMessagesSent.sum();
-            long totalTxnOpSuccess = 0;
-            long totalTxnOpFail = 0;
-            double rateOpenTxn = 0;
-            double rate = messagesSent.sumThenReset() / elapsed;
-            double failureRate = messagesFailed.sumThenReset() / elapsed;
-            double throughput = bytesSent.sumThenReset() / elapsed / 1024 / 1024 * 8;
-
-            reportHistogram = recorder.getIntervalHistogram(reportHistogram);
-
-            if (this.isEnableTransaction) {
-                totalTxnOpSuccess = totalEndTxnOpSuccessNum.sum();
-                totalTxnOpFail = totalEndTxnOpFailNum.sum();
-                rateOpenTxn = numTxnOpSuccess.sumThenReset() / elapsed;
-                log.infof("--- Transaction: %d transaction end successfully"
-                                + " --- %d transaction end failed --- %.3f Txn/s",
-                        totalTxnOpSuccess, totalTxnOpFail, rateOpenTxn);
-            }
-            log.infof("Throughput produced: %7d msg --- %8.1f msg/s --- %8.1f Mbit/s"
-                            + " --- failure %8.1f msg/s"
-                            + " --- Latency: mean: %7.3f ms - med: %7.3f"
-                            + " - 95pct: %7.3f - 99pct: %7.3f"
-                            + " - 99.9pct: %7.3f - 99.99pct: %7.3f - Max: %7.3f",
-                    total, rate, throughput, failureRate,
-                    reportHistogram.getMean() / 1000.0,
-                    reportHistogram.getValueAtPercentile(50) / 1000.0,
-                    reportHistogram.getValueAtPercentile(95) / 1000.0,
-                    reportHistogram.getValueAtPercentile(99) / 1000.0,
-                    reportHistogram.getValueAtPercentile(99.9) / 1000.0,
-                    reportHistogram.getValueAtPercentile(99.99) / 1000.0,
-                    reportHistogram.getMaxValue() / 1000.0);
-
-            if (histogramLogWriter != null) {
-                histogramLogWriter.outputIntervalHistogram(reportHistogram);
-            }
-
-            reportHistogram.reset();
-
-            oldTime = now;
-        }
-
-        PerfClientUtils.removeAndRunShutdownHook(shutdownHookThread);
-    }
 
     public PerformanceProducer() {
         super("produce");
     }
 
-    private static void executorShutdownNow(ExecutorService executor) {
-        executor.shutdownNow();
-        try {
-            if (!executor.awaitTermination(10, TimeUnit.SECONDS)) {
-                log.warn("Failed to terminate executor within timeout. The following are stack"
-                        + " traces of still running threads.");
-            }
-        } catch (InterruptedException e) {
-            log.warn("Shutdown of thread pool was interrupted");
-            Thread.currentThread().interrupt();
+    @Override
+    protected PulsarClient createClient() throws PulsarClientException {
+        PulsarClientBuilder clientBuilder = PerfClientUtils.createV5ClientBuilderFromArguments(this);
+        if (this.isEnableTransaction) {
+            clientBuilder.transactionPolicy(TransactionPolicy.builder()
+                    .timeout(Duration.ofSeconds(this.transactionTimeout))
+                    .build());
         }
+        return clientBuilder.build();
     }
 
-    @SuppressWarnings("unchecked")
-    static IMessageFormatter getMessageFormatter(String formatterClass) {
-        try {
-            ClassLoader classLoader = PerformanceProducer.class.getClassLoader();
-            Class clz = classLoader.loadClass(formatterClass);
-            return (IMessageFormatter) clz.getDeclaredConstructor().newInstance();
-        } catch (Exception e) {
-            if (PerfClientUtils.hasInterruptedException(e)) {
-                Thread.currentThread().interrupt();
-            }
-            return null;
-        }
+    @Override
+    protected void closeClient(PulsarClient client) {
+        PerfClientUtils.closeClient(client);
     }
 
     ProducerBuilder<byte[]> createProducerBuilder(PulsarClient client, int producerId, String topic) {
@@ -479,7 +93,8 @@ public class PerformanceProducer extends PerformanceTopicListArguments{
         // messageRoutingMode as user-configurable knobs; the SDK manages memory via the
         // client-level MemorySize policy and routes appropriately for regular and scalable
         // topics. The legacy --max-outstanding / --max-outstanding-across-partitions flags
-        // are accepted for back-compat but have no effect on the V5 client.
+        // are accepted for back-compat but have no effect on the V5 client. Use produce-v4
+        // to exercise them.
 
         if (this.producerName != null) {
             producerBuilder.producerName(String.format("%s%s%d", this.producerName, this.separator, producerId));
@@ -506,7 +121,7 @@ public class PerformanceProducer extends PerformanceTopicListArguments{
 
         if (isNotBlank(this.encKeyName) && isNotBlank(this.encKeyFile)) {
             PemFileKeyProvider keyProvider = PemFileKeyProvider.builder()
-                    .publicKey(this.encKeyName, java.nio.file.Path.of(this.encKeyFile))
+                    .publicKey(this.encKeyName, Path.of(this.encKeyFile))
                     .build();
             producerBuilder.encryptionPolicy(ProducerEncryptionPolicy.builder()
                     .publicKeyProvider(keyProvider)
@@ -517,333 +132,54 @@ public class PerformanceProducer extends PerformanceTopicListArguments{
         return producerBuilder;
     }
 
-    private void runProducer(int producerId,
-                                    PerformanceProducer arguments,
-                                    long numMessages,
-                                    int msgRate,
-                                    List<byte[]> payloadByteList,
-                                    byte[] payloadBytes,
-                                    CountDownLatch doneLatch) {
-        PulsarClient client = null;
-        boolean produceEnough = false;
-        try {
-            List<Future<Producer<byte[]>>> futures = new ArrayList<>();
+    @Override
+    protected CompletableFuture<AsyncProducer<byte[]>> createProducerAsync(PulsarClient client, int producerId,
+                                                                           String topic) {
+        return createProducerBuilder(client, producerId, topic).createAsync().thenApply(Producer::async);
+    }
 
-            PulsarClientBuilder clientBuilder = PerfClientUtils.createV5ClientBuilderFromArguments(arguments);
-            if (this.isEnableTransaction) {
-                clientBuilder.transactionPolicy(TransactionPolicy.builder()
-                        .timeout(Duration.ofSeconds(this.transactionTimeout))
-                        .build());
-            }
-            client = clientBuilder.build();
+    @Override
+    protected Transaction newTransaction(PulsarClient client) throws PulsarClientException {
+        return client.newTransaction();
+    }
 
-            AtomicReference<Transaction> transactionAtomicReference;
-            if (this.isEnableTransaction) {
-                transactionAtomicReference = new AtomicReference<>(
-                        PerfClientUtils.newTransactionWithRetry(client));
-            } else {
-                transactionAtomicReference = new AtomicReference<>(null);
-            }
+    @Override
+    protected Transaction openFirstTransaction(PulsarClient client)
+            throws PulsarClientException, InterruptedException {
+        return PerfClientUtils.newTransactionWithRetry(client);
+    }
 
-            for (int i = 0; i < this.numTopics; i++) {
+    @Override
+    protected CompletableFuture<Void> commitTransaction(Transaction transaction) {
+        return transaction.async().commit();
+    }
 
-                String topic = this.topics.get(i);
-                log.info().attr("adding", this.numProducers).attr("topic", topic).log("Adding publishers on topic");
+    @Override
+    protected CompletableFuture<Void> abortTransaction(Transaction transaction) {
+        return transaction.async().abort();
+    }
 
-                for (int j = 0; j < this.numProducers; j++) {
-                    ProducerBuilder<byte[]> prodBuilder = createProducerBuilder(client, producerId, topic);
-                    futures.add(prodBuilder.createAsync());
-                }
-            }
-
-            final List<Producer<byte[]>> producers = new ArrayList<>(futures.size());
-            for (Future<Producer<byte[]>> future : futures) {
-                producers.add(future.get());
-            }
-            Collections.shuffle(producers);
-            final List<AsyncProducer<byte[]>> asyncProducers = new ArrayList<>(producers.size());
-            for (Producer<byte[]> p : producers) {
-                asyncProducers.add(p.async());
-            }
-
-            log.info().attr("created", producers.size()).log("Created producers");
-
-            RateLimiter rateLimiter = RateLimiter.create(msgRate);
-
-            long startTime = System.nanoTime();
-            long warmupEndTime = startTime + (long) (this.warmupTimeSeconds * 1e9);
-            long testEndTime = startTime + (long) (this.testTime * 1e9);
-            MessageKeyGenerationMode msgKeyMode = null;
-            if (isNotBlank(this.messageKeyGenerationMode)) {
-                try {
-                    msgKeyMode = MessageKeyGenerationMode.valueOf(this.messageKeyGenerationMode);
-                } catch (IllegalArgumentException e) {
-                    throw new IllegalArgumentException("messageKeyGenerationMode only support [autoIncrement, random]");
-                }
-            }
-            // Send messages on all topics/producers
-            AtomicLong totalSent = new AtomicLong(0);
-            AtomicLong numMessageSend = new AtomicLong(0);
-            Semaphore numMsgPerTxnLimit = new Semaphore(this.numMessagesPerTransaction);
-            // Send futures of the in-flight transaction. V5 transaction-aware sends are queued
-            // onto an internal dispatch chain, so the v4-side txn-coordinator registration can
-            // lag the local counter; we await these before committing so commit never races
-            // ahead of the sends (otherwise the broker rejects with InvalidTxnStatusException).
-            final List<java.util.concurrent.CompletableFuture<?>> pendingTxnSends = new ArrayList<>();
-            while (!Thread.currentThread().isInterrupted()) {
-                if (produceEnough) {
-                    break;
-                }
-                for (AsyncProducer<byte[]> producer : asyncProducers) {
-                    if (this.testTime > 0) {
-                        if (System.nanoTime() > testEndTime) {
-                            log.info()
-                                    .attr("duration", this.testTime)
-                                    .log("------------- DONE (reached the maximum duration:"
-                                            + " [ seconds] of production) --------------");
-                            doneLatch.countDown();
-                            produceEnough = true;
-                            break;
-                        }
-                    }
-
-                    if (numMessages > 0) {
-                        if (totalSent.get() >= numMessages) {
-                            log.info()
-                                    .attr("number", numMessages)
-                                    .log("DONE (reached the maximum number: of production");
-                            doneLatch.countDown();
-                            produceEnough = true;
-                            break;
-                        }
-                    }
-                    rateLimiter.acquire();
-                    //if transaction is disable, transaction will be null.
-                    Transaction transaction = transactionAtomicReference.get();
-                    final long sendTime = System.nanoTime();
-
-                    byte[] payloadData;
-
-                    if (this.payloadFilename != null) {
-                        if (messageFormatter != null) {
-                            payloadData = messageFormatter.formatMessage(this.producerName, totalSent.get(),
-                                    payloadByteList.get(ThreadLocalRandom.current().nextInt(payloadByteList.size())));
-                        } else {
-                            payloadData = payloadByteList.get(
-                                    ThreadLocalRandom.current().nextInt(payloadByteList.size()));
-                        }
-                    } else {
-                        payloadData = payloadBytes;
-                    }
-                    AsyncMessageBuilder<byte[]> messageBuilder = producer.newMessage().value(payloadData);
-                    if (this.isEnableTransaction) {
-                        if (this.numMessagesPerTransaction > 0) {
-                            try {
-                                numMsgPerTxnLimit.acquire();
-                            } catch (InterruptedException exception){
-                                log.error().exception(exception).log("Get exception");
-                                Thread.currentThread().interrupt();
-                            }
-                        }
-                        messageBuilder.transaction(transaction);
-                    }
-                    if (this.delay > 0) {
-                        messageBuilder.deliverAfter(Duration.ofSeconds(this.delay));
-                    } else if (this.delayRange != null) {
-                        final long deliverAfter = ThreadLocalRandom.current()
-                                .nextLong(this.delayRange.lowerEndpoint(), this.delayRange.upperEndpoint());
-                        messageBuilder.deliverAfter(Duration.ofSeconds(deliverAfter));
-                    }
-                    if (this.setEventTime) {
-                        messageBuilder.eventTime(Instant.now());
-                    }
-                    //generate msg key
-                    if (msgKeyMode == MessageKeyGenerationMode.random) {
-                        messageBuilder.key(String.valueOf(ThreadLocalRandom.current().nextInt()));
-                    } else if (msgKeyMode == MessageKeyGenerationMode.autoIncrement) {
-                        messageBuilder.key(String.valueOf(totalSent.get()));
-                    }
-                    PulsarClient pulsarClient = client;
-                    var sendFuture = messageBuilder.send().thenRun(() -> {
-                        bytesSent.add(payloadData.length);
-                        messagesSent.increment();
-                        totalSent.incrementAndGet();
-                        totalMessagesSent.increment();
-                        totalBytesSent.add(payloadData.length);
-
-                        long now = System.nanoTime();
-                        if (now > warmupEndTime) {
-                            long latencyMicros =
-                                    Math.min(NANOSECONDS.toMicros(now - sendTime), MAX_LATENCY_MICROS);
-                            recorder.recordValue(latencyMicros);
-                            cumulativeRecorder.recordValue(latencyMicros);
-                        }
-                    }).exceptionally(ex -> {
-                        Throwable cause = FutureUtil.unwrapCompletionException(ex);
-                        // Ignore the exception when the producer is closed
-                        if (cause instanceof PulsarClientException.AlreadyClosedException) {
-                            return null;
-                        }
-                        if (PerfClientUtils.hasInterruptedException(ex)) {
-                            Thread.currentThread().interrupt();
-                            return null;
-                        }
-                        log.warn().exception(ex).log("Write message error with exception");
-                        messagesFailed.increment();
-                        if (this.exitOnFailure) {
-                            PerfClientUtils.exit(1);
-                        }
-                        return null;
-                    });
-                    if (this.isEnableTransaction) {
-                        pendingTxnSends.add(sendFuture);
-                    }
-                    if (this.isEnableTransaction
-                            && numMessageSend.incrementAndGet() == this.numMessagesPerTransaction) {
-                        // Await all sends issued under this transaction before committing, so the
-                        // txn coordinator has registered every send. The chain above already
-                        // swallows per-send failures, so this join never throws on a send error.
-                        try {
-                            java.util.concurrent.CompletableFuture.allOf(
-                                    pendingTxnSends.toArray(new java.util.concurrent.CompletableFuture[0]))
-                                    .join();
-                        } catch (Exception awaitEx) {
-                            if (PerfClientUtils.hasInterruptedException(awaitEx)) {
-                                Thread.currentThread().interrupt();
-                            }
-                        }
-                        pendingTxnSends.clear();
-                        if (!this.isAbortTransaction) {
-                            transaction.async().commit()
-                                    .thenRun(() -> {
-                                        log.debug().log("Committed transaction");
-                                        totalEndTxnOpSuccessNum.increment();
-                                        numTxnOpSuccess.increment();
-                                    })
-                                    .exceptionally(exception -> {
-                                        if (PerfClientUtils.hasInterruptedException(exception)) {
-                                            Thread.currentThread().interrupt();
-                                            return null;
-                                        }
-                                        log.error()
-                                                .exception(exception)
-                                                .log("Commit transaction failed with exception");
-                                        totalEndTxnOpFailNum.increment();
-                                        return null;
-                                    });
-                        } else {
-                            transaction.async().abort().thenRun(() -> {
-                                log.debug().log("Abort transaction");
-                                totalEndTxnOpSuccessNum.increment();
-                                numTxnOpSuccess.increment();
-                            }).exceptionally(exception -> {
-                                if (PerfClientUtils.hasInterruptedException(exception)) {
-                                    Thread.currentThread().interrupt();
-                                    return null;
-                                }
-                                log.error()
-                                        .exception(exception)
-                                        .log("Abort transaction failed with exception");
-                                totalEndTxnOpFailNum.increment();
-                                return null;
-                            });
-                        }
-                        while (!Thread.currentThread().isInterrupted()) {
-                            try {
-                                Transaction newTransaction = pulsarClient.newTransaction();
-                                transactionAtomicReference.compareAndSet(transaction, newTransaction);
-                                numMessageSend.set(0);
-                                numMsgPerTxnLimit.release(this.numMessagesPerTransaction);
-                                totalNumTxnOpenTxnSuccess.increment();
-                                break;
-                            } catch (Exception e){
-                                if (PerfClientUtils.hasInterruptedException(e)) {
-                                    Thread.currentThread().interrupt();
-                                } else {
-                                    totalNumTxnOpenTxnFail.increment();
-                                    log.error().exception(e).log("Failed to new transaction with exception");
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        } catch (Throwable t) {
-            if (PerfClientUtils.hasInterruptedException(t)) {
-                Thread.currentThread().interrupt();
-            } else {
-                log.error().exception(t).log("Got error");
-            }
-        } finally {
-            if (!produceEnough) {
-                doneLatch.countDown();
-            }
-            PerfClientUtils.closeClient(client);
+    @Override
+    protected CompletableFuture<?> sendMessage(AsyncProducer<byte[]> producer, byte[] payload,
+                                               Transaction transaction, String key, Long deliverAfterSeconds) {
+        AsyncMessageBuilder<byte[]> messageBuilder = producer.newMessage().value(payload);
+        if (transaction != null) {
+            messageBuilder.transaction(transaction);
         }
-    }
-
-    private void printAggregatedThroughput(long start) {
-        double elapsed = (System.nanoTime() - start) / 1e9;
-        double rate = totalMessagesSent.sum() / elapsed;
-        double throughput = totalBytesSent.sum() / elapsed / 1024 / 1024 * 8;
-        long totalTxnSuccess = 0;
-        long totalTxnFail = 0;
-        double rateOpenTxn = 0;
-        long numTransactionOpenFailed = 0;
-        long numTransactionOpenSuccess = 0;
-
-        if (this.isEnableTransaction) {
-            totalTxnSuccess = totalEndTxnOpSuccessNum.sum();
-            totalTxnFail = totalEndTxnOpFailNum.sum();
-            rateOpenTxn = elapsed / (totalTxnFail + totalTxnSuccess);
-            numTransactionOpenFailed = totalNumTxnOpenTxnFail.sum();
-            numTransactionOpenSuccess = totalNumTxnOpenTxnSuccess.sum();
-            log.infof("--- Transaction: %d transaction end successfully"
-                            + " --- %d transaction end failed"
-                            + " --- %d transaction open successfully"
-                            + " --- %d transaction open failed --- %.3f Txn/s",
-                    totalTxnSuccess, totalTxnFail,
-                    numTransactionOpenSuccess, numTransactionOpenFailed, rateOpenTxn);
+        if (deliverAfterSeconds != null) {
+            messageBuilder.deliverAfter(Duration.ofSeconds(deliverAfterSeconds));
         }
-        log.infof("Aggregated throughput stats --- %d records sent --- %.3f msg/s --- %.3f Mbit/s",
-                totalMessagesSent.sum(), rate, throughput);
-    }
-
-    private void printAggregatedStats() {
-        Histogram reportHistogram = cumulativeRecorder.getIntervalHistogram();
-
-        log.infof("Aggregated latency stats --- Latency: mean: %7.3f ms"
-                        + " - med: %7.3f - 95pct: %7.3f - 99pct: %7.3f"
-                        + " - 99.9pct: %7.3f - 99.99pct: %7.3f"
-                        + " - 99.999pct: %7.3f - Max: %7.3f",
-                reportHistogram.getMean() / 1000.0,
-                reportHistogram.getValueAtPercentile(50) / 1000.0,
-                reportHistogram.getValueAtPercentile(95) / 1000.0,
-                reportHistogram.getValueAtPercentile(99) / 1000.0,
-                reportHistogram.getValueAtPercentile(99.9) / 1000.0,
-                reportHistogram.getValueAtPercentile(99.99) / 1000.0,
-                reportHistogram.getValueAtPercentile(99.999) / 1000.0,
-                reportHistogram.getMaxValue() / 1000.0);
-    }
-
-    public enum MessageKeyGenerationMode {
-        autoIncrement, random
-    }
-
-    static class RangeConvert implements ITypeConverter<Range<Long>> {
-        @Override
-        public Range<Long> convert(String rangeStr) {
-            try {
-                requireNonNull(rangeStr);
-                final String[] facts = rangeStr.split(",");
-                final long min = Long.parseLong(facts[0].trim());
-                final long max = Long.parseLong(facts[1].trim());
-                return Range.closedOpen(min, max);
-            } catch (Throwable ex) {
-                throw new TypeConversionException("Unknown delay range interval,"
-                        + " the format should be \"<origin>,<bound>\". error message: " + rangeStr);
-            }
+        if (this.setEventTime) {
+            messageBuilder.eventTime(Instant.now());
         }
+        if (key != null) {
+            messageBuilder.key(key);
+        }
+        return messageBuilder.send();
     }
 
+    @Override
+    protected boolean isAlreadyClosedException(Throwable cause) {
+        return cause instanceof PulsarClientException.AlreadyClosedException;
+    }
 }

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducerBase.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducerBase.java
@@ -1,0 +1,842 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.testclient;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.apache.pulsar.client.impl.conf.ProducerConfigurationData.DEFAULT_BATCHING_MAX_MESSAGES;
+import static org.apache.pulsar.client.impl.conf.ProducerConfigurationData.DEFAULT_MAX_PENDING_MESSAGES;
+import static org.apache.pulsar.client.impl.conf.ProducerConfigurationData.DEFAULT_MAX_PENDING_MESSAGES_ACROSS_PARTITIONS;
+import static org.apache.pulsar.testclient.PerfClientUtils.LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.google.common.collect.Range;
+import com.google.common.util.concurrent.RateLimiter;
+import io.github.merlimat.slog.Logger;
+import io.netty.util.concurrent.DefaultThreadFactory;
+import java.io.FileOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.LongAdder;
+import org.HdrHistogram.Histogram;
+import org.HdrHistogram.HistogramLogWriter;
+import org.HdrHistogram.Recorder;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminBuilder;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
+import org.apache.pulsar.common.util.FutureUtil;
+import picocli.CommandLine.ITypeConverter;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.TypeConversionException;
+
+/**
+ * Client-agnostic implementation of the {@code pulsar-perf} producer benchmark.
+ *
+ * <p>Everything that does not touch a client API lives here: the CLI options, the latency and
+ * throughput accounting, the partitioned-topic pre-creation, the per-thread send loop, and the
+ * periodic and aggregated reports. Concrete subclasses bind the three client types and implement
+ * the handful of seams below — {@link PerformanceProducer} against the V5 client and
+ * {@link PerformanceProducerV4} against the v4 ({@code pulsar-client-original}) client — so both
+ * commands share one benchmark and one set of measurements.
+ *
+ * @param <ClientT> the client type ({@code PulsarClient} of the respective API generation)
+ * @param <ProducerT> the producer handle the send loop drives
+ * @param <TxnT> the transaction type used when {@code --txn-enable} is set
+ */
+public abstract class PerformanceProducerBase<ClientT, ProducerT, TxnT> extends PerformanceTopicListArguments {
+
+    /**
+     * Logger named after the <em>concrete</em> command class rather than this base, so that the
+     * report lines keep identifying the subcommand that produced them (the integration tests in
+     * {@code PerfToolTest} match on {@code PerformanceProducer - Aggregated ...}).
+     */
+    protected final Logger log = Logger.get(getClass());
+
+    private final LongAdder messagesSent = new LongAdder();
+    private final LongAdder messagesFailed = new LongAdder();
+    private final LongAdder bytesSent = new LongAdder();
+
+    private final LongAdder totalNumTxnOpenTxnFail = new LongAdder();
+    private final LongAdder totalNumTxnOpenTxnSuccess = new LongAdder();
+
+    private final LongAdder totalMessagesSent = new LongAdder();
+    private final LongAdder totalBytesSent = new LongAdder();
+
+    // Publish latencies are recorded in microseconds. A send slower than this means the benchmark is
+    // broken rather than slow, so values are clamped to keep HdrHistogram in range.
+    private static final long MAX_LATENCY_MICROS = TimeUnit.HOURS.toMicros(1);
+
+    private final Recorder recorder =
+            new Recorder(MAX_LATENCY_MICROS, LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS);
+    private final Recorder cumulativeRecorder =
+            new Recorder(MAX_LATENCY_MICROS, LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS);
+
+    private final LongAdder totalEndTxnOpSuccessNum = new LongAdder();
+    private final LongAdder totalEndTxnOpFailNum = new LongAdder();
+    private final LongAdder numTxnOpSuccess = new LongAdder();
+
+    /**
+     * Resolved from {@code --format-class} when {@code --format-payload} is set. An instance field
+     * rather than a static one: two producer subcommands can be loaded in the same JVM, and a static
+     * would leak one run's formatter into the other.
+     */
+    private IMessageFormatter messageFormatter = null;
+
+    @Option(names = { "-threads", "--num-test-threads" }, description = "Number of test threads",
+            converter = PositiveNumberParameterConvert.class
+    )
+    public int numTestThreads = 1;
+
+    @Option(names = { "-r", "--rate" }, description = "Publish rate msg/s across topics")
+    public int msgRate = 100;
+
+    @Option(names = { "-s", "--size" }, description = "Message size (bytes)")
+    public int msgSize = 1024;
+
+    @Option(names = { "-n", "--num-producers" }, description = "Number of producers (per topic)",
+            converter = PositiveNumberParameterConvert.class
+    )
+    public int numProducers = 1;
+
+    @Option(names = {"--separator"}, description = "Separator between the topic and topic number")
+    public String separator = "-";
+
+    @Option(names = {"--send-timeout"}, description = "Set the sendTimeout value default 0 to keep "
+            + "compatibility with previous version of pulsar-perf")
+    public int sendTimeout = 0;
+
+    @Option(names = { "-pn", "--producer-name" }, description = "Producer Name")
+    public String producerName = null;
+
+    @Option(names = { "-au", "--admin-url" }, description = "Pulsar Admin URL", descriptionKey = "webServiceUrl")
+    public String adminURL;
+
+    @Option(names = { "-ch",
+            "--chunking" }, description = "Should split the message and publish in chunks if message size is "
+            + "larger than allowed max size")
+    protected boolean chunkingAllowed = false;
+
+    @Option(names = { "-o", "--max-outstanding" }, description = "Max number of outstanding messages")
+    public int maxOutstanding = DEFAULT_MAX_PENDING_MESSAGES;
+
+    @Option(names = { "-p", "--max-outstanding-across-partitions" }, description = "Max number of outstanding "
+            + "messages across partitions")
+    public int maxPendingMessagesAcrossPartitions = DEFAULT_MAX_PENDING_MESSAGES_ACROSS_PARTITIONS;
+
+    @Option(names = { "-np", "--partitions" }, description = "Create partitioned topics with the given number "
+            + "of partitions, set 0 to not try to create the topic")
+    public Integer partitions = null;
+
+    @Option(names = { "-m",
+            "--num-messages" }, description = "Number of messages to publish in total. If <= 0, it will keep "
+            + "publishing")
+    public long numMessages = 0;
+
+    @Option(names = { "-f", "--payload-file" }, description = "Use payload from an UTF-8 encoded text file and "
+            + "a payload will be randomly selected when publishing messages")
+    public String payloadFilename = null;
+
+    @Option(names = { "-e", "--payload-delimiter" }, description = "The delimiter used to split lines when "
+            + "using payload from a file")
+    // here escaping \n since default value will be printed with the help text
+    public String payloadDelimiter = "\\n";
+
+    @Option(names = { "-b",
+            "--batch-time-window" }, description = "Batch messages in 'x' ms window (Default: 1ms)")
+    public double batchTimeMillis = 1.0;
+
+    @Option(names = { "-db",
+            "--disable-batching" }, description = "Disable batching if true")
+    public boolean disableBatching;
+
+    @Option(names = {
+            "-bm", "--batch-max-messages"
+    }, description = "Maximum number of messages per batch")
+    public int batchMaxMessages = DEFAULT_BATCHING_MAX_MESSAGES;
+
+    @Option(names = {
+            "-bb", "--batch-max-bytes"
+    }, description = "Maximum number of bytes per batch")
+    public int batchMaxBytes = 4 * 1024 * 1024;
+
+    @Option(names = { "-time",
+            "--test-duration" }, description = "Test duration in secs. If <= 0, it will keep publishing")
+    public long testTime = 0;
+
+    @Option(names = "--warmup-time", description = "Warm-up time in seconds (Default: 1 sec)")
+    public double warmupTimeSeconds = 1.0;
+
+    @Option(names = { "-k", "--encryption-key-name" }, description = "The public key name to encrypt payload")
+    public String encKeyName = null;
+
+    @Option(names = { "-v",
+            "--encryption-key-value-file" },
+            description = "The file which contains the public key to encrypt payload")
+    public String encKeyFile = null;
+
+    @Option(names = { "-d",
+            "--delay" }, description = "Mark messages with a given delay in seconds")
+    public long delay = 0;
+
+    @Option(names = { "-dr", "--delay-range"}, description = "Mark messages with a given delay by a random"
+            + " number of seconds. this value between the specified origin (inclusive) and the specified bound"
+            + " (exclusive). e.g. 1,300", converter = RangeConvert.class)
+    public Range<Long> delayRange = null;
+
+    @Option(names = { "-set",
+            "--set-event-time" }, description = "Set the eventTime on messages")
+    public boolean setEventTime = false;
+
+    @Option(names = { "-ef",
+            "--exit-on-failure" }, description = "Exit from the process on publish failure (default: disable)")
+    public boolean exitOnFailure = false;
+
+    @Option(names = {"-mk", "--message-key-generation-mode"}, description = "The generation mode of message key"
+            + ", valid options are: [autoIncrement, random]", descriptionKey = "messageKeyGenerationMode")
+    public String messageKeyGenerationMode = null;
+
+    @Option(names = { "-fp", "--format-payload" },
+            description = "Format %%i as a message index in the stream from producer and/or %%t as the timestamp"
+                    + " nanoseconds.")
+    public boolean formatPayload = false;
+
+    @Option(names = {"-fc", "--format-class"}, description = "Custom Formatter class name")
+    public String formatterClass = "org.apache.pulsar.testclient.DefaultMessageFormatter";
+
+    @Option(names = {"-tto", "--txn-timeout"}, description = "Set the time value of transaction timeout,"
+            + " and the time unit is second. (After --txn-enable setting to true, --txn-timeout takes effect)")
+    public long transactionTimeout = 10;
+
+    @Option(names = {"-nmt", "--numMessage-perTransaction"},
+            description = "The number of messages sent by a transaction. "
+                    + "(After --txn-enable setting to true, -nmt takes effect)")
+    public int numMessagesPerTransaction = 50;
+
+    @Option(names = {"-txn", "--txn-enable"}, description = "Enable or disable the transaction")
+    public boolean isEnableTransaction = false;
+
+    @Option(names = {"-abort"}, description = "Abort the transaction. (After --txn-enable "
+            + "setting to true, -abort takes effect)")
+    public boolean isAbortTransaction = false;
+
+    @Option(names = { "--histogram-file" }, description = "HdrHistogram output file")
+    public String histogramFile = null;
+
+    protected PerformanceProducerBase(String cmdName) {
+        super(cmdName);
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // Client-specific seams
+    // ------------------------------------------------------------------------------------------
+
+    /** Build and connect the client one test thread will use. */
+    protected abstract ClientT createClient() throws Exception;
+
+    /** Close a client built by {@link #createClient()}; must tolerate a {@code null} argument. */
+    protected abstract void closeClient(ClientT client);
+
+    /**
+     * Create one producer on {@code topic}. {@code producerId} identifies the test thread and is
+     * only used to derive a unique producer name from {@code --producer-name}.
+     */
+    protected abstract CompletableFuture<ProducerT> createProducerAsync(ClientT client, int producerId,
+                                                                        String topic);
+
+    /**
+     * Open a new transaction, honouring {@code --txn-timeout}. Used for every rollover inside the
+     * send loop, which has its own retry loop and counts each failure, so this must surface a
+     * failed open rather than retrying internally.
+     */
+    protected abstract TxnT newTransaction(ClientT client) throws Exception;
+
+    /**
+     * Open the first transaction of a test thread, before any producer exists. Separate from
+     * {@link #newTransaction} because the V5 client needs to wait out its transaction-coordinator
+     * handler's asynchronous connect here, whereas the rollover path must see each failure.
+     */
+    protected TxnT openFirstTransaction(ClientT client) throws Exception {
+        return newTransaction(client);
+    }
+
+    /** Commit a transaction. */
+    protected abstract CompletableFuture<Void> commitTransaction(TxnT transaction);
+
+    /** Abort a transaction. */
+    protected abstract CompletableFuture<Void> abortTransaction(TxnT transaction);
+
+    /**
+     * Send one message and return its completion. {@code transaction} is {@code null} unless
+     * {@code --txn-enable} is set, {@code key} is {@code null} unless {@code -mk} selected a key
+     * generation mode, and {@code deliverAfterSeconds} is {@code null} when no delivery delay was
+     * requested. Implementations must also apply {@code --set-event-time} from {@link #setEventTime}.
+     */
+    protected abstract CompletableFuture<?> sendMessage(ProducerT producer, byte[] payload, TxnT transaction,
+                                                        String key, Long deliverAfterSeconds);
+
+    /** Whether a send failure is just the producer having been closed, which is not counted or logged. */
+    protected abstract boolean isAlreadyClosedException(Throwable cause);
+
+    /**
+     * Whether the send loop awaits every send of a transaction before ending it.
+     *
+     * <p>Required on V5, whose transaction-aware sends are queued onto an internal dispatch chain
+     * that the commit can otherwise overtake. The v4 client registers the send with the transaction
+     * coordinator as part of {@code sendAsync} itself, and the v4 tool never awaited, so
+     * {@link PerformanceProducerV4} turns this off to keep its transaction throughput comparable
+     * with what {@code pulsar-perf produce} reported before the V5 migration.
+     */
+    protected boolean awaitSendsBeforeEndingTransaction() {
+        return true;
+    }
+
+    // ------------------------------------------------------------------------------------------
+
+    @Override
+    public void run() throws Exception {
+
+        // Dump config variables
+        PerfClientUtils.printJVMInformation(log);
+        ObjectMapper m = new ObjectMapper();
+        ObjectWriter w = m.writerWithDefaultPrettyPrinter();
+        log.info().attr("config", w.writeValueAsString(this)).log("Starting Pulsar perf producer with config");
+
+        // Read payload data from file if needed
+        final byte[] payloadBytes = new byte[msgSize];
+        Random random = new Random(0);
+        List<byte[]> payloadByteList = new ArrayList<>();
+        if (this.payloadFilename != null) {
+            Path payloadFilePath = Paths.get(this.payloadFilename);
+            if (Files.notExists(payloadFilePath) || Files.size(payloadFilePath) == 0)  {
+                throw new IllegalArgumentException("Payload file doesn't exist or it is empty.");
+            }
+            // here escaping the default payload delimiter to correct value
+            String delimiter = this.payloadDelimiter.equals("\\n") ? "\n" : this.payloadDelimiter;
+            String[] payloadList = new String(Files.readAllBytes(payloadFilePath),
+                    StandardCharsets.UTF_8).split(delimiter);
+            log.info()
+                    .attr("payloads", payloadFilePath.toAbsolutePath())
+                    .attr("length", payloadList.length)
+                    .log("Reading payloads from and records read");
+            for (String payload : payloadList) {
+                payloadByteList.add(payload.getBytes(StandardCharsets.UTF_8));
+            }
+
+            if (this.formatPayload) {
+                messageFormatter = getMessageFormatter(this.formatterClass);
+            }
+        } else {
+            for (int i = 0; i < payloadBytes.length; ++i) {
+                payloadBytes[i] = (byte) (random.nextInt(26) + 65);
+            }
+        }
+
+        long start = System.nanoTime();
+
+        ExecutorService executor = Executors
+                .newCachedThreadPool(new DefaultThreadFactory("pulsar-perf-producer-exec"));
+        Thread shutdownHookThread = PerfClientUtils.addShutdownHook(() -> {
+            executorShutdownNow(executor);
+            printAggregatedThroughput(start);
+            printAggregatedStats();
+        });
+
+        if (this.partitions  != null) {
+            final PulsarAdminBuilder adminBuilder = PerfClientUtils
+                    .createAdminBuilderFromArguments(this, this.adminURL);
+
+            try (PulsarAdmin adminClient = adminBuilder.build()) {
+                for (String topic : this.topics) {
+                    log.info()
+                            .attr("topic", topic)
+                            .attr("partitions", this.partitions)
+                            .log("Creating partitioned topic with partitions");
+                    try {
+                        adminClient.topics().createPartitionedTopic(topic, this.partitions);
+                    } catch (PulsarAdminException.ConflictException alreadyExists) {
+                        log.debug().attr("topic", topic).attr("exists", alreadyExists).log("Topic already exists");
+                        PartitionedTopicMetadata partitionedTopicMetadata = adminClient.topics()
+                                .getPartitionedTopicMetadata(topic);
+                        if (partitionedTopicMetadata.partitions != this.partitions) {
+                            log.error()
+                                    .attr("topic", topic)
+                                    .attr("partitions", partitionedTopicMetadata.partitions)
+                                    .attr("expecting", this.partitions)
+                                    .log("Topic  already exists but it has a wrong number of partitions: , expecting");
+                            PerfClientUtils.exit(1);
+                        }
+                    }
+                }
+            }
+        }
+
+        CountDownLatch doneLatch = new CountDownLatch(this.numTestThreads);
+
+        final long numMessagesPerThread = this.numMessages / this.numTestThreads;
+        final int msgRatePerThread = this.msgRate / this.numTestThreads;
+
+        for (int i = 0; i < this.numTestThreads; i++) {
+            final int threadIdx = i;
+            executor.submit(() -> {
+                log.info().attr("thread", threadIdx).log("Started performance test thread");
+                runProducer(
+                        threadIdx,
+                        numMessagesPerThread,
+                        msgRatePerThread,
+                        payloadByteList,
+                        payloadBytes,
+                        doneLatch
+                );
+            });
+        }
+
+        // Print report stats
+        long oldTime = System.nanoTime();
+
+        Histogram reportHistogram = null;
+        HistogramLogWriter histogramLogWriter = null;
+
+        if (this.histogramFile != null) {
+            String statsFileName = this.histogramFile;
+            log.info().attr("stats", statsFileName).log("Dumping latency stats to");
+
+            PrintStream histogramLog = new PrintStream(new FileOutputStream(statsFileName), false);
+            histogramLogWriter = new HistogramLogWriter(histogramLog);
+
+            // Some log header bits
+            histogramLogWriter.outputLogFormatVersion();
+            histogramLogWriter.outputLegend();
+        }
+
+        while (!Thread.currentThread().isInterrupted()) {
+            try {
+                Thread.sleep(10000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+
+            if (doneLatch.getCount() <= 0) {
+                break;
+            }
+
+            long now = System.nanoTime();
+            double elapsed = (now - oldTime) / 1e9;
+            long total = totalMessagesSent.sum();
+            long totalTxnOpSuccess = 0;
+            long totalTxnOpFail = 0;
+            double rateOpenTxn = 0;
+            double rate = messagesSent.sumThenReset() / elapsed;
+            double failureRate = messagesFailed.sumThenReset() / elapsed;
+            double throughput = bytesSent.sumThenReset() / elapsed / 1024 / 1024 * 8;
+
+            reportHistogram = recorder.getIntervalHistogram(reportHistogram);
+
+            if (this.isEnableTransaction) {
+                totalTxnOpSuccess = totalEndTxnOpSuccessNum.sum();
+                totalTxnOpFail = totalEndTxnOpFailNum.sum();
+                rateOpenTxn = numTxnOpSuccess.sumThenReset() / elapsed;
+                log.infof("--- Transaction: %d transaction end successfully"
+                                + " --- %d transaction end failed --- %.3f Txn/s",
+                        totalTxnOpSuccess, totalTxnOpFail, rateOpenTxn);
+            }
+            log.infof("Throughput produced: %7d msg --- %8.1f msg/s --- %8.1f Mbit/s"
+                            + " --- failure %8.1f msg/s"
+                            + " --- Latency: mean: %7.3f ms - med: %7.3f"
+                            + " - 95pct: %7.3f - 99pct: %7.3f"
+                            + " - 99.9pct: %7.3f - 99.99pct: %7.3f - Max: %7.3f",
+                    total, rate, throughput, failureRate,
+                    reportHistogram.getMean() / 1000.0,
+                    reportHistogram.getValueAtPercentile(50) / 1000.0,
+                    reportHistogram.getValueAtPercentile(95) / 1000.0,
+                    reportHistogram.getValueAtPercentile(99) / 1000.0,
+                    reportHistogram.getValueAtPercentile(99.9) / 1000.0,
+                    reportHistogram.getValueAtPercentile(99.99) / 1000.0,
+                    reportHistogram.getMaxValue() / 1000.0);
+
+            if (histogramLogWriter != null) {
+                histogramLogWriter.outputIntervalHistogram(reportHistogram);
+            }
+
+            reportHistogram.reset();
+
+            oldTime = now;
+        }
+
+        PerfClientUtils.removeAndRunShutdownHook(shutdownHookThread);
+    }
+
+    private void executorShutdownNow(ExecutorService executor) {
+        executor.shutdownNow();
+        try {
+            if (!executor.awaitTermination(10, TimeUnit.SECONDS)) {
+                log.warn("Failed to terminate executor within timeout. The following are stack"
+                        + " traces of still running threads.");
+            }
+        } catch (InterruptedException e) {
+            log.warn("Shutdown of thread pool was interrupted");
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    static IMessageFormatter getMessageFormatter(String formatterClass) {
+        try {
+            ClassLoader classLoader = PerformanceProducerBase.class.getClassLoader();
+            Class clz = classLoader.loadClass(formatterClass);
+            return (IMessageFormatter) clz.getDeclaredConstructor().newInstance();
+        } catch (Exception e) {
+            if (PerfClientUtils.hasInterruptedException(e)) {
+                Thread.currentThread().interrupt();
+            }
+            return null;
+        }
+    }
+
+    private void runProducer(int producerId,
+                             long numMessages,
+                             int msgRate,
+                             List<byte[]> payloadByteList,
+                             byte[] payloadBytes,
+                             CountDownLatch doneLatch) {
+        ClientT client = null;
+        boolean produceEnough = false;
+        try {
+            client = createClient();
+
+            AtomicReference<TxnT> transactionAtomicReference;
+            if (this.isEnableTransaction) {
+                transactionAtomicReference = new AtomicReference<>(openFirstTransaction(client));
+            } else {
+                transactionAtomicReference = new AtomicReference<>(null);
+            }
+
+            List<CompletableFuture<ProducerT>> futures = new ArrayList<>();
+            for (int i = 0; i < this.numTopics; i++) {
+
+                String topic = this.topics.get(i);
+                log.info().attr("adding", this.numProducers).attr("topic", topic).log("Adding publishers on topic");
+
+                for (int j = 0; j < this.numProducers; j++) {
+                    futures.add(createProducerAsync(client, producerId, topic));
+                }
+            }
+
+            final List<ProducerT> producers = new ArrayList<>(futures.size());
+            for (CompletableFuture<ProducerT> future : futures) {
+                producers.add(future.get());
+            }
+            Collections.shuffle(producers);
+
+            log.info().attr("created", producers.size()).log("Created producers");
+
+            RateLimiter rateLimiter = RateLimiter.create(msgRate);
+
+            long startTime = System.nanoTime();
+            long warmupEndTime = startTime + (long) (this.warmupTimeSeconds * 1e9);
+            long testEndTime = startTime + (long) (this.testTime * 1e9);
+            MessageKeyGenerationMode msgKeyMode = null;
+            if (isNotBlank(this.messageKeyGenerationMode)) {
+                try {
+                    msgKeyMode = MessageKeyGenerationMode.valueOf(this.messageKeyGenerationMode);
+                } catch (IllegalArgumentException e) {
+                    throw new IllegalArgumentException("messageKeyGenerationMode only support [autoIncrement, random]");
+                }
+            }
+            // Send messages on all topics/producers
+            AtomicLong totalSent = new AtomicLong(0);
+            AtomicLong numMessageSend = new AtomicLong(0);
+            Semaphore numMsgPerTxnLimit = new Semaphore(this.numMessagesPerTransaction);
+            // Send futures of the in-flight transaction, awaited before the transaction is ended when
+            // awaitSendsBeforeEndingTransaction() is on, so the commit never races ahead of the sends
+            // (otherwise the broker rejects with InvalidTxnStatusException).
+            final List<CompletableFuture<?>> pendingTxnSends = new ArrayList<>();
+            while (!Thread.currentThread().isInterrupted()) {
+                if (produceEnough) {
+                    break;
+                }
+                for (ProducerT producer : producers) {
+                    if (this.testTime > 0) {
+                        if (System.nanoTime() > testEndTime) {
+                            log.info()
+                                    .attr("duration", this.testTime)
+                                    .log("------------- DONE (reached the maximum duration:"
+                                            + " [ seconds] of production) --------------");
+                            doneLatch.countDown();
+                            produceEnough = true;
+                            break;
+                        }
+                    }
+
+                    if (numMessages > 0) {
+                        if (totalSent.get() >= numMessages) {
+                            log.info()
+                                    .attr("number", numMessages)
+                                    .log("DONE (reached the maximum number: of production");
+                            doneLatch.countDown();
+                            produceEnough = true;
+                            break;
+                        }
+                    }
+                    rateLimiter.acquire();
+                    //if transaction is disable, transaction will be null.
+                    TxnT transaction = transactionAtomicReference.get();
+                    final long sendTime = System.nanoTime();
+
+                    byte[] payloadData;
+
+                    if (this.payloadFilename != null) {
+                        if (messageFormatter != null) {
+                            payloadData = messageFormatter.formatMessage(this.producerName, totalSent.get(),
+                                    payloadByteList.get(ThreadLocalRandom.current().nextInt(payloadByteList.size())));
+                        } else {
+                            payloadData = payloadByteList.get(
+                                    ThreadLocalRandom.current().nextInt(payloadByteList.size()));
+                        }
+                    } else {
+                        payloadData = payloadBytes;
+                    }
+                    if (this.isEnableTransaction && this.numMessagesPerTransaction > 0) {
+                        try {
+                            numMsgPerTxnLimit.acquire();
+                        } catch (InterruptedException exception){
+                            log.error().exception(exception).log("Get exception");
+                            Thread.currentThread().interrupt();
+                        }
+                    }
+                    Long deliverAfterSeconds = nextDeliverAfterSeconds();
+                    //generate msg key
+                    String messageKey = null;
+                    if (msgKeyMode == MessageKeyGenerationMode.random) {
+                        messageKey = String.valueOf(ThreadLocalRandom.current().nextInt());
+                    } else if (msgKeyMode == MessageKeyGenerationMode.autoIncrement) {
+                        messageKey = String.valueOf(totalSent.get());
+                    }
+                    CompletableFuture<?> sendFuture =
+                            sendMessage(producer, payloadData, transaction, messageKey, deliverAfterSeconds)
+                            .thenRun(() -> {
+                                bytesSent.add(payloadData.length);
+                                messagesSent.increment();
+                                totalSent.incrementAndGet();
+                                totalMessagesSent.increment();
+                                totalBytesSent.add(payloadData.length);
+
+                                long now = System.nanoTime();
+                                if (now > warmupEndTime) {
+                                    long latencyMicros =
+                                            Math.min(NANOSECONDS.toMicros(now - sendTime), MAX_LATENCY_MICROS);
+                                    recorder.recordValue(latencyMicros);
+                                    cumulativeRecorder.recordValue(latencyMicros);
+                                }
+                            }).exceptionally(ex -> {
+                                Throwable cause = FutureUtil.unwrapCompletionException(ex);
+                                // Ignore the exception when the producer is closed
+                                if (isAlreadyClosedException(cause)) {
+                                    return null;
+                                }
+                                if (PerfClientUtils.hasInterruptedException(ex)) {
+                                    Thread.currentThread().interrupt();
+                                    return null;
+                                }
+                                log.warn().exception(ex).log("Write message error with exception");
+                                messagesFailed.increment();
+                                if (this.exitOnFailure) {
+                                    PerfClientUtils.exit(1);
+                                }
+                                return null;
+                            });
+                    if (this.isEnableTransaction) {
+                        pendingTxnSends.add(sendFuture);
+                    }
+                    if (this.isEnableTransaction
+                            && numMessageSend.incrementAndGet() == this.numMessagesPerTransaction) {
+                        if (awaitSendsBeforeEndingTransaction()) {
+                            // Await all sends issued under this transaction before ending it, so the
+                            // txn coordinator has registered every send. The chain above already
+                            // swallows per-send failures, so this join never throws on a send error.
+                            try {
+                                CompletableFuture.allOf(pendingTxnSends.toArray(new CompletableFuture[0])).join();
+                            } catch (Exception awaitEx) {
+                                if (PerfClientUtils.hasInterruptedException(awaitEx)) {
+                                    Thread.currentThread().interrupt();
+                                }
+                            }
+                        }
+                        pendingTxnSends.clear();
+                        endTransaction(transaction);
+                        while (!Thread.currentThread().isInterrupted()) {
+                            try {
+                                TxnT newTransaction = newTransaction(client);
+                                transactionAtomicReference.compareAndSet(transaction, newTransaction);
+                                numMessageSend.set(0);
+                                numMsgPerTxnLimit.release(this.numMessagesPerTransaction);
+                                totalNumTxnOpenTxnSuccess.increment();
+                                break;
+                            } catch (Exception e){
+                                if (PerfClientUtils.hasInterruptedException(e)) {
+                                    Thread.currentThread().interrupt();
+                                } else {
+                                    totalNumTxnOpenTxnFail.increment();
+                                    log.error().exception(e).log("Failed to new transaction with exception");
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        } catch (Throwable t) {
+            if (PerfClientUtils.hasInterruptedException(t)) {
+                Thread.currentThread().interrupt();
+            } else {
+                log.error().exception(t).log("Got error");
+            }
+        } finally {
+            if (!produceEnough) {
+                doneLatch.countDown();
+            }
+            closeClient(client);
+        }
+    }
+
+    /**
+     * The delivery delay to mark the next message with, from {@code --delay} or a fresh draw from
+     * {@code --delay-range}, or {@code null} when neither was given.
+     *
+     * <p>{@code null} rather than a numeric sentinel on purpose: {@code --delay-range} accepts any
+     * range, so a drawn delay of {@code 0} — or a negative one — is a delay the user asked for and
+     * must still reach the message. Package-private for {@code PerformanceV4CommandsTest}
+     * (VisibleForTesting).
+     */
+    Long nextDeliverAfterSeconds() {
+        if (this.delay > 0) {
+            return this.delay;
+        }
+        if (this.delayRange != null) {
+            return ThreadLocalRandom.current()
+                    .nextLong(this.delayRange.lowerEndpoint(), this.delayRange.upperEndpoint());
+        }
+        return null;
+    }
+
+    /** Commit or abort the transaction according to {@code -abort}, counting the outcome. */
+    private void endTransaction(TxnT transaction) {
+        final boolean abort = this.isAbortTransaction;
+        CompletableFuture<Void> endFuture = abort ? abortTransaction(transaction) : commitTransaction(transaction);
+        endFuture.thenRun(() -> {
+            log.debug().log(abort ? "Abort transaction" : "Committed transaction");
+            totalEndTxnOpSuccessNum.increment();
+            numTxnOpSuccess.increment();
+        }).exceptionally(exception -> {
+            if (PerfClientUtils.hasInterruptedException(exception)) {
+                Thread.currentThread().interrupt();
+                return null;
+            }
+            log.error()
+                    .exception(exception)
+                    .log(abort ? "Abort transaction failed with exception"
+                            : "Commit transaction failed with exception");
+            totalEndTxnOpFailNum.increment();
+            return null;
+        });
+    }
+
+    private void printAggregatedThroughput(long start) {
+        double elapsed = (System.nanoTime() - start) / 1e9;
+        double rate = totalMessagesSent.sum() / elapsed;
+        double throughput = totalBytesSent.sum() / elapsed / 1024 / 1024 * 8;
+        long totalTxnSuccess = 0;
+        long totalTxnFail = 0;
+        double rateOpenTxn = 0;
+        long numTransactionOpenFailed = 0;
+        long numTransactionOpenSuccess = 0;
+
+        if (this.isEnableTransaction) {
+            totalTxnSuccess = totalEndTxnOpSuccessNum.sum();
+            totalTxnFail = totalEndTxnOpFailNum.sum();
+            rateOpenTxn = elapsed / (totalTxnFail + totalTxnSuccess);
+            numTransactionOpenFailed = totalNumTxnOpenTxnFail.sum();
+            numTransactionOpenSuccess = totalNumTxnOpenTxnSuccess.sum();
+            log.infof("--- Transaction: %d transaction end successfully"
+                            + " --- %d transaction end failed"
+                            + " --- %d transaction open successfully"
+                            + " --- %d transaction open failed --- %.3f Txn/s",
+                    totalTxnSuccess, totalTxnFail,
+                    numTransactionOpenSuccess, numTransactionOpenFailed, rateOpenTxn);
+        }
+        log.infof("Aggregated throughput stats --- %d records sent --- %.3f msg/s --- %.3f Mbit/s",
+                totalMessagesSent.sum(), rate, throughput);
+    }
+
+    private void printAggregatedStats() {
+        Histogram reportHistogram = cumulativeRecorder.getIntervalHistogram();
+
+        log.infof("Aggregated latency stats --- Latency: mean: %7.3f ms"
+                        + " - med: %7.3f - 95pct: %7.3f - 99pct: %7.3f"
+                        + " - 99.9pct: %7.3f - 99.99pct: %7.3f"
+                        + " - 99.999pct: %7.3f - Max: %7.3f",
+                reportHistogram.getMean() / 1000.0,
+                reportHistogram.getValueAtPercentile(50) / 1000.0,
+                reportHistogram.getValueAtPercentile(95) / 1000.0,
+                reportHistogram.getValueAtPercentile(99) / 1000.0,
+                reportHistogram.getValueAtPercentile(99.9) / 1000.0,
+                reportHistogram.getValueAtPercentile(99.99) / 1000.0,
+                reportHistogram.getValueAtPercentile(99.999) / 1000.0,
+                reportHistogram.getMaxValue() / 1000.0);
+    }
+
+    /** How {@code -mk/--message-key-generation-mode} derives a key for each message. */
+    public enum MessageKeyGenerationMode {
+        autoIncrement, random
+    }
+
+    /** Converts the {@code -dr/--delay-range} {@code "<origin>,<bound>"} argument. */
+    static class RangeConvert implements ITypeConverter<Range<Long>> {
+        @Override
+        public Range<Long> convert(String rangeStr) {
+            try {
+                requireNonNull(rangeStr);
+                final String[] facts = rangeStr.split(",");
+                final long min = Long.parseLong(facts[0].trim());
+                final long max = Long.parseLong(facts[1].trim());
+                return Range.closedOpen(min, max);
+            } catch (Throwable ex) {
+                throw new TypeConversionException("Unknown delay range interval,"
+                        + " the format should be \"<origin>,<bound>\". error message: " + rangeStr);
+            }
+        }
+    }
+}

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducerV4.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducerV4.java
@@ -85,8 +85,9 @@ public class PerformanceProducerV4
         }
 
         if (this.isEnableTransaction) {
-            // A send timeout and a transaction are mutually exclusive on the v4 client: a timed-out
-            // send would be retried outside the transaction it was issued under.
+            // The v4 client has allowed a send timeout inside a transaction since #16519, but a
+            // timeout still fails the send on its own schedule and takes the transaction with it.
+            // Disable it so the transaction timeout is the only deadline.
             producerBuilder.sendTimeout(0, TimeUnit.SECONDS);
         }
 

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducerV4.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducerV4.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.testclient;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.apache.pulsar.client.api.ClientBuilder;
+import org.apache.pulsar.client.api.CompressionType;
+import org.apache.pulsar.client.api.MessageRoutingMode;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.ProducerAccessMode;
+import org.apache.pulsar.client.api.ProducerBuilder;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.TypedMessageBuilder;
+import org.apache.pulsar.client.api.transaction.Transaction;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+/**
+ * The {@code produce} benchmark driven by the v4 ({@code pulsar-client-original}) client.
+ *
+ * <p>This is the counterpart of {@link PerformanceProducer}: the benchmark itself — options,
+ * accounting, send loop and reports — comes from {@link PerformanceProducerBase}, and only the
+ * client bindings differ. It exists so the v4 client and v4 (non-scalable) topics can be measured
+ * without the V5 SDK in the path, and it keeps the v4 producer knobs that have no V5 equivalent
+ * working: {@code --max-outstanding}, {@code --max-outstanding-across-partitions} and
+ * round-robin partition routing.
+ */
+@Command(name = "produce-v4", description = "Test pulsar producer performance using the v4 client.")
+public class PerformanceProducerV4
+        extends PerformanceProducerBase<PulsarClient, Producer<byte[]>, Transaction> {
+
+    @Option(names = { "-z", "--compression" }, description = "Compress messages payload")
+    public CompressionType compression = CompressionType.NONE;
+
+    @Option(names = { "-am", "--access-mode" }, description = "Producer access mode")
+    public ProducerAccessMode producerAccessMode = ProducerAccessMode.Shared;
+
+    public PerformanceProducerV4() {
+        super("produce-v4");
+    }
+
+    @Override
+    protected PulsarClient createClient() throws PulsarClientException {
+        ClientBuilder clientBuilder = PerfClientUtils.createClientBuilderFromArguments(this)
+                .enableTransaction(this.isEnableTransaction);
+        return clientBuilder.build();
+    }
+
+    @Override
+    protected void closeClient(PulsarClient client) {
+        PerfClientUtils.closeClient(client);
+    }
+
+    @SuppressWarnings("deprecation")
+    ProducerBuilder<byte[]> createProducerBuilder(PulsarClient client, int producerId, String topic) {
+        ProducerBuilder<byte[]> producerBuilder = client.newProducer()
+                .topic(topic)
+                .sendTimeout(this.sendTimeout, TimeUnit.SECONDS)
+                .compressionType(this.compression)
+                .maxPendingMessages(this.maxOutstanding)
+                .accessMode(this.producerAccessMode)
+                // enable round robin message routing if it is a partitioned topic
+                .messageRoutingMode(MessageRoutingMode.RoundRobinPartition);
+        if (this.maxPendingMessagesAcrossPartitions > 0) {
+            producerBuilder.maxPendingMessagesAcrossPartitions(this.maxPendingMessagesAcrossPartitions);
+        }
+
+        if (this.isEnableTransaction) {
+            // A send timeout and a transaction are mutually exclusive on the v4 client: a timed-out
+            // send would be retried outside the transaction it was issued under.
+            producerBuilder.sendTimeout(0, TimeUnit.SECONDS);
+        }
+
+        if (this.producerName != null) {
+            String name = String.format("%s%s%d", this.producerName, this.separator, producerId);
+            producerBuilder.producerName(name);
+        }
+
+        if (this.disableBatching || (this.batchTimeMillis <= 0.0 && this.batchMaxMessages <= 0)) {
+            producerBuilder.enableBatching(false);
+        } else {
+            long batchTimeUsec = (long) (this.batchTimeMillis * 1000);
+            producerBuilder.batchingMaxPublishDelay(batchTimeUsec, TimeUnit.MICROSECONDS).enableBatching(true);
+        }
+        if (this.batchMaxMessages > 0) {
+            producerBuilder.batchingMaxMessages(this.batchMaxMessages);
+        }
+        if (this.batchMaxBytes > 0) {
+            producerBuilder.batchingMaxBytes(this.batchMaxBytes);
+        }
+
+        // Block if queue is full else we will start seeing errors in sendAsync
+        producerBuilder.blockIfQueueFull(true);
+
+        if (isNotBlank(this.encKeyName) && isNotBlank(this.encKeyFile)) {
+            producerBuilder.addEncryptionKey(this.encKeyName);
+            producerBuilder.defaultCryptoKeyReader(this.encKeyFile);
+        }
+
+        // Chunking and batching are mutually exclusive; chunking wins when both are requested.
+        if (this.chunkingAllowed) {
+            producerBuilder.enableChunking(true);
+            producerBuilder.enableBatching(false);
+        }
+
+        return producerBuilder;
+    }
+
+    @Override
+    protected CompletableFuture<Producer<byte[]>> createProducerAsync(PulsarClient client, int producerId,
+                                                                      String topic) {
+        return createProducerBuilder(client, producerId, topic).createAsync();
+    }
+
+    @Override
+    protected Transaction newTransaction(PulsarClient client) throws Exception {
+        return client.newTransaction()
+                .withTransactionTimeout(this.transactionTimeout, TimeUnit.SECONDS)
+                .build()
+                .get();
+    }
+
+    @Override
+    protected CompletableFuture<Void> commitTransaction(Transaction transaction) {
+        return transaction.commit();
+    }
+
+    @Override
+    protected CompletableFuture<Void> abortTransaction(Transaction transaction) {
+        return transaction.abort();
+    }
+
+    @Override
+    protected CompletableFuture<?> sendMessage(Producer<byte[]> producer, byte[] payload, Transaction transaction,
+                                               String key, Long deliverAfterSeconds) {
+        TypedMessageBuilder<byte[]> messageBuilder = transaction != null
+                ? producer.newMessage(transaction).value(payload)
+                : producer.newMessage().value(payload);
+        if (deliverAfterSeconds != null) {
+            messageBuilder.deliverAfter(deliverAfterSeconds, TimeUnit.SECONDS);
+        }
+        if (this.setEventTime) {
+            messageBuilder.eventTime(System.currentTimeMillis());
+        }
+        if (key != null) {
+            messageBuilder.key(key);
+        }
+        return messageBuilder.sendAsync();
+    }
+
+    @Override
+    protected boolean isAlreadyClosedException(Throwable cause) {
+        return cause instanceof PulsarClientException.AlreadyClosedException;
+    }
+
+    /**
+     * The v4 client registers a transactional send with the transaction coordinator as part of
+     * {@code sendAsync} itself, so the commit cannot overtake it the way it can on V5. Not awaiting
+     * keeps send and commit pipelined, which is what {@code pulsar-perf produce} measured before the
+     * V5 migration.
+     */
+    @Override
+    protected boolean awaitSendsBeforeEndingTransaction() {
+        return false;
+    }
+}

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceReader.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceReader.java
@@ -18,74 +18,36 @@
  */
 package org.apache.pulsar.testclient;
 
-import static org.apache.pulsar.testclient.PerfClientUtils.LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS;
-import static org.apache.pulsar.testclient.PerfClientUtils.addShutdownHook;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectWriter;
-import com.google.common.util.concurrent.RateLimiter;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Timer;
-import java.util.TimerTask;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.LongAdder;
-import lombok.CustomLog;
-import org.HdrHistogram.Histogram;
-import org.HdrHistogram.Recorder;
 import org.apache.pulsar.client.api.v5.Checkpoint;
 import org.apache.pulsar.client.api.v5.CheckpointConsumer;
 import org.apache.pulsar.client.api.v5.CheckpointConsumerBuilder;
 import org.apache.pulsar.client.api.v5.Message;
 import org.apache.pulsar.client.api.v5.PulsarClient;
+import org.apache.pulsar.client.api.v5.PulsarClientException;
 import org.apache.pulsar.client.api.v5.schema.Schema;
-import org.apache.pulsar.common.naming.TopicName;
-import org.apache.pulsar.common.util.FutureUtil;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.Option;
 
+/**
+ * A client program to test pulsar reader performance with the V5 client API.
+ *
+ * <p>V5 has no {@code Reader}; the closest equivalent is the {@code CheckpointConsumer}, which is
+ * what this command measures. Everything that is not V5-specific lives in
+ * {@link PerformanceReaderBase}; the v4 {@code Reader} is driven by {@link PerformanceReaderV4}
+ * under the {@code read-v4} name.
+ */
 @Command(name = "read", description = "Test pulsar reader performance.")
-@CustomLog
-public class PerformanceReader extends PerformanceTopicListArguments {
-    private final LongAdder messagesReceived = new LongAdder();
-    private final LongAdder bytesReceived = new LongAdder();
+public class PerformanceReader
+        extends PerformanceReaderBase<PulsarClient, CheckpointConsumer<byte[]>, Message<byte[]>> {
 
-    private final LongAdder totalMessagesReceived = new LongAdder();
-    private final LongAdder totalBytesReceived = new LongAdder();
+    private ExecutorService readerExec;
 
-    private static final long MAX_LATENCY_MILLIS = TimeUnit.DAYS.toMillis(10);
-
-    private final Recorder recorder = new Recorder(MAX_LATENCY_MILLIS, LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS);
-    private final Recorder cumulativeRecorder =
-            new Recorder(MAX_LATENCY_MILLIS, LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS);
-
-    @Option(names = {"-r", "--rate"}, description = "Simulate a slow message reader (rate in msg/s)")
-    public double rate = 0;
-
-    @Option(names = {"-m",
-            "--start-message-id"}, description = "Start message id. This can be either 'earliest', "
-            + "'latest' or a specific message id by using 'lid:eid'")
-    public String startMessageId = "earliest";
-
-    @Option(names = {"-q", "--receiver-queue-size"}, description = "Size of the receiver queue")
-    public int receiverQueueSize = 1000;
-
-    @Option(names = {"-n",
-            "--num-messages"}, description = "Number of messages to consume in total. If <= 0, "
-            + "it will keep consuming")
-    public long numMessages = 0;
-
-    @Option(names = {
-            "--use-tls"}, description = "Use TLS encryption on the connection", descriptionKey = "useTls")
-    public boolean useTls;
-
-    @Option(names = {"-time",
-            "--test-duration"}, description = "Test duration in secs. If <= 0, it will keep consuming")
-    public long testTime = 0;
     public PerformanceReader() {
         super("read");
     }
@@ -97,19 +59,14 @@ public class PerformanceReader extends PerformanceTopicListArguments {
         // It does not expose the v4 "lid:eid" specific MessageId form, so reject it explicitly.
         if (!"earliest".equals(startMessageId) && !"latest".equals(startMessageId)) {
             throw new Exception(String.format("invalid start message ID '%s'. V5 CheckpointConsumer "
-                    + "only accepts 'earliest' or 'latest'; the v4 'lid:eid' form is not supported.",
+                    + "only accepts 'earliest' or 'latest'; the v4 'lid:eid' form is not supported. "
+                    + "Use read-v4 for the v4 reader, which does support it.",
                     startMessageId));
         }
     }
 
     @Override
-    public void run() throws Exception {
-        // Dump config variables
-        PerfClientUtils.printJVMInformation(log);
-        ObjectMapper m = new ObjectMapper();
-        ObjectWriter w = m.writerWithDefaultPrettyPrinter();
-        log.info().attr("config", w.writeValueAsString(this)).log("Starting Pulsar performance reader with config");
-
+    protected void prepareRun() {
         if (this.useTls) {
             log.info("--use-tls has no effect on V5 (TLS is enabled automatically when the service URL "
                     + "uses pulsar+ssl:// — pass that scheme via --service-url instead).");
@@ -117,97 +74,57 @@ public class PerformanceReader extends PerformanceTopicListArguments {
         if (this.receiverQueueSize != 1000) {
             log.info("--receiver-queue-size has no effect on V5 CheckpointConsumer.");
         }
+    }
 
-        final RateLimiter limiter = this.rate > 0 ? RateLimiter.create(this.rate) : null;
+    @Override
+    protected PulsarClient createClient() throws PulsarClientException {
+        return PerfClientUtils.createV5ClientBuilderFromArguments(this).build();
+    }
 
-        PulsarClient pulsarClient = PerfClientUtils.createV5ClientBuilderFromArguments(this).build();
+    @Override
+    protected void closeClient(PulsarClient client) {
+        PerfClientUtils.closeClient(client);
+    }
 
-        List<CompletableFuture<CheckpointConsumer<byte[]>>> futures = new ArrayList<>();
-
+    @Override
+    protected CompletableFuture<CheckpointConsumer<byte[]>> createReaderAsync(PulsarClient client, String topic) {
         Checkpoint startPosition = "earliest".equals(this.startMessageId)
                 ? Checkpoint.earliest()
                 : Checkpoint.latest();
+        CheckpointConsumerBuilder<byte[]> b = client.newCheckpointConsumer(Schema.bytes())
+                .topic(topic)
+                .startPosition(startPosition);
+        return b.createAsync();
+    }
 
-        for (int i = 0; i < this.numTopics; i++) {
-            final TopicName topicName = TopicName.get(this.topics.get(i));
-            CheckpointConsumerBuilder<byte[]> b = pulsarClient.newCheckpointConsumer(Schema.bytes())
-                    .topic(topicName.toString())
-                    .startPosition(startPosition);
-            futures.add(b.createAsync());
-        }
+    @Override
+    protected int messageSize(Message<byte[]> msg) {
+        return msg.value().length;
+    }
 
-        FutureUtil.waitForAll(futures).get();
-        final List<CheckpointConsumer<byte[]>> consumers = new ArrayList<>(futures.size());
-        for (CompletableFuture<CheckpointConsumer<byte[]>> future : futures) {
-            consumers.add(future.get());
-        }
+    @Override
+    protected long publishTimeMillis(Message<byte[]> msg) {
+        return msg.publishTime().toEpochMilli();
+    }
 
-        // V5 has no ReaderListener — drive each consumer from a dedicated poll thread that calls
-        // receive(timeout) and runs the same per-message handler the v4 listener did.
-        ExecutorService readerExec = Executors.newCachedThreadPool(
+    /**
+     * V5 has no ReaderListener — drive each consumer from a dedicated poll thread that calls
+     * receive(timeout) and runs the same per-message handler the v4 listener does.
+     */
+    @Override
+    protected void startReading(List<CheckpointConsumer<byte[]>> readers) {
+        readerExec = Executors.newCachedThreadPool(
                 new DefaultThreadFactory("pulsar-perf-reader-poll"));
-        for (CheckpointConsumer<byte[]> consumer : consumers) {
-            readerExec.submit(() -> readLoop(consumer, limiter));
+        for (CheckpointConsumer<byte[]> consumer : readers) {
+            readerExec.submit(() -> readLoop(consumer));
         }
+    }
 
-        log.info().attr("reading", this.numTopics).log("Start reading from topics");
-
-        final long start = System.nanoTime();
-        Thread shutdownHookThread = addShutdownHook(() -> {
-            printAggregatedThroughput(start);
-            printAggregatedStats();
-        });
-
-        if (this.testTime > 0) {
-            TimerTask timoutTask = new TimerTask() {
-                @Override
-                public void run() {
-                    log.info()
-                            .attr("duration", testTime)
-                            .log("------------- DONE (reached the maximum duration:"
-                                    + " [ seconds] of consumption) --------------");
-                    PerfClientUtils.exit(0);
-                }
-            };
-            Timer timer = new Timer();
-            timer.schedule(timoutTask, this.testTime * 1000);
+    @Override
+    protected void stopReading() {
+        if (readerExec == null) {
+            return;
         }
-
-        long oldTime = System.nanoTime();
-        Histogram reportHistogram = null;
-
-        while (!Thread.currentThread().isInterrupted()) {
-            try {
-                Thread.sleep(10000);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                break;
-            }
-
-            long now = System.nanoTime();
-            double elapsed = (now - oldTime) / 1e9;
-            long total = totalMessagesReceived.sum();
-            double rate = messagesReceived.sumThenReset() / elapsed;
-            double throughput = bytesReceived.sumThenReset() / elapsed * 8 / 1024 / 1024;
-
-            reportHistogram = recorder.getIntervalHistogram(reportHistogram);
-            log.infof("Read throughput: %7d msg --- %.3f msg/s --- %.3f Mbit/s"
-                            + " --- Latency: mean: %.3f ms - med: %d"
-                            + " - 95pct: %d - 99pct: %d"
-                            + " - 99.9pct: %d - 99.99pct: %d - Max: %d",
-                    total, rate, throughput,
-                    reportHistogram.getMean(),
-                    reportHistogram.getValueAtPercentile(50),
-                    reportHistogram.getValueAtPercentile(95),
-                    reportHistogram.getValueAtPercentile(99),
-                    reportHistogram.getValueAtPercentile(99.9),
-                    reportHistogram.getValueAtPercentile(99.99),
-                    reportHistogram.getMaxValue());
-
-            reportHistogram.reset();
-            oldTime = now;
-        }
-
         readerExec.shutdownNow();
         try {
             if (!readerExec.awaitTermination(10, TimeUnit.SECONDS)) {
@@ -216,16 +133,9 @@ public class PerformanceReader extends PerformanceTopicListArguments {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         }
-        PerfClientUtils.closeClient(pulsarClient);
-        PerfClientUtils.removeAndRunShutdownHook(shutdownHookThread);
     }
 
-    /**
-     * Per-consumer poll loop replacing the v4 {@code ReaderListener}. Drives
-     * {@code receive(timeout)} on the CheckpointConsumer and runs the same per-message
-     * counters + latency record + rate-limit the v4 listener did.
-     */
-    private void readLoop(CheckpointConsumer<byte[]> consumer, RateLimiter limiter) {
+    private void readLoop(CheckpointConsumer<byte[]> consumer) {
         while (!Thread.currentThread().isInterrupted()) {
             Message<byte[]> msg;
             try {
@@ -241,55 +151,9 @@ public class PerformanceReader extends PerformanceTopicListArguments {
             if (msg == null) {
                 continue;
             }
-
-            byte[] data = msg.value();
-            messagesReceived.increment();
-            bytesReceived.add(data.length);
-            totalMessagesReceived.increment();
-            totalBytesReceived.add(data.length);
-
-            if (this.numMessages > 0 && totalMessagesReceived.sum() >= this.numMessages) {
-                log.info().attr("number", this.numMessages).log("DONE (reached the maximum number: of consumption");
-                PerfClientUtils.exit(0);
+            if (handleMessage(msg)) {
                 return;
             }
-
-            if (limiter != null) {
-                limiter.acquire();
-            }
-
-            long latencyMillis = System.currentTimeMillis() - msg.publishTime().toEpochMilli();
-            if (latencyMillis >= 0) {
-                // Reading a backlog older than the histogram range must not blow up the read loop.
-                long clampedLatencyMillis = Math.min(latencyMillis, MAX_LATENCY_MILLIS);
-                recorder.recordValue(clampedLatencyMillis);
-                cumulativeRecorder.recordValue(clampedLatencyMillis);
-            }
         }
-    }
-
-    private void printAggregatedThroughput(long start) {
-        double elapsed = (System.nanoTime() - start) / 1e9;
-        double rate = totalMessagesReceived.sum() / elapsed;
-        double throughput = totalBytesReceived.sum() / elapsed * 8 / 1024 / 1024;
-        log.infof("Aggregated throughput stats --- %d records received --- %.3f msg/s --- %.3f Mbit/s",
-                totalMessagesReceived.sum(), rate, throughput);
-    }
-
-    private void printAggregatedStats() {
-        Histogram reportHistogram = cumulativeRecorder.getIntervalHistogram();
-
-        log.infof("Aggregated latency stats --- Latency: mean: %.3f ms"
-                        + " - med: %d - 95pct: %d - 99pct: %d"
-                        + " - 99.9pct: %d - 99.99pct: %d"
-                        + " - 99.999pct: %d - Max: %d",
-                reportHistogram.getMean(),
-                reportHistogram.getValueAtPercentile(50),
-                reportHistogram.getValueAtPercentile(95),
-                reportHistogram.getValueAtPercentile(99),
-                reportHistogram.getValueAtPercentile(99.9),
-                reportHistogram.getValueAtPercentile(99.99),
-                reportHistogram.getValueAtPercentile(99.999),
-                reportHistogram.getMaxValue());
     }
 }

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceReaderBase.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceReaderBase.java
@@ -1,0 +1,284 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.testclient;
+
+import static org.apache.pulsar.testclient.PerfClientUtils.LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS;
+import static org.apache.pulsar.testclient.PerfClientUtils.addShutdownHook;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.google.common.util.concurrent.RateLimiter;
+import io.github.merlimat.slog.Logger;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.LongAdder;
+import org.HdrHistogram.Histogram;
+import org.HdrHistogram.Recorder;
+import org.apache.pulsar.common.naming.TopicName;
+import picocli.CommandLine.Option;
+
+/**
+ * Client-agnostic implementation of the {@code pulsar-perf} reader benchmark.
+ *
+ * <p>The CLI options, the throughput and latency accounting and the reports live here. Concrete
+ * subclasses bind the client types: {@link PerformanceReader} drives the V5 {@code
+ * CheckpointConsumer} from dedicated poll threads, and {@link PerformanceReaderV4} drives a v4
+ * {@code Reader} through a {@code ReaderListener}.
+ *
+ * @param <ClientT> the client type ({@code PulsarClient} of the respective API generation)
+ * @param <ReaderT> the reader handle
+ * @param <MessageT> the received message type
+ */
+public abstract class PerformanceReaderBase<ClientT, ReaderT, MessageT> extends PerformanceTopicListArguments {
+
+    /**
+     * Logger named after the <em>concrete</em> command class rather than this base, so that the
+     * report lines keep identifying the subcommand that produced them (the integration tests in
+     * {@code PerfToolTest} match on {@code PerformanceReader - Aggregated ...}).
+     */
+    protected final Logger log = Logger.get(getClass());
+
+    private final LongAdder messagesReceived = new LongAdder();
+    private final LongAdder bytesReceived = new LongAdder();
+
+    private final LongAdder totalMessagesReceived = new LongAdder();
+    private final LongAdder totalBytesReceived = new LongAdder();
+
+    protected static final long MAX_LATENCY_MILLIS = TimeUnit.DAYS.toMillis(10);
+
+    private final Recorder recorder = new Recorder(MAX_LATENCY_MILLIS, LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS);
+    private final Recorder cumulativeRecorder =
+            new Recorder(MAX_LATENCY_MILLIS, LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS);
+
+    private RateLimiter limiter;
+
+    @Option(names = {"-r", "--rate"}, description = "Simulate a slow message reader (rate in msg/s)")
+    public double rate = 0;
+
+    @Option(names = {"-m",
+            "--start-message-id"}, description = "Start message id. This can be either 'earliest', "
+            + "'latest' or a specific message id by using 'lid:eid'")
+    public String startMessageId = "earliest";
+
+    @Option(names = {"-q", "--receiver-queue-size"}, description = "Size of the receiver queue")
+    public int receiverQueueSize = 1000;
+
+    @Option(names = {"-n",
+            "--num-messages"}, description = "Number of messages to consume in total. If <= 0, "
+            + "it will keep consuming")
+    public long numMessages = 0;
+
+    @Option(names = {
+            "--use-tls"}, description = "Use TLS encryption on the connection", descriptionKey = "useTls")
+    public boolean useTls;
+
+    @Option(names = {"-time",
+            "--test-duration"}, description = "Test duration in secs. If <= 0, it will keep consuming")
+    public long testTime = 0;
+
+    protected PerformanceReaderBase(String cmdName) {
+        super(cmdName);
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // Client-specific seams
+    // ------------------------------------------------------------------------------------------
+
+    /** Build and connect the client. */
+    protected abstract ClientT createClient() throws Exception;
+
+    /** Close a client built by {@link #createClient()}; must tolerate a {@code null} argument. */
+    protected abstract void closeClient(ClientT client);
+
+    /** Create one reader on {@code topic}, positioned according to {@code --start-message-id}. */
+    protected abstract CompletableFuture<ReaderT> createReaderAsync(ClientT client, String topic) throws Exception;
+
+    /** Payload size of a received message, in bytes. */
+    protected abstract int messageSize(MessageT msg);
+
+    /** Publish timestamp of a received message, in milliseconds since the epoch. */
+    protected abstract long publishTimeMillis(MessageT msg);
+
+    /**
+     * Start driving the readers. A no-op where the client pushes messages itself (the v4
+     * {@code ReaderListener}); V5 has no listener, so it starts one poll thread per reader.
+     */
+    protected void startReading(List<ReaderT> readers) throws Exception {
+    }
+
+    /** Stop whatever {@link #startReading(List)} started, before the client is closed. */
+    protected void stopReading() {
+    }
+
+    /** Hook for per-client run preparation, e.g. warnings about options with no effect. */
+    protected void prepareRun() {
+    }
+
+    // ------------------------------------------------------------------------------------------
+
+    @Override
+    public void run() throws Exception {
+        // Dump config variables
+        PerfClientUtils.printJVMInformation(log);
+        ObjectMapper m = new ObjectMapper();
+        ObjectWriter w = m.writerWithDefaultPrettyPrinter();
+        log.info().attr("config", w.writeValueAsString(this)).log("Starting Pulsar performance reader with config");
+
+        prepareRun();
+
+        this.limiter = this.rate > 0 ? RateLimiter.create(this.rate) : null;
+
+        ClientT client = createClient();
+
+        List<CompletableFuture<ReaderT>> futures = new ArrayList<>();
+        for (int i = 0; i < this.numTopics; i++) {
+            final TopicName topicName = TopicName.get(this.topics.get(i));
+            futures.add(createReaderAsync(client, topicName.toString()));
+        }
+
+        final List<ReaderT> readers = new ArrayList<>(futures.size());
+        for (CompletableFuture<ReaderT> future : futures) {
+            readers.add(future.get());
+        }
+
+        startReading(readers);
+
+        log.info().attr("reading", this.numTopics).log("Start reading from topics");
+
+        final long start = System.nanoTime();
+        Thread shutdownHookThread = addShutdownHook(() -> {
+            printAggregatedThroughput(start);
+            printAggregatedStats();
+        });
+
+        if (this.testTime > 0) {
+            TimerTask timoutTask = new TimerTask() {
+                @Override
+                public void run() {
+                    log.info()
+                            .attr("duration", testTime)
+                            .log("------------- DONE (reached the maximum duration:"
+                                    + " [ seconds] of consumption) --------------");
+                    PerfClientUtils.exit(0);
+                }
+            };
+            Timer timer = new Timer();
+            timer.schedule(timoutTask, this.testTime * 1000);
+        }
+
+        long oldTime = System.nanoTime();
+        Histogram reportHistogram = null;
+
+        while (!Thread.currentThread().isInterrupted()) {
+            try {
+                Thread.sleep(10000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+
+            long now = System.nanoTime();
+            double elapsed = (now - oldTime) / 1e9;
+            long total = totalMessagesReceived.sum();
+            double rate = messagesReceived.sumThenReset() / elapsed;
+            double throughput = bytesReceived.sumThenReset() / elapsed * 8 / 1024 / 1024;
+
+            reportHistogram = recorder.getIntervalHistogram(reportHistogram);
+            log.infof("Read throughput: %7d msg --- %.3f msg/s --- %.3f Mbit/s"
+                            + " --- Latency: mean: %.3f ms - med: %d"
+                            + " - 95pct: %d - 99pct: %d"
+                            + " - 99.9pct: %d - 99.99pct: %d - Max: %d",
+                    total, rate, throughput,
+                    reportHistogram.getMean(),
+                    reportHistogram.getValueAtPercentile(50),
+                    reportHistogram.getValueAtPercentile(95),
+                    reportHistogram.getValueAtPercentile(99),
+                    reportHistogram.getValueAtPercentile(99.9),
+                    reportHistogram.getValueAtPercentile(99.99),
+                    reportHistogram.getMaxValue());
+
+            reportHistogram.reset();
+            oldTime = now;
+        }
+
+        stopReading();
+        closeClient(client);
+        PerfClientUtils.removeAndRunShutdownHook(shutdownHookThread);
+    }
+
+    /**
+     * The per-message handler shared by the v4 reader listener and the V5 poll loop.
+     *
+     * @return whether the run is done and the caller should stop reading
+     */
+    protected final boolean handleMessage(MessageT msg) {
+        int size = messageSize(msg);
+        messagesReceived.increment();
+        bytesReceived.add(size);
+        totalMessagesReceived.increment();
+        totalBytesReceived.add(size);
+
+        if (this.numMessages > 0 && totalMessagesReceived.sum() >= this.numMessages) {
+            log.info().attr("number", this.numMessages).log("DONE (reached the maximum number: of consumption");
+            PerfClientUtils.exit(0);
+            return true;
+        }
+
+        if (limiter != null) {
+            limiter.acquire();
+        }
+
+        long latencyMillis = System.currentTimeMillis() - publishTimeMillis(msg);
+        if (latencyMillis >= 0) {
+            // Reading a backlog older than the histogram range must not blow up the read loop.
+            long clampedLatencyMillis = Math.min(latencyMillis, MAX_LATENCY_MILLIS);
+            recorder.recordValue(clampedLatencyMillis);
+            cumulativeRecorder.recordValue(clampedLatencyMillis);
+        }
+        return false;
+    }
+
+    private void printAggregatedThroughput(long start) {
+        double elapsed = (System.nanoTime() - start) / 1e9;
+        double rate = totalMessagesReceived.sum() / elapsed;
+        double throughput = totalBytesReceived.sum() / elapsed * 8 / 1024 / 1024;
+        log.infof("Aggregated throughput stats --- %d records received --- %.3f msg/s --- %.3f Mbit/s",
+                totalMessagesReceived.sum(), rate, throughput);
+    }
+
+    private void printAggregatedStats() {
+        Histogram reportHistogram = cumulativeRecorder.getIntervalHistogram();
+
+        log.infof("Aggregated latency stats --- Latency: mean: %.3f ms"
+                        + " - med: %d - 95pct: %d - 99pct: %d"
+                        + " - 99.9pct: %d - 99.99pct: %d"
+                        + " - 99.999pct: %d - Max: %d",
+                reportHistogram.getMean(),
+                reportHistogram.getValueAtPercentile(50),
+                reportHistogram.getValueAtPercentile(95),
+                reportHistogram.getValueAtPercentile(99),
+                reportHistogram.getValueAtPercentile(99.9),
+                reportHistogram.getValueAtPercentile(99.99),
+                reportHistogram.getValueAtPercentile(99.999),
+                reportHistogram.getMaxValue());
+    }
+}

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceReaderV4.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceReaderV4.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.testclient;
+
+import java.util.concurrent.CompletableFuture;
+import org.apache.pulsar.client.api.ClientBuilder;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.Reader;
+import org.apache.pulsar.client.api.ReaderBuilder;
+import org.apache.pulsar.client.api.ReaderListener;
+import org.apache.pulsar.client.impl.MessageIdImpl;
+import picocli.CommandLine.Command;
+
+/**
+ * The {@code read} benchmark driven by the v4 ({@code pulsar-client-original}) client.
+ *
+ * <p>This is the counterpart of {@link PerformanceReader}, which measures the V5
+ * {@code CheckpointConsumer} — a different broker-side entity — so without this command nothing in
+ * {@code pulsar-perf} exercises the v4 {@code Reader} at all. It also keeps the v4-only reader
+ * behaviour working: a {@code lid:eid} start message id, {@code --receiver-queue-size},
+ * {@code --use-tls}, and {@code ReaderListener} dispatch on the client's listener threads.
+ */
+@Command(name = "read-v4", description = "Test pulsar reader performance using the v4 client.")
+public class PerformanceReaderV4
+        extends PerformanceReaderBase<PulsarClient, Reader<byte[]>, Message<byte[]>> {
+
+    private ReaderListener<byte[]> listener;
+
+    public PerformanceReaderV4() {
+        super("read-v4");
+    }
+
+    @Override
+    public void validate() throws Exception {
+        super.validate();
+        if (!"earliest".equals(startMessageId) && !"latest".equals(startMessageId)
+                && (startMessageId.split(":")).length != 2) {
+            String errMsg = String.format("invalid start message ID '%s', must be either 'earliest', "
+                    + "'latest' or a specific message id by using 'lid:eid'", startMessageId);
+            throw new Exception(errMsg);
+        }
+    }
+
+    @Override
+    protected void prepareRun() {
+        this.listener = (reader, msg) -> handleMessage(msg);
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    protected PulsarClient createClient() throws PulsarClientException {
+        ClientBuilder clientBuilder = PerfClientUtils.createClientBuilderFromArguments(this)
+                .enableTls(this.useTls);
+        return clientBuilder.build();
+    }
+
+    @Override
+    protected void closeClient(PulsarClient client) {
+        PerfClientUtils.closeClient(client);
+    }
+
+    @Override
+    protected CompletableFuture<Reader<byte[]>> createReaderAsync(PulsarClient client, String topic) {
+        ReaderBuilder<byte[]> readerBuilder = client.newReader()
+                .readerListener(this.listener)
+                .receiverQueueSize(this.receiverQueueSize)
+                .startMessageId(parseStartMessageId())
+                .topic(topic);
+        return readerBuilder.createAsync();
+    }
+
+    private MessageId parseStartMessageId() {
+        if ("earliest".equals(this.startMessageId)) {
+            return MessageId.earliest;
+        }
+        if ("latest".equals(this.startMessageId)) {
+            return MessageId.latest;
+        }
+        String[] parts = this.startMessageId.split(":");
+        return new MessageIdImpl(Long.parseLong(parts[0]), Long.parseLong(parts[1]), -1);
+    }
+
+    @Override
+    protected int messageSize(Message<byte[]> msg) {
+        return msg.getData().length;
+    }
+
+    @Override
+    protected long publishTimeMillis(Message<byte[]> msg) {
+        return msg.getPublishTime();
+    }
+}

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceTransaction.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceTransaction.java
@@ -18,113 +18,39 @@
  */
 package org.apache.pulsar.testclient;
 
-import static java.util.concurrent.TimeUnit.NANOSECONDS;
-import static org.apache.pulsar.testclient.PerfClientUtils.LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS;
-import static org.apache.pulsar.testclient.PerfClientUtils.addShutdownHook;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectWriter;
-import com.google.common.util.concurrent.RateLimiter;
-import java.io.FileOutputStream;
-import java.io.PrintStream;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Random;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.atomic.LongAdder;
-import lombok.CustomLog;
-import org.HdrHistogram.Histogram;
-import org.HdrHistogram.HistogramLogWriter;
-import org.HdrHistogram.Recorder;
+import java.util.concurrent.CompletableFuture;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminBuilder;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.v5.Message;
 import org.apache.pulsar.client.api.v5.Producer;
-import org.apache.pulsar.client.api.v5.ProducerBuilder;
 import org.apache.pulsar.client.api.v5.PulsarClient;
 import org.apache.pulsar.client.api.v5.PulsarClientBuilder;
 import org.apache.pulsar.client.api.v5.PulsarClientException;
 import org.apache.pulsar.client.api.v5.QueueConsumer;
 import org.apache.pulsar.client.api.v5.QueueConsumerBuilder;
 import org.apache.pulsar.client.api.v5.Transaction;
+import org.apache.pulsar.client.api.v5.async.AsyncMessageBuilder;
 import org.apache.pulsar.client.api.v5.async.AsyncProducer;
 import org.apache.pulsar.client.api.v5.config.SubscriptionInitialPosition;
 import org.apache.pulsar.client.api.v5.config.TransactionPolicy;
 import org.apache.pulsar.client.api.v5.schema.Schema;
-import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
+/**
+ * A client program to test pulsar transaction performance with the V5 client API.
+ *
+ * <p>Everything that is not V5-specific lives in {@link PerformanceTransactionBase}; the v4 client
+ * and its transaction coordinator are driven by {@link PerformanceTransactionV4} under the
+ * {@code transaction-v4} name.
+ */
 @Command(name = "transaction", description = "Test pulsar transaction performance.")
-@CustomLog
-public class PerformanceTransaction extends PerformanceBaseArguments{
-
-    /** Same v4-compat SubscriptionType flag as PerformanceConsumer. See its javadoc. */
-    public enum SubscriptionType {
-        Exclusive,
-        Shared,
-        Failover,
-        Key_Shared
-    }
-
-
-    private final LongAdder totalNumEndTxnOpFailed = new LongAdder();
-    private final LongAdder totalNumEndTxnOpSuccess = new LongAdder();
-    private final LongAdder numTxnOpSuccess = new LongAdder();
-    private final LongAdder totalNumTxnOpenTxnFail = new LongAdder();
-    private final LongAdder totalNumTxnOpenTxnSuccess = new LongAdder();
-
-    private final LongAdder numMessagesAckFailed = new LongAdder();
-    private final LongAdder numMessagesAckSuccess = new LongAdder();
-    private final LongAdder numMessagesSendFailed = new LongAdder();
-    private final LongAdder numMessagesSendSuccess = new LongAdder();
-
-    // Send and ack latencies are recorded in microseconds. Anything slower than this means the
-    // benchmark is broken rather than slow, so values are clamped to keep HdrHistogram in range.
-    private static final long MAX_LATENCY_MICROS = TimeUnit.HOURS.toMicros(1);
-
-    private final Recorder messageAckRecorder =
-            new Recorder(MAX_LATENCY_MICROS, LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS);
-    private final Recorder messageAckCumulativeRecorder =
-            new Recorder(MAX_LATENCY_MICROS, LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS);
-
-    private final Recorder messageSendRecorder =
-            new Recorder(MAX_LATENCY_MICROS, LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS);
-    private final Recorder messageSendRCumulativeRecorder =
-            new Recorder(MAX_LATENCY_MICROS, LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS);
-
-    @Option(names = "--topics-c", description = "All topics that need ack for a transaction", required =
-            true)
-    public List<String> consumerTopic = Collections.singletonList("test-consume");
-
-    @Option(names = "--topics-p", description = "All topics that need produce for a transaction",
-            required = true)
-    public List<String> producerTopic = Collections.singletonList("test-produce");
-
-    @Option(names = {"-threads", "--num-test-threads"}, description = "Number of test threads."
-            + "This thread is for a new transaction to ack messages from consumer topics and produce message to "
-            + "producer topics, and then commit or abort this transaction. "
-            + "Increasing the number of threads increases the parallelism of the performance test, "
-            + "thereby increasing the intensity of the stress test.")
-    public int numTestThreads = 1;
-
-    @Option(names = {"-au", "--admin-url"}, description = "Pulsar Admin URL", descriptionKey = "webServiceUrl")
-    public String adminURL;
-
-    @Option(names = {"-np",
-            "--partitions"}, description = "Create partitioned topics with a given number of partitions, 0 means"
-            + "not trying to create a topic")
-    public Integer partitions = null;
+public class PerformanceTransaction extends PerformanceTransactionBase<PulsarClient, AsyncProducer<byte[]>,
+        QueueConsumer<byte[]>, Message<byte[]>, Transaction> {
 
     @Option(names = {"--scalable"}, description = "Create the producer/consumer topics as scalable"
             + " topics (PIP-473) with --scalable-segments initial segments. Required for transactions"
@@ -135,566 +61,141 @@ public class PerformanceTransaction extends PerformanceBaseArguments{
             + " topics created via --scalable.")
     public int scalableSegments = 1;
 
-    @Option(names = {"-time",
-            "--test-duration"}, description = "Test duration (in second). 0 means keeping publishing")
-    public long testTime = 0;
-
-    @Option(names = {"-ss",
-            "--subscriptions"}, description = "A list of subscriptions to consume (for example, sub1,sub2)")
-    public List<String> subscriptions = Collections.singletonList("sub");
-
-    @Option(names = {"-ns", "--num-subscriptions"}, description = "Number of subscriptions (per topic)")
-    public int numSubscriptions = 1;
-
     @Option(names = {"-sp", "--subscription-position"}, description = "Subscription position")
     private SubscriptionInitialPosition subscriptionInitialPosition = SubscriptionInitialPosition.EARLIEST;
 
-    @Option(names = {"-st", "--subscription-type"}, description = "Subscription type")
-    public SubscriptionType subscriptionType = SubscriptionType.Shared;
-
-    @Option(names = {"-rs", "--replicated" },
-            description = "Whether the subscription status should be replicated")
-    private boolean replicatedSubscription = false;
-
-    @Option(names = {"-q", "--receiver-queue-size"}, description = "Size of the receiver queue")
-    public int receiverQueueSize = 1000;
-
-    @Option(names = {"-tto", "--txn-timeout"}, description = "Set the time value of transaction timeout,"
-            + " and the time unit is second. (After --txn-enable setting to true, --txn-timeout takes effect)")
-    public long transactionTimeout = 5;
-
-    @Option(names = {"-ntxn",
-            "--number-txn"}, description = "Set the number of transaction. 0 means keeping open."
-            + "If transaction disabled, it means the number of tasks. The task or transaction produces or "
-            + "consumes a specified number of messages.")
-    public long numTransactions = 0;
-
-    @Option(names = {"-nmp", "--numMessage-perTransaction-produce"},
-            description = "Set the number of messages produced in  a transaction."
-                    + "If transaction disabled, it means the number of messages produced in a task.")
-    public int numMessagesProducedPerTransaction = 1;
-
-    @Option(names = {"-nmc", "--numMessage-perTransaction-consume"},
-            description = "Set the number of messages consumed in a transaction."
-                    + "If transaction disabled, it means the number of messages consumed in a task.")
-    public int numMessagesReceivedPerTransaction = 1;
-
-    @Option(names = {"--txn-disable"}, description = "Disable transaction")
-    public boolean isDisableTransaction = false;
-
-    @Option(names = {"-abort"}, description = "Abort the transaction. (After --txn-disEnable "
-            + "setting to false, -abort takes effect)")
-    public boolean isAbortTransaction = false;
-
-    @Option(names = "-txnRate", description = "Set the rate of opened transaction or task. 0 means no limit")
-    public int openTxnRate = 0;
     public PerformanceTransaction() {
         super("transaction");
     }
 
     @Override
-    public void run() throws Exception {
-        super.parseCLI();
-
-
-        // Dump config variables
-        PerfClientUtils.printJVMInformation(log);
-        ObjectMapper m = new ObjectMapper();
-        ObjectWriter w = m.writerWithDefaultPrettyPrinter();
-        log.info().attr("config", w.writeValueAsString(this)).log("Starting Pulsar perf transaction with config");
-
-        final byte[] payloadBytes = new byte[1024];
-        Random random = new Random(0);
-        for (int i = 0; i < payloadBytes.length; ++i) {
-            payloadBytes[i] = (byte) (random.nextInt(26) + 65);
+    protected void createTopicsIfNeeded() throws Exception {
+        if (!this.scalable) {
+            super.createTopicsIfNeeded();
+            return;
         }
-        if (this.scalable) {
-            // Scalable topics (PIP-473) must be pre-created via the admin API — they don't
-            // auto-create on produce. Create both the produce and consume topics so a
-            // transaction against the scalable-topics coordinator has segment participants.
-            final PulsarAdminBuilder adminBuilder = PerfClientUtils
-                    .createAdminBuilderFromArguments(this, this.adminURL);
-            try (PulsarAdmin adminClient = adminBuilder.build()) {
-                List<String> allTopics = new ArrayList<>(this.producerTopic);
-                allTopics.addAll(this.consumerTopic);
-                for (String topic : allTopics) {
-                    try {
-                        adminClient.scalableTopics().createScalableTopic(topic, this.scalableSegments);
-                        log.info().attr("topic", topic).attr("segments", this.scalableSegments)
-                                .log("Created scalable topic");
-                    } catch (PulsarAdminException.ConflictException alreadyExists) {
-                        log.debug().attr("topic", topic).attr("exists", alreadyExists)
-                                .log("Scalable topic already exists");
-                    }
-                }
-            }
-        } else if (this.partitions != null) {
-            final PulsarAdminBuilder adminBuilder = PerfClientUtils
-                    .createAdminBuilderFromArguments(this, this.adminURL);
-
-            try (PulsarAdmin adminClient = adminBuilder.build()) {
-                for (String topic : this.producerTopic) {
-                    log.info()
-                            .attr("topic", topic)
-                            .attr("partitions", this.partitions)
-                            .log("Creating produce partitioned topic with partitions");
-                    try {
-                        adminClient.topics().createPartitionedTopic(topic, this.partitions);
-                    } catch (PulsarAdminException.ConflictException alreadyExists) {
-                        log.debug().attr("topic", topic).attr("exists", alreadyExists).log("Topic already exists");
-                        PartitionedTopicMetadata partitionedTopicMetadata =
-                                adminClient.topics().getPartitionedTopicMetadata(topic);
-                        if (partitionedTopicMetadata.partitions != this.partitions) {
-                            log.error()
-                                    .attr("topic", topic)
-                                    .attr("partitions", partitionedTopicMetadata.partitions)
-                                    .attr("expecting", this.partitions)
-                                    .log("Topic already exists but it has a wrong number of partitions: , expecting");
-                            PerfClientUtils.exit(1);
-                        }
-                    }
+        // Scalable topics (PIP-473) must be pre-created via the admin API — they don't
+        // auto-create on produce. Create both the produce and consume topics so a
+        // transaction against the scalable-topics coordinator has segment participants.
+        final PulsarAdminBuilder adminBuilder = PerfClientUtils
+                .createAdminBuilderFromArguments(this, this.adminURL);
+        try (PulsarAdmin adminClient = adminBuilder.build()) {
+            List<String> allTopics = new ArrayList<>(this.producerTopic);
+            allTopics.addAll(this.consumerTopic);
+            for (String topic : allTopics) {
+                try {
+                    adminClient.scalableTopics().createScalableTopic(topic, this.scalableSegments);
+                    log.info().attr("topic", topic).attr("segments", this.scalableSegments)
+                            .log("Created scalable topic");
+                } catch (PulsarAdminException.ConflictException alreadyExists) {
+                    log.debug().attr("topic", topic).attr("exists", alreadyExists)
+                            .log("Scalable topic already exists");
                 }
             }
         }
+    }
 
+    @Override
+    protected void prepareRun() {
         if (this.subscriptionType == SubscriptionType.Exclusive
                 || this.subscriptionType == SubscriptionType.Failover) {
             log.warn().attr("type", this.subscriptionType)
                     .log("V5 has no exclusive/failover subscription type. Falling back to QueueConsumer "
-                            + "(Shared-style work distribution).");
+                            + "(Shared-style work distribution). Use transaction-v4 for the v4 client.");
         }
+    }
 
+    @Override
+    protected PulsarClient createClient() throws PulsarClientException {
         PulsarClientBuilder clientBuilder = PerfClientUtils.createV5ClientBuilderFromArguments(this);
         if (!this.isDisableTransaction) {
             clientBuilder.transactionPolicy(TransactionPolicy.builder()
                     .timeout(Duration.ofSeconds(this.transactionTimeout))
                     .build());
         }
-        PulsarClient client = clientBuilder.build();
+        return clientBuilder.build();
+    }
+
+    @Override
+    protected void closeClient(PulsarClient client) {
+        PerfClientUtils.closeClient(client);
+    }
+
+    @Override
+    protected CompletableFuture<AsyncProducer<byte[]>> createProducerAsync(PulsarClient client, String topic) {
+        return client.newProducer(Schema.bytes())
+                .sendTimeout(Duration.ZERO)
+                .topic(topic)
+                .createAsync()
+                .thenApply(Producer::async);
+    }
+
+    @Override
+    protected CompletableFuture<QueueConsumer<byte[]>> subscribeAsync(PulsarClient client, String topic,
+                                                                      String subscription) {
+        // V5 QueueConsumerBuilder has no clone(); build fresh per subscription.
+        QueueConsumerBuilder<byte[]> b = client.newQueueConsumer(Schema.bytes())
+                .receiverQueueSize(this.receiverQueueSize)
+                .subscriptionInitialPosition(this.subscriptionInitialPosition)
+                .replicateSubscriptionState(this.replicatedSubscription)
+                .topic(topic)
+                .subscriptionName(subscription);
+        return b.subscribeAsync();
+    }
+
+    @Override
+    protected Transaction newTransaction(PulsarClient client) throws PulsarClientException {
+        // Deliberately not PerfClientUtils.newTransactionWithRetry: this command builds its
+        // producers and consumers before opening its first transaction, so it does not hit the
+        // coordinator-connect race that helper exists for, and the worker's own retry loop has to
+        // see - and count - every failed open for -ntxn to terminate.
+        return client.newTransaction();
+    }
+
+    @Override
+    protected CompletableFuture<Void> commitTransaction(Transaction transaction) {
+        return transaction.async().commit();
+    }
+
+    @Override
+    protected CompletableFuture<Void> abortTransaction(Transaction transaction) {
+        return transaction.async().abort();
+    }
+
+    @Override
+    protected Message<byte[]> receive(QueueConsumer<byte[]> consumer) throws PulsarClientException {
+        return consumer.receive();
+    }
+
+    @Override
+    protected CompletableFuture<Void> acknowledgeAsync(QueueConsumer<byte[]> consumer, Message<byte[]> msg,
+                                                       Transaction transaction) {
+        // V5 acknowledge is synchronous void, so the reported ack latency is a local measurement
+        // rather than the broker round trip the v4 command reports.
         try {
-
-            ExecutorService executorService = new ThreadPoolExecutor(this.numTestThreads,
-                    this.numTestThreads,
-                    0L, TimeUnit.MILLISECONDS,
-                    new LinkedBlockingQueue<>());
-
-
-            long startTime = System.nanoTime();
-            long testEndTime = startTime + (long) (this.testTime * 1e9);
-            Thread shutdownHookThread = addShutdownHook(() -> {
-                if (!this.isDisableTransaction) {
-                    printTxnAggregatedThroughput(startTime);
-                } else {
-                    printAggregatedThroughput(startTime);
-                }
-                printAggregatedStats();
-            });
-
-            // start perf test
-            AtomicBoolean executing = new AtomicBoolean(true);
-
-            RateLimiter rateLimiter = this.openTxnRate > 0
-                    ? RateLimiter.create(this.openTxnRate)
-                    : null;
-            for (int i = 0; i < this.numTestThreads; i++) {
-                executorService.submit(() -> {
-                    //The producer and consumer clients are built in advance, and then this thread is
-                    //responsible for the production and consumption tasks of the transaction through the loop.
-                    //A thread may perform tasks of multiple transactions in a traversing manner.
-                    List<Producer<byte[]>> producers = null;
-                    List<List<QueueConsumer<byte[]>>> consumers = null;
-                    AtomicReference<Transaction> atomicReference = null;
-                    try {
-                        producers = buildProducers(client);
-                        consumers = buildConsumer(client);
-                        if (!this.isDisableTransaction) {
-                            atomicReference = new AtomicReference<>(client.newTransaction());
-                        } else {
-                            atomicReference = new AtomicReference<>(null);
-                        }
-                    } catch (Exception e) {
-                        if (PerfClientUtils.hasInterruptedException(e)) {
-                            Thread.currentThread().interrupt();
-                        } else {
-                            log.error().exception(e).log("Failed to build Producer/Consumer with exception");
-                        }
-                        executorService.shutdownNow();
-                        PerfClientUtils.exit(1);
-                    }
-                    //The while loop has no break, and finally ends the execution through the shutdownNow of
-                    //the executorService
-                    while (!Thread.currentThread().isInterrupted()) {
-                        if (this.numTransactions > 0) {
-                            if (totalNumTxnOpenTxnFail.sum()
-                                    + totalNumTxnOpenTxnSuccess.sum() >= this.numTransactions) {
-                                if (totalNumEndTxnOpFailed.sum()
-                                        + totalNumEndTxnOpSuccess.sum() < this.numTransactions) {
-                                    continue;
-                                }
-                                log.info("------------------- DONE -----------------------");
-                                executing.compareAndSet(true, false);
-                                executorService.shutdownNow();
-                                PerfClientUtils.exit(0);
-                                break;
-                            }
-                        }
-                        if (this.testTime > 0) {
-                            if (System.nanoTime() > testEndTime) {
-                                log.info("------------------- DONE -----------------------");
-                                executing.compareAndSet(true, false);
-                                executorService.shutdownNow();
-                                PerfClientUtils.exit(0);
-                                break;
-                            }
-                        }
-                        Transaction transaction = atomicReference.get();
-                        for (List<QueueConsumer<byte[]>> subscriptions : consumers) {
-                            for (QueueConsumer<byte[]> consumer : subscriptions) {
-                                for (int j = 0; j < this.numMessagesReceivedPerTransaction; j++) {
-                                    Message<byte[]> message = null;
-                                    try {
-                                        message = consumer.receive();
-                                    } catch (PulsarClientException e) {
-                                        log.error().exception(e).log("Receive message failed");
-                                        executorService.shutdownNow();
-                                        PerfClientUtils.exit(1);
-                                    }
-                                    long receiveTime = System.nanoTime();
-                                    // V5 acknowledge is synchronous void. Record latency immediately
-                                    // and catch any failure into the existing counter.
-                                    try {
-                                        if (!this.isDisableTransaction) {
-                                            consumer.acknowledge(message.id(), transaction);
-                                        } else {
-                                            consumer.acknowledge(message.id());
-                                        }
-                                        long latencyMicros = Math.min(NANOSECONDS.toMicros(
-                                                System.nanoTime() - receiveTime), MAX_LATENCY_MICROS);
-                                        messageAckRecorder.recordValue(latencyMicros);
-                                        messageAckCumulativeRecorder.recordValue(latencyMicros);
-                                        numMessagesAckSuccess.increment();
-                                    } catch (Exception ackEx) {
-                                        if (PerfClientUtils.hasInterruptedException(ackEx)) {
-                                            Thread.currentThread().interrupt();
-                                        } else {
-                                            log.error()
-                                                    .exception(ackEx)
-                                                    .log("Ack message failed with transaction throw exception");
-                                            numMessagesAckFailed.increment();
-                                        }
-                                    }
-                                }
-                            }
-                        }
-
-                        // V5 transaction-aware sends are queued onto an internal dispatch chain,
-                        // so the v4-side txn-coordinator registration of the send can race the
-                        // commit() if commit fires before the chain drains. We collect each
-                        // per-txn send future here and await them all before committing — this is
-                        // also the semantically-correct ordering (commit only after sends land).
-                        java.util.List<java.util.concurrent.CompletableFuture<?>> pendingSends =
-                                new java.util.ArrayList<>();
-                        for (Producer<byte[]> producer : producers) {
-                            AsyncProducer<byte[]> asyncProducer = producer.async();
-                            for (int j = 0; j < this.numMessagesProducedPerTransaction; j++) {
-                                long sendTime = System.nanoTime();
-                                var msg = asyncProducer.newMessage().value(payloadBytes);
-                                if (!this.isDisableTransaction) {
-                                    msg.transaction(transaction);
-                                }
-                                pendingSends.add(msg.send().whenComplete((id, ex) -> {
-                                    if (ex == null) {
-                                        long latencyMicros = Math.min(NANOSECONDS.toMicros(
-                                                System.nanoTime() - sendTime), MAX_LATENCY_MICROS);
-                                        messageSendRecorder.recordValue(latencyMicros);
-                                        messageSendRCumulativeRecorder.recordValue(latencyMicros);
-                                        numMessagesSendSuccess.increment();
-                                    } else {
-                                        if (PerfClientUtils.hasInterruptedException(ex)) {
-                                            Thread.currentThread().interrupt();
-                                            return;
-                                        }
-                                        // Ignore the exception when the producer is closed
-                                        if (ex.getCause()
-                                                instanceof PulsarClientException.AlreadyClosedException) {
-                                            return;
-                                        }
-                                        log.error()
-                                                .exception(ex)
-                                                .log("Send message failed with exception");
-                                        numMessagesSendFailed.increment();
-                                    }
-                                }));
-                            }
-                        }
-
-                        // Await all pending sends before committing so the txn-coordinator has
-                        // registered every send. allOf().exceptionally() swallows individual send
-                        // failures here — they are already counted in the whenComplete above.
-                        try {
-                            java.util.concurrent.CompletableFuture.allOf(
-                                    pendingSends.toArray(new java.util.concurrent.CompletableFuture[0]))
-                                    .exceptionally(t -> null)
-                                    .join();
-                        } catch (Exception awaitEx) {
-                            if (PerfClientUtils.hasInterruptedException(awaitEx)) {
-                                Thread.currentThread().interrupt();
-                            }
-                        }
-
-                        if (rateLimiter != null) {
-                            rateLimiter.tryAcquire();
-                        }
-                        if (!this.isDisableTransaction) {
-                            if (!this.isAbortTransaction) {
-                                transaction.async().commit()
-                                        .thenRun(() -> {
-                                            numTxnOpSuccess.increment();
-                                            totalNumEndTxnOpSuccess.increment();
-                                        }).exceptionally(exception -> {
-                                            if (PerfClientUtils.hasInterruptedException(exception)) {
-                                                Thread.currentThread().interrupt();
-                                                return null;
-                                            }
-                                            log.error()
-                                                    .exception(exception)
-                                                    .log("Commit transaction failed with exception");
-                                            totalNumEndTxnOpFailed.increment();
-                                            return null;
-                                        });
-                            } else {
-                                transaction.async().abort()
-                                        .thenRun(() -> {
-                                            numTxnOpSuccess.increment();
-                                            totalNumEndTxnOpSuccess.increment();
-                                        }).exceptionally(exception -> {
-                                            if (PerfClientUtils.hasInterruptedException(exception)) {
-                                                Thread.currentThread().interrupt();
-                                                return null;
-                                            }
-                                            log.error()
-                                                    .exception(exception)
-                                                    .log("Abort transaction failed with exception");
-                                            totalNumEndTxnOpFailed.increment();
-                                            return null;
-                                        });
-                            }
-                            while (!Thread.currentThread().isInterrupted()) {
-                                try {
-                                    Transaction newTransaction = client.newTransaction();
-                                    atomicReference.compareAndSet(transaction, newTransaction);
-                                    totalNumTxnOpenTxnSuccess.increment();
-                                    break;
-                                } catch (Exception throwable) {
-                                    if (PerfClientUtils.hasInterruptedException(throwable)) {
-                                        Thread.currentThread().interrupt();
-                                    } else {
-                                        log.error()
-                                                .exception(throwable)
-                                                .log("Failed to new transaction with exception");
-                                        totalNumTxnOpenTxnFail.increment();
-                                    }
-                                }
-                            }
-                        } else {
-                            totalNumTxnOpenTxnSuccess.increment();
-                            totalNumEndTxnOpSuccess.increment();
-                            numTxnOpSuccess.increment();
-                        }
-                    }
-                });
+            if (transaction != null) {
+                consumer.acknowledge(msg.id(), transaction);
+            } else {
+                consumer.acknowledge(msg.id());
             }
-
-
-            // Print report stats
-            long oldTime = System.nanoTime();
-
-            Histogram reportSendHistogram = null;
-            Histogram reportAckHistogram = null;
-
-            String statsFileName = "perf-transaction-" + System.currentTimeMillis() + ".hgrm";
-            log.info().attr("stats", statsFileName).log("Dumping latency stats to");
-
-            PrintStream histogramLog = new PrintStream(new FileOutputStream(statsFileName), false);
-            HistogramLogWriter histogramLogWriter = new HistogramLogWriter(histogramLog);
-
-            // Some log header bits
-            histogramLogWriter.outputLogFormatVersion();
-            histogramLogWriter.outputLegend();
-
-            while (!Thread.currentThread().isInterrupted() && executing.get()) {
-                try {
-                    Thread.sleep(10000);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    break;
-                }
-                long now = System.nanoTime();
-                double elapsed = (now - oldTime) / 1e9;
-                long total = totalNumEndTxnOpFailed.sum() + totalNumTxnOpenTxnSuccess.sum();
-                double rate = numTxnOpSuccess.sumThenReset() / elapsed;
-                reportSendHistogram = messageSendRecorder.getIntervalHistogram(reportSendHistogram);
-                reportAckHistogram = messageAckRecorder.getIntervalHistogram(reportAckHistogram);
-                String label = !this.isDisableTransaction
-                        ? "Throughput transaction" : "Throughput task";
-                log.infof("%s: %7d --- %7.3f/s"
-                                + " --- SendLatency: mean: %7.3f ms - med: %7.3f"
-                                + " - 95pct: %7.3f - 99pct: %7.3f"
-                                + " - 99.9pct: %7.3f - 99.99pct: %7.3f - Max: %7.3f"
-                                + " --- AckLatency: mean: %7.3f ms - med: %7.3f"
-                                + " - 95pct: %7.3f - 99pct: %7.3f"
-                                + " - 99.9pct: %7.3f - 99.99pct: %7.3f - Max: %7.3f",
-                        label, total, rate,
-                        reportSendHistogram.getMean() / 1000.0,
-                        reportSendHistogram.getValueAtPercentile(50) / 1000.0,
-                        reportSendHistogram.getValueAtPercentile(95) / 1000.0,
-                        reportSendHistogram.getValueAtPercentile(99) / 1000.0,
-                        reportSendHistogram.getValueAtPercentile(99.9) / 1000.0,
-                        reportSendHistogram.getValueAtPercentile(99.99) / 1000.0,
-                        reportSendHistogram.getMaxValue() / 1000.0,
-                        reportAckHistogram.getMean() / 1000.0,
-                        reportAckHistogram.getValueAtPercentile(50) / 1000.0,
-                        reportAckHistogram.getValueAtPercentile(95) / 1000.0,
-                        reportAckHistogram.getValueAtPercentile(99) / 1000.0,
-                        reportAckHistogram.getValueAtPercentile(99.9) / 1000.0,
-                        reportAckHistogram.getValueAtPercentile(99.99) / 1000.0,
-                        reportAckHistogram.getMaxValue() / 1000.0);
-
-                histogramLogWriter.outputIntervalHistogram(reportSendHistogram);
-                histogramLogWriter.outputIntervalHistogram(reportAckHistogram);
-                reportSendHistogram.reset();
-                reportAckHistogram.reset();
-
-                oldTime = now;
-            }
-
-            PerfClientUtils.removeAndRunShutdownHook(shutdownHookThread);
-        } finally {
-            PerfClientUtils.closeClient(client);
+            return CompletableFuture.completedFuture(null);
+        } catch (Exception e) {
+            return CompletableFuture.failedFuture(e);
         }
     }
 
-
-    private void printTxnAggregatedThroughput(long start) {
-        double elapsed = (System.nanoTime() - start) / 1e9;
-        long numTransactionEndFailed = totalNumEndTxnOpFailed.sum();
-        long numTransactionEndSuccess = totalNumEndTxnOpSuccess.sum();
-        long total = numTransactionEndFailed + numTransactionEndSuccess;
-        double rate = total / elapsed;
-        long numMessageAckFailed = numMessagesAckFailed.sum();
-        long numMessageAckSuccess = numMessagesAckSuccess.sum();
-        long numMessageSendFailed = numMessagesSendFailed.sum();
-        long numMessageSendSuccess = numMessagesSendSuccess.sum();
-        long numTransactionOpenFailed = totalNumTxnOpenTxnFail.sum();
-        long numTransactionOpenSuccess = totalNumTxnOpenTxnSuccess.sum();
-
-        log.infof("Aggregated throughput stats --- %d transaction executed --- %7.3f transaction/s"
-                        + " --- %d transaction open successfully --- %d transaction open failed"
-                        + " --- %d transaction end successfully --- %d transaction end failed"
-                        + " --- %d message ack failed --- %d message send failed"
-                        + " --- %d message ack success --- %d message send success",
-                total, rate,
-                numTransactionOpenSuccess, numTransactionOpenFailed,
-                numTransactionEndSuccess, numTransactionEndFailed,
-                numMessageAckFailed, numMessageSendFailed,
-                numMessageAckSuccess, numMessageSendSuccess);
-
-    }
-
-    private void printAggregatedThroughput(long start) {
-        double elapsed = (System.nanoTime() - start) / 1e9;
-        long total = totalNumEndTxnOpFailed.sum() + totalNumEndTxnOpSuccess.sum();
-        double rate = total / elapsed;
-        long numMessageAckFailed = numMessagesAckFailed.sum();
-        long numMessageAckSuccess = numMessagesAckSuccess.sum();
-        long numMessageSendFailed = numMessagesSendFailed.sum();
-        long numMessageSendSuccess = numMessagesSendSuccess.sum();
-        log.infof("Aggregated throughput stats --- %d task executed --- %.3f task/s"
-                        + " --- %d message ack failed --- %d message send failed"
-                        + " --- %d message ack success --- %d message send success",
-                total, rate,
-                numMessageAckFailed, numMessageSendFailed,
-                numMessageAckSuccess, numMessageSendSuccess);
-    }
-
-    private void printAggregatedStats() {
-        Histogram reportAckHistogram = messageAckCumulativeRecorder.getIntervalHistogram();
-        Histogram reportSendHistogram = messageSendRCumulativeRecorder.getIntervalHistogram();
-        log.infof("Messages ack aggregated latency stats --- Latency: mean: %7.3f ms"
-                        + " - med: %7.3f - 95pct: %7.3f - 99pct: %7.3f"
-                        + " - 99.9pct: %7.3f - 99.99pct: %7.3f"
-                        + " - 99.999pct: %7.3f - Max: %7.3f",
-                reportAckHistogram.getMean() / 1000.0,
-                reportAckHistogram.getValueAtPercentile(50) / 1000.0,
-                reportAckHistogram.getValueAtPercentile(95) / 1000.0,
-                reportAckHistogram.getValueAtPercentile(99) / 1000.0,
-                reportAckHistogram.getValueAtPercentile(99.9) / 1000.0,
-                reportAckHistogram.getValueAtPercentile(99.99) / 1000.0,
-                reportAckHistogram.getValueAtPercentile(99.999) / 1000.0,
-                reportAckHistogram.getMaxValue() / 1000.0);
-        log.infof("Messages send aggregated latency stats --- Latency: mean: %7.3f ms"
-                        + " - med: %7.3f - 95pct: %7.3f - 99pct: %7.3f"
-                        + " - 99.9pct: %7.3f - 99.99pct: %7.3f"
-                        + " - 99.999pct: %7.3f - Max: %7.3f",
-                reportSendHistogram.getMean() / 1000.0,
-                reportSendHistogram.getValueAtPercentile(50) / 1000.0,
-                reportSendHistogram.getValueAtPercentile(95) / 1000.0,
-                reportSendHistogram.getValueAtPercentile(99) / 1000.0,
-                reportSendHistogram.getValueAtPercentile(99.9) / 1000.0,
-                reportSendHistogram.getValueAtPercentile(99.99) / 1000.0,
-                reportSendHistogram.getValueAtPercentile(99.999) / 1000.0,
-                reportSendHistogram.getMaxValue() / 1000.0);
-    }
-
-
-
-    private List<List<QueueConsumer<byte[]>>> buildConsumer(PulsarClient client)
-            throws ExecutionException, InterruptedException {
-
-        Iterator<String> consumerTopicsIterator = this.consumerTopic.iterator();
-        List<List<QueueConsumer<byte[]>>> consumers = new ArrayList<>(this.consumerTopic.size());
-        while (consumerTopicsIterator.hasNext()){
-            String topic = consumerTopicsIterator.next();
-            final List<QueueConsumer<byte[]>> subscriptions = new ArrayList<>(this.numSubscriptions);
-            final List<Future<QueueConsumer<byte[]>>> subscriptionFutures =
-                    new ArrayList<>(this.numSubscriptions);
-            log.info().attr("topic", topic).log("Create subscriptions for topic");
-            for (int j = 0; j < this.numSubscriptions; j++) {
-                String subscriberName = this.subscriptions.get(j);
-                // V5 QueueConsumerBuilder has no clone(); build fresh per subscription.
-                QueueConsumerBuilder<byte[]> b = client.newQueueConsumer(Schema.bytes())
-                        .receiverQueueSize(this.receiverQueueSize)
-                        .subscriptionInitialPosition(this.subscriptionInitialPosition)
-                        .replicateSubscriptionState(this.replicatedSubscription)
-                        .topic(topic)
-                        .subscriptionName(subscriberName);
-                subscriptionFutures.add(b.subscribeAsync());
-            }
-            for (Future<QueueConsumer<byte[]>> future : subscriptionFutures) {
-                subscriptions.add(future.get());
-            }
-            consumers.add(subscriptions);
+    @Override
+    protected CompletableFuture<?> sendMessage(AsyncProducer<byte[]> producer, byte[] payload,
+                                               Transaction transaction) {
+        AsyncMessageBuilder<byte[]> msg = producer.newMessage().value(payload);
+        if (transaction != null) {
+            msg.transaction(transaction);
         }
-        return consumers;
+        return msg.send();
     }
 
-    private List<Producer<byte[]>> buildProducers(PulsarClient client)
-            throws ExecutionException, InterruptedException {
-
-        final List<Future<Producer<byte[]>>> producerFutures = new ArrayList<>();
-        for (String topic : this.producerTopic) {
-            log.info().attr("topic", topic).log("Create producer for topic");
-            ProducerBuilder<byte[]> b = client.newProducer(Schema.bytes())
-                    .sendTimeout(Duration.ZERO)
-                    .topic(topic);
-            producerFutures.add(b.createAsync());
-        }
-        final List<Producer<byte[]>> producers = new ArrayList<>(producerFutures.size());
-
-        for (Future<Producer<byte[]>> future : producerFutures) {
-            producers.add(future.get());
-        }
-        return  producers;
+    @Override
+    protected boolean isAlreadyClosedException(Throwable cause) {
+        return cause instanceof PulsarClientException.AlreadyClosedException;
     }
-
 }

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceTransactionBase.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceTransactionBase.java
@@ -1,0 +1,703 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.testclient;
+
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static org.apache.pulsar.testclient.PerfClientUtils.LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS;
+import static org.apache.pulsar.testclient.PerfClientUtils.addShutdownHook;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.google.common.util.concurrent.RateLimiter;
+import io.github.merlimat.slog.Logger;
+import java.io.FileOutputStream;
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.LongAdder;
+import org.HdrHistogram.Histogram;
+import org.HdrHistogram.HistogramLogWriter;
+import org.HdrHistogram.Recorder;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminBuilder;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
+import picocli.CommandLine.Option;
+
+/**
+ * Client-agnostic implementation of the {@code pulsar-perf} transaction benchmark.
+ *
+ * <p>Each test thread owns a set of producers and consumers and repeats one unit of work: consume
+ * and acknowledge {@code -nmc} messages, produce {@code -nmp} messages, then end the transaction and
+ * open the next one. That loop, the CLI options, the send/ack latency accounting and the reports
+ * live here. Concrete subclasses bind the client types: {@link PerformanceTransaction} against the
+ * V5 client and {@link PerformanceTransactionV4} against the v4 client.
+ *
+ * @param <ClientT> the client type ({@code PulsarClient} of the respective API generation)
+ * @param <ProducerT> the producer handle
+ * @param <ConsumerT> the subscribed consumer handle
+ * @param <MessageT> the received message type
+ * @param <TxnT> the transaction type
+ */
+public abstract class PerformanceTransactionBase<ClientT, ProducerT, ConsumerT, MessageT, TxnT>
+        extends PerformanceBaseArguments {
+
+    /**
+     * Logger named after the <em>concrete</em> command class rather than this base, so that the
+     * report lines keep identifying the subcommand that produced them.
+     */
+    protected final Logger log = Logger.get(getClass());
+
+    /** Same v4-compat subscription-type flag as {@link PerformanceConsumerBase.SubscriptionType}. */
+    public enum SubscriptionType {
+        Exclusive,
+        Shared,
+        Failover,
+        Key_Shared
+    }
+
+    private final LongAdder totalNumEndTxnOpFailed = new LongAdder();
+    private final LongAdder totalNumEndTxnOpSuccess = new LongAdder();
+    private final LongAdder numTxnOpSuccess = new LongAdder();
+    private final LongAdder totalNumTxnOpenTxnFail = new LongAdder();
+    private final LongAdder totalNumTxnOpenTxnSuccess = new LongAdder();
+
+    private final LongAdder numMessagesAckFailed = new LongAdder();
+    private final LongAdder numMessagesAckSuccess = new LongAdder();
+    private final LongAdder numMessagesSendFailed = new LongAdder();
+    private final LongAdder numMessagesSendSuccess = new LongAdder();
+
+    // Send and ack latencies are recorded in microseconds. Anything slower than this means the
+    // benchmark is broken rather than slow, so values are clamped to keep HdrHistogram in range.
+    private static final long MAX_LATENCY_MICROS = TimeUnit.HOURS.toMicros(1);
+
+    private final Recorder messageAckRecorder =
+            new Recorder(MAX_LATENCY_MICROS, LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS);
+    private final Recorder messageAckCumulativeRecorder =
+            new Recorder(MAX_LATENCY_MICROS, LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS);
+
+    private final Recorder messageSendRecorder =
+            new Recorder(MAX_LATENCY_MICROS, LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS);
+    private final Recorder messageSendRCumulativeRecorder =
+            new Recorder(MAX_LATENCY_MICROS, LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS);
+
+    @Option(names = "--topics-c", description = "All topics that need ack for a transaction", required =
+            true)
+    public List<String> consumerTopic = Collections.singletonList("test-consume");
+
+    @Option(names = "--topics-p", description = "All topics that need produce for a transaction",
+            required = true)
+    public List<String> producerTopic = Collections.singletonList("test-produce");
+
+    @Option(names = {"-threads", "--num-test-threads"}, description = "Number of test threads."
+            + "This thread is for a new transaction to ack messages from consumer topics and produce message to "
+            + "producer topics, and then commit or abort this transaction. "
+            + "Increasing the number of threads increases the parallelism of the performance test, "
+            + "thereby increasing the intensity of the stress test.")
+    public int numTestThreads = 1;
+
+    @Option(names = {"-au", "--admin-url"}, description = "Pulsar Admin URL", descriptionKey = "webServiceUrl")
+    public String adminURL;
+
+    @Option(names = {"-np",
+            "--partitions"}, description = "Create partitioned topics with a given number of partitions, 0 means"
+            + "not trying to create a topic")
+    public Integer partitions = null;
+
+    @Option(names = {"-time",
+            "--test-duration"}, description = "Test duration (in second). 0 means keeping publishing")
+    public long testTime = 0;
+
+    @Option(names = {"-ss",
+            "--subscriptions"}, description = "A list of subscriptions to consume (for example, sub1,sub2)")
+    public List<String> subscriptions = Collections.singletonList("sub");
+
+    @Option(names = {"-ns", "--num-subscriptions"}, description = "Number of subscriptions (per topic)")
+    public int numSubscriptions = 1;
+
+    @Option(names = {"-st", "--subscription-type"}, description = "Subscription type")
+    public SubscriptionType subscriptionType = SubscriptionType.Shared;
+
+    @Option(names = {"-rs", "--replicated" },
+            description = "Whether the subscription status should be replicated")
+    protected boolean replicatedSubscription = false;
+
+    @Option(names = {"-q", "--receiver-queue-size"}, description = "Size of the receiver queue")
+    public int receiverQueueSize = 1000;
+
+    @Option(names = {"-tto", "--txn-timeout"}, description = "Set the time value of transaction timeout,"
+            + " and the time unit is second. (After --txn-enable setting to true, --txn-timeout takes effect)")
+    public long transactionTimeout = 5;
+
+    @Option(names = {"-ntxn",
+            "--number-txn"}, description = "Set the number of transaction. 0 means keeping open."
+            + "If transaction disabled, it means the number of tasks. The task or transaction produces or "
+            + "consumes a specified number of messages.")
+    public long numTransactions = 0;
+
+    @Option(names = {"-nmp", "--numMessage-perTransaction-produce"},
+            description = "Set the number of messages produced in  a transaction."
+                    + "If transaction disabled, it means the number of messages produced in a task.")
+    public int numMessagesProducedPerTransaction = 1;
+
+    @Option(names = {"-nmc", "--numMessage-perTransaction-consume"},
+            description = "Set the number of messages consumed in a transaction."
+                    + "If transaction disabled, it means the number of messages consumed in a task.")
+    public int numMessagesReceivedPerTransaction = 1;
+
+    @Option(names = {"--txn-disable"}, description = "Disable transaction")
+    public boolean isDisableTransaction = false;
+
+    @Option(names = {"-abort"}, description = "Abort the transaction. (After --txn-disEnable "
+            + "setting to false, -abort takes effect)")
+    public boolean isAbortTransaction = false;
+
+    @Option(names = "-txnRate", description = "Set the rate of opened transaction or task. 0 means no limit")
+    public int openTxnRate = 0;
+
+    protected PerformanceTransactionBase(String cmdName) {
+        super(cmdName);
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // Client-specific seams
+    // ------------------------------------------------------------------------------------------
+
+    /** Build and connect the client, enabling transactions unless {@code --txn-disable} is set. */
+    protected abstract ClientT createClient() throws Exception;
+
+    /** Close a client built by {@link #createClient()}; must tolerate a {@code null} argument. */
+    protected abstract void closeClient(ClientT client);
+
+    /** Create one producer on {@code topic}. */
+    protected abstract CompletableFuture<ProducerT> createProducerAsync(ClientT client, String topic);
+
+    /** Subscribe one consumer to {@code topic} under {@code subscription}. */
+    protected abstract CompletableFuture<ConsumerT> subscribeAsync(ClientT client, String topic,
+                                                                   String subscription);
+
+    /** Open a new transaction, honouring {@code --txn-timeout}. */
+    protected abstract TxnT newTransaction(ClientT client) throws Exception;
+
+    /** Commit a transaction. */
+    protected abstract CompletableFuture<Void> commitTransaction(TxnT transaction);
+
+    /** Abort a transaction. */
+    protected abstract CompletableFuture<Void> abortTransaction(TxnT transaction);
+
+    /** Receive the next message, blocking until one arrives. */
+    protected abstract MessageT receive(ConsumerT consumer) throws Exception;
+
+    /**
+     * Acknowledge one message, individually or under {@code transaction} when it is non-null.
+     *
+     * <p>The returned future is what the reported ack latency measures. On the v4 client that is a
+     * broker round trip; V5's {@code acknowledge} is a synchronous void, so its future is already
+     * complete and the measurement is local.
+     */
+    protected abstract CompletableFuture<Void> acknowledgeAsync(ConsumerT consumer, MessageT msg,
+                                                                TxnT transaction);
+
+    /** Send one message, individually or under {@code transaction} when it is non-null. */
+    protected abstract CompletableFuture<?> sendMessage(ProducerT producer, byte[] payload, TxnT transaction);
+
+    /** Whether a send failure is just the producer having been closed, which is not counted or logged. */
+    protected abstract boolean isAlreadyClosedException(Throwable cause);
+
+    /**
+     * Whether the worker awaits every send of a transaction before ending it. See
+     * {@link PerformanceProducerBase#awaitSendsBeforeEndingTransaction()} for why the two clients
+     * differ.
+     */
+    protected boolean awaitSendsBeforeEndingTransaction() {
+        return true;
+    }
+
+    /** Hook for per-client run preparation, e.g. warnings about options with no effect. */
+    protected void prepareRun() {
+    }
+
+    /**
+     * Pre-create the topics the run needs. The default handles {@code --partitions} through the
+     * admin API; subclasses may add their own topic kinds before delegating.
+     */
+    protected void createTopicsIfNeeded() throws Exception {
+        if (this.partitions == null) {
+            return;
+        }
+        final PulsarAdminBuilder adminBuilder = PerfClientUtils
+                .createAdminBuilderFromArguments(this, this.adminURL);
+
+        try (PulsarAdmin adminClient = adminBuilder.build()) {
+            for (String topic : this.producerTopic) {
+                log.info()
+                        .attr("topic", topic)
+                        .attr("partitions", this.partitions)
+                        .log("Creating produce partitioned topic with partitions");
+                try {
+                    adminClient.topics().createPartitionedTopic(topic, this.partitions);
+                } catch (PulsarAdminException.ConflictException alreadyExists) {
+                    log.debug().attr("topic", topic).attr("exists", alreadyExists).log("Topic already exists");
+                    PartitionedTopicMetadata partitionedTopicMetadata =
+                            adminClient.topics().getPartitionedTopicMetadata(topic);
+                    if (partitionedTopicMetadata.partitions != this.partitions) {
+                        log.error()
+                                .attr("topic", topic)
+                                .attr("partitions", partitionedTopicMetadata.partitions)
+                                .attr("expecting", this.partitions)
+                                .log("Topic already exists but it has a wrong number of partitions: , expecting");
+                        PerfClientUtils.exit(1);
+                    }
+                }
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------------------------------
+
+    @Override
+    public void run() throws Exception {
+        super.parseCLI();
+
+        // Dump config variables
+        PerfClientUtils.printJVMInformation(log);
+        ObjectMapper m = new ObjectMapper();
+        ObjectWriter w = m.writerWithDefaultPrettyPrinter();
+        log.info().attr("config", w.writeValueAsString(this)).log("Starting Pulsar perf transaction with config");
+
+        final byte[] payloadBytes = new byte[1024];
+        Random random = new Random(0);
+        for (int i = 0; i < payloadBytes.length; ++i) {
+            payloadBytes[i] = (byte) (random.nextInt(26) + 65);
+        }
+
+        createTopicsIfNeeded();
+        prepareRun();
+
+        ClientT client = createClient();
+        try {
+            ExecutorService executorService = new ThreadPoolExecutor(this.numTestThreads,
+                    this.numTestThreads,
+                    0L, TimeUnit.MILLISECONDS,
+                    new LinkedBlockingQueue<>());
+
+            long startTime = System.nanoTime();
+            long testEndTime = startTime + (long) (this.testTime * 1e9);
+            Thread shutdownHookThread = addShutdownHook(() -> {
+                if (!this.isDisableTransaction) {
+                    printTxnAggregatedThroughput(startTime);
+                } else {
+                    printAggregatedThroughput(startTime);
+                }
+                printAggregatedStats();
+            });
+
+            // start perf test
+            AtomicBoolean executing = new AtomicBoolean(true);
+
+            RateLimiter rateLimiter = this.openTxnRate > 0
+                    ? RateLimiter.create(this.openTxnRate)
+                    : null;
+            for (int i = 0; i < this.numTestThreads; i++) {
+                executorService.submit(() -> runWorker(client, payloadBytes, executorService, executing,
+                        rateLimiter, testEndTime));
+            }
+
+            // Print report stats
+            long oldTime = System.nanoTime();
+
+            Histogram reportSendHistogram = null;
+            Histogram reportAckHistogram = null;
+
+            String statsFileName = "perf-transaction-" + System.currentTimeMillis() + ".hgrm";
+            log.info().attr("stats", statsFileName).log("Dumping latency stats to");
+
+            PrintStream histogramLog = new PrintStream(new FileOutputStream(statsFileName), false);
+            HistogramLogWriter histogramLogWriter = new HistogramLogWriter(histogramLog);
+
+            // Some log header bits
+            histogramLogWriter.outputLogFormatVersion();
+            histogramLogWriter.outputLegend();
+
+            while (!Thread.currentThread().isInterrupted() && executing.get()) {
+                try {
+                    Thread.sleep(10000);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+                long now = System.nanoTime();
+                double elapsed = (now - oldTime) / 1e9;
+                long total = totalNumEndTxnOpFailed.sum() + totalNumTxnOpenTxnSuccess.sum();
+                double rate = numTxnOpSuccess.sumThenReset() / elapsed;
+                reportSendHistogram = messageSendRecorder.getIntervalHistogram(reportSendHistogram);
+                reportAckHistogram = messageAckRecorder.getIntervalHistogram(reportAckHistogram);
+                String label = !this.isDisableTransaction
+                        ? "Throughput transaction" : "Throughput task";
+                log.infof("%s: %7d --- %7.3f/s"
+                                + " --- SendLatency: mean: %7.3f ms - med: %7.3f"
+                                + " - 95pct: %7.3f - 99pct: %7.3f"
+                                + " - 99.9pct: %7.3f - 99.99pct: %7.3f - Max: %7.3f"
+                                + " --- AckLatency: mean: %7.3f ms - med: %7.3f"
+                                + " - 95pct: %7.3f - 99pct: %7.3f"
+                                + " - 99.9pct: %7.3f - 99.99pct: %7.3f - Max: %7.3f",
+                        label, total, rate,
+                        reportSendHistogram.getMean() / 1000.0,
+                        reportSendHistogram.getValueAtPercentile(50) / 1000.0,
+                        reportSendHistogram.getValueAtPercentile(95) / 1000.0,
+                        reportSendHistogram.getValueAtPercentile(99) / 1000.0,
+                        reportSendHistogram.getValueAtPercentile(99.9) / 1000.0,
+                        reportSendHistogram.getValueAtPercentile(99.99) / 1000.0,
+                        reportSendHistogram.getMaxValue() / 1000.0,
+                        reportAckHistogram.getMean() / 1000.0,
+                        reportAckHistogram.getValueAtPercentile(50) / 1000.0,
+                        reportAckHistogram.getValueAtPercentile(95) / 1000.0,
+                        reportAckHistogram.getValueAtPercentile(99) / 1000.0,
+                        reportAckHistogram.getValueAtPercentile(99.9) / 1000.0,
+                        reportAckHistogram.getValueAtPercentile(99.99) / 1000.0,
+                        reportAckHistogram.getMaxValue() / 1000.0);
+
+                histogramLogWriter.outputIntervalHistogram(reportSendHistogram);
+                histogramLogWriter.outputIntervalHistogram(reportAckHistogram);
+                reportSendHistogram.reset();
+                reportAckHistogram.reset();
+
+                oldTime = now;
+            }
+
+            PerfClientUtils.removeAndRunShutdownHook(shutdownHookThread);
+        } finally {
+            closeClient(client);
+        }
+    }
+
+    /**
+     * One test thread: build its own producers and consumers, then loop over transactions until the
+     * run is stopped. The loop has no break of its own; it ends through the executor's shutdownNow.
+     */
+    private void runWorker(ClientT client, byte[] payloadBytes, ExecutorService executorService,
+                           AtomicBoolean executing, RateLimiter rateLimiter, long testEndTime) {
+        // The producer and consumer clients are built in advance, and then this thread is
+        // responsible for the production and consumption tasks of the transaction through the loop.
+        // A thread may perform tasks of multiple transactions in a traversing manner.
+        List<ProducerT> producers = null;
+        List<List<ConsumerT>> consumers = null;
+        AtomicReference<TxnT> atomicReference = null;
+        try {
+            producers = buildProducers(client);
+            consumers = buildConsumers(client);
+            if (!this.isDisableTransaction) {
+                atomicReference = new AtomicReference<>(newTransaction(client));
+            } else {
+                atomicReference = new AtomicReference<>(null);
+            }
+        } catch (Exception e) {
+            if (PerfClientUtils.hasInterruptedException(e)) {
+                Thread.currentThread().interrupt();
+            } else {
+                log.error().exception(e).log("Failed to build Producer/Consumer with exception");
+            }
+            executorService.shutdownNow();
+            PerfClientUtils.exit(1);
+            return;
+        }
+
+        while (!Thread.currentThread().isInterrupted()) {
+            if (this.numTransactions > 0) {
+                if (totalNumTxnOpenTxnFail.sum()
+                        + totalNumTxnOpenTxnSuccess.sum() >= this.numTransactions) {
+                    if (totalNumEndTxnOpFailed.sum()
+                            + totalNumEndTxnOpSuccess.sum() < this.numTransactions) {
+                        continue;
+                    }
+                    log.info("------------------- DONE -----------------------");
+                    executing.compareAndSet(true, false);
+                    executorService.shutdownNow();
+                    PerfClientUtils.exit(0);
+                    break;
+                }
+            }
+            if (this.testTime > 0) {
+                if (System.nanoTime() > testEndTime) {
+                    log.info("------------------- DONE -----------------------");
+                    executing.compareAndSet(true, false);
+                    executorService.shutdownNow();
+                    PerfClientUtils.exit(0);
+                    break;
+                }
+            }
+            TxnT transaction = atomicReference.get();
+            for (List<ConsumerT> subscriptions : consumers) {
+                for (ConsumerT consumer : subscriptions) {
+                    for (int j = 0; j < this.numMessagesReceivedPerTransaction; j++) {
+                        MessageT message;
+                        try {
+                            message = receive(consumer);
+                        } catch (Exception e) {
+                            if (PerfClientUtils.hasInterruptedException(e)) {
+                                Thread.currentThread().interrupt();
+                                return;
+                            }
+                            log.error().exception(e).log("Receive message failed");
+                            executorService.shutdownNow();
+                            PerfClientUtils.exit(1);
+                            return;
+                        }
+                        acknowledgeAndRecord(consumer, message, transaction);
+                    }
+                }
+            }
+
+            // Send futures of the in-flight transaction, awaited before it is ended when
+            // awaitSendsBeforeEndingTransaction() is on, so the commit never races the sends.
+            List<CompletableFuture<?>> pendingSends = new ArrayList<>();
+            for (ProducerT producer : producers) {
+                for (int j = 0; j < this.numMessagesProducedPerTransaction; j++) {
+                    pendingSends.add(sendAndRecord(producer, payloadBytes, transaction));
+                }
+            }
+
+            if (awaitSendsBeforeEndingTransaction()) {
+                // allOf().exceptionally() swallows individual send failures here — they are
+                // already counted by sendAndRecord.
+                try {
+                    CompletableFuture.allOf(pendingSends.toArray(new CompletableFuture[0]))
+                            .exceptionally(t -> null)
+                            .join();
+                } catch (Exception awaitEx) {
+                    if (PerfClientUtils.hasInterruptedException(awaitEx)) {
+                        Thread.currentThread().interrupt();
+                    }
+                }
+            }
+
+            if (rateLimiter != null) {
+                rateLimiter.tryAcquire();
+            }
+            if (!this.isDisableTransaction) {
+                endTransaction(transaction);
+                openNextTransaction(client, atomicReference, transaction);
+            } else {
+                totalNumTxnOpenTxnSuccess.increment();
+                totalNumEndTxnOpSuccess.increment();
+                numTxnOpSuccess.increment();
+            }
+        }
+    }
+
+    private void acknowledgeAndRecord(ConsumerT consumer, MessageT message, TxnT transaction) {
+        long receiveTime = System.nanoTime();
+        acknowledgeAsync(consumer, message, transaction)
+                .thenRun(() -> {
+                    long latencyMicros = Math.min(NANOSECONDS.toMicros(
+                            System.nanoTime() - receiveTime), MAX_LATENCY_MICROS);
+                    messageAckRecorder.recordValue(latencyMicros);
+                    messageAckCumulativeRecorder.recordValue(latencyMicros);
+                    numMessagesAckSuccess.increment();
+                })
+                .exceptionally(exception -> {
+                    if (PerfClientUtils.hasInterruptedException(exception)) {
+                        Thread.currentThread().interrupt();
+                        return null;
+                    }
+                    log.error()
+                            .exception(exception)
+                            .log("Ack message failed with transaction throw exception");
+                    numMessagesAckFailed.increment();
+                    return null;
+                });
+    }
+
+    private CompletableFuture<?> sendAndRecord(ProducerT producer, byte[] payloadBytes, TxnT transaction) {
+        long sendTime = System.nanoTime();
+        return sendMessage(producer, payloadBytes, transaction).whenComplete((id, ex) -> {
+            if (ex == null) {
+                long latencyMicros = Math.min(NANOSECONDS.toMicros(
+                        System.nanoTime() - sendTime), MAX_LATENCY_MICROS);
+                messageSendRecorder.recordValue(latencyMicros);
+                messageSendRCumulativeRecorder.recordValue(latencyMicros);
+                numMessagesSendSuccess.increment();
+            } else {
+                if (PerfClientUtils.hasInterruptedException(ex)) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+                // Ignore the exception when the producer is closed
+                if (isAlreadyClosedException(ex.getCause())) {
+                    return;
+                }
+                log.error()
+                        .exception(ex)
+                        .log("Send message failed with exception");
+                numMessagesSendFailed.increment();
+            }
+        });
+    }
+
+    /** End the transaction according to {@code -abort}, counting the outcome. */
+    private void endTransaction(TxnT transaction) {
+        final boolean abort = this.isAbortTransaction;
+        CompletableFuture<Void> endFuture = abort ? abortTransaction(transaction) : commitTransaction(transaction);
+        endFuture.thenRun(() -> {
+            numTxnOpSuccess.increment();
+            totalNumEndTxnOpSuccess.increment();
+        }).exceptionally(exception -> {
+            if (PerfClientUtils.hasInterruptedException(exception)) {
+                Thread.currentThread().interrupt();
+                return null;
+            }
+            log.error()
+                    .exception(exception)
+                    .log(abort ? "Abort transaction failed with exception"
+                            : "Commit transaction failed with exception");
+            totalNumEndTxnOpFailed.increment();
+            return null;
+        });
+    }
+
+    private void openNextTransaction(ClientT client, AtomicReference<TxnT> atomicReference, TxnT previous) {
+        while (!Thread.currentThread().isInterrupted()) {
+            try {
+                TxnT newTransaction = newTransaction(client);
+                atomicReference.compareAndSet(previous, newTransaction);
+                totalNumTxnOpenTxnSuccess.increment();
+                break;
+            } catch (Exception throwable) {
+                if (PerfClientUtils.hasInterruptedException(throwable)) {
+                    Thread.currentThread().interrupt();
+                } else {
+                    log.error()
+                            .exception(throwable)
+                            .log("Failed to new transaction with exception");
+                    totalNumTxnOpenTxnFail.increment();
+                }
+            }
+        }
+    }
+
+    private List<List<ConsumerT>> buildConsumers(ClientT client) throws Exception {
+        List<List<ConsumerT>> consumers = new ArrayList<>(this.consumerTopic.size());
+        for (String topic : this.consumerTopic) {
+            final List<CompletableFuture<ConsumerT>> subscriptionFutures =
+                    new ArrayList<>(this.numSubscriptions);
+            log.info().attr("topic", topic).log("Create subscriptions for topic");
+            for (int j = 0; j < this.numSubscriptions; j++) {
+                subscriptionFutures.add(subscribeAsync(client, topic, this.subscriptions.get(j)));
+            }
+            final List<ConsumerT> subscriptions = new ArrayList<>(subscriptionFutures.size());
+            for (CompletableFuture<ConsumerT> future : subscriptionFutures) {
+                subscriptions.add(future.get());
+            }
+            consumers.add(subscriptions);
+        }
+        return consumers;
+    }
+
+    private List<ProducerT> buildProducers(ClientT client) throws Exception {
+        final List<CompletableFuture<ProducerT>> producerFutures = new ArrayList<>();
+        for (String topic : this.producerTopic) {
+            log.info().attr("topic", topic).log("Create producer for topic");
+            producerFutures.add(createProducerAsync(client, topic));
+        }
+        final List<ProducerT> producers = new ArrayList<>(producerFutures.size());
+        for (CompletableFuture<ProducerT> future : producerFutures) {
+            producers.add(future.get());
+        }
+        return producers;
+    }
+
+    private void printTxnAggregatedThroughput(long start) {
+        double elapsed = (System.nanoTime() - start) / 1e9;
+        long numTransactionEndFailed = totalNumEndTxnOpFailed.sum();
+        long numTransactionEndSuccess = totalNumEndTxnOpSuccess.sum();
+        long total = numTransactionEndFailed + numTransactionEndSuccess;
+        double rate = total / elapsed;
+        long numMessageAckFailed = numMessagesAckFailed.sum();
+        long numMessageAckSuccess = numMessagesAckSuccess.sum();
+        long numMessageSendFailed = numMessagesSendFailed.sum();
+        long numMessageSendSuccess = numMessagesSendSuccess.sum();
+        long numTransactionOpenFailed = totalNumTxnOpenTxnFail.sum();
+        long numTransactionOpenSuccess = totalNumTxnOpenTxnSuccess.sum();
+
+        log.infof("Aggregated throughput stats --- %d transaction executed --- %7.3f transaction/s"
+                        + " --- %d transaction open successfully --- %d transaction open failed"
+                        + " --- %d transaction end successfully --- %d transaction end failed"
+                        + " --- %d message ack failed --- %d message send failed"
+                        + " --- %d message ack success --- %d message send success",
+                total, rate,
+                numTransactionOpenSuccess, numTransactionOpenFailed,
+                numTransactionEndSuccess, numTransactionEndFailed,
+                numMessageAckFailed, numMessageSendFailed,
+                numMessageAckSuccess, numMessageSendSuccess);
+
+    }
+
+    private void printAggregatedThroughput(long start) {
+        double elapsed = (System.nanoTime() - start) / 1e9;
+        long total = totalNumEndTxnOpFailed.sum() + totalNumEndTxnOpSuccess.sum();
+        double rate = total / elapsed;
+        long numMessageAckFailed = numMessagesAckFailed.sum();
+        long numMessageAckSuccess = numMessagesAckSuccess.sum();
+        long numMessageSendFailed = numMessagesSendFailed.sum();
+        long numMessageSendSuccess = numMessagesSendSuccess.sum();
+        log.infof("Aggregated throughput stats --- %d task executed --- %.3f task/s"
+                        + " --- %d message ack failed --- %d message send failed"
+                        + " --- %d message ack success --- %d message send success",
+                total, rate,
+                numMessageAckFailed, numMessageSendFailed,
+                numMessageAckSuccess, numMessageSendSuccess);
+    }
+
+    private void printAggregatedStats() {
+        Histogram reportAckHistogram = messageAckCumulativeRecorder.getIntervalHistogram();
+        Histogram reportSendHistogram = messageSendRCumulativeRecorder.getIntervalHistogram();
+        log.infof("Messages ack aggregated latency stats --- Latency: mean: %7.3f ms"
+                        + " - med: %7.3f - 95pct: %7.3f - 99pct: %7.3f"
+                        + " - 99.9pct: %7.3f - 99.99pct: %7.3f"
+                        + " - 99.999pct: %7.3f - Max: %7.3f",
+                reportAckHistogram.getMean() / 1000.0,
+                reportAckHistogram.getValueAtPercentile(50) / 1000.0,
+                reportAckHistogram.getValueAtPercentile(95) / 1000.0,
+                reportAckHistogram.getValueAtPercentile(99) / 1000.0,
+                reportAckHistogram.getValueAtPercentile(99.9) / 1000.0,
+                reportAckHistogram.getValueAtPercentile(99.99) / 1000.0,
+                reportAckHistogram.getValueAtPercentile(99.999) / 1000.0,
+                reportAckHistogram.getMaxValue() / 1000.0);
+        log.infof("Messages send aggregated latency stats --- Latency: mean: %7.3f ms"
+                        + " - med: %7.3f - 95pct: %7.3f - 99pct: %7.3f"
+                        + " - 99.9pct: %7.3f - 99.99pct: %7.3f"
+                        + " - 99.999pct: %7.3f - Max: %7.3f",
+                reportSendHistogram.getMean() / 1000.0,
+                reportSendHistogram.getValueAtPercentile(50) / 1000.0,
+                reportSendHistogram.getValueAtPercentile(95) / 1000.0,
+                reportSendHistogram.getValueAtPercentile(99) / 1000.0,
+                reportSendHistogram.getValueAtPercentile(99.9) / 1000.0,
+                reportSendHistogram.getValueAtPercentile(99.99) / 1000.0,
+                reportSendHistogram.getValueAtPercentile(99.999) / 1000.0,
+                reportSendHistogram.getMaxValue() / 1000.0);
+    }
+}

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceTransactionBase.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceTransactionBase.java
@@ -511,6 +511,12 @@ public abstract class PerformanceTransactionBase<ClientT, ProducerT, ConsumerT, 
 
     private void acknowledgeAndRecord(ConsumerT consumer, MessageT message, TxnT transaction) {
         long receiveTime = System.nanoTime();
+        // Capture the worker so an interrupt targets it rather than whichever thread happens to run
+        // the callback. The V5 ack future is already complete when it is returned, so the callbacks
+        // below do run on this thread, but the v4 one completes on a client-internal thread — as do
+        // the send and end-transaction futures on both clients, which capture it for the same
+        // reason.
+        final Thread workerThread = Thread.currentThread();
         acknowledgeAsync(consumer, message, transaction)
                 .thenRun(() -> {
                     long latencyMicros = Math.min(NANOSECONDS.toMicros(
@@ -521,7 +527,7 @@ public abstract class PerformanceTransactionBase<ClientT, ProducerT, ConsumerT, 
                 })
                 .exceptionally(exception -> {
                     if (PerfClientUtils.hasInterruptedException(exception)) {
-                        Thread.currentThread().interrupt();
+                        workerThread.interrupt();
                         return null;
                     }
                     log.error()
@@ -534,6 +540,7 @@ public abstract class PerformanceTransactionBase<ClientT, ProducerT, ConsumerT, 
 
     private CompletableFuture<?> sendAndRecord(ProducerT producer, byte[] payloadBytes, TxnT transaction) {
         long sendTime = System.nanoTime();
+        final Thread workerThread = Thread.currentThread();
         return sendMessage(producer, payloadBytes, transaction).whenComplete((id, ex) -> {
             if (ex == null) {
                 long latencyMicros = Math.min(NANOSECONDS.toMicros(
@@ -543,7 +550,7 @@ public abstract class PerformanceTransactionBase<ClientT, ProducerT, ConsumerT, 
                 numMessagesSendSuccess.increment();
             } else {
                 if (PerfClientUtils.hasInterruptedException(ex)) {
-                    Thread.currentThread().interrupt();
+                    workerThread.interrupt();
                     return;
                 }
                 // Ignore the exception when the producer is closed
@@ -561,13 +568,14 @@ public abstract class PerformanceTransactionBase<ClientT, ProducerT, ConsumerT, 
     /** End the transaction according to {@code -abort}, counting the outcome. */
     private void endTransaction(TxnT transaction) {
         final boolean abort = this.isAbortTransaction;
+        final Thread workerThread = Thread.currentThread();
         CompletableFuture<Void> endFuture = abort ? abortTransaction(transaction) : commitTransaction(transaction);
         endFuture.thenRun(() -> {
             numTxnOpSuccess.increment();
             totalNumEndTxnOpSuccess.increment();
         }).exceptionally(exception -> {
             if (PerfClientUtils.hasInterruptedException(exception)) {
-                Thread.currentThread().interrupt();
+                workerThread.interrupt();
                 return null;
             }
             log.error()

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceTransactionV4.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceTransactionV4.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.testclient;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.apache.pulsar.client.api.ClientBuilder;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.ConsumerBuilder;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
+import org.apache.pulsar.client.api.TypedMessageBuilder;
+import org.apache.pulsar.client.api.transaction.Transaction;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+/**
+ * The {@code transaction} benchmark driven by the v4 ({@code pulsar-client-original}) client and
+ * the v4 transaction coordinator, which stays a live broker code path alongside the v5 one
+ * (PIP-473 P5.4) but has no other perf command driving it.
+ *
+ * <p>This is the counterpart of {@link PerformanceTransaction}: the benchmark itself comes from
+ * {@link PerformanceTransactionBase} and only the client bindings differ. Two things it measures
+ * that the V5 command cannot: the acknowledgement round trip (v4 {@code acknowledgeAsync} completes
+ * when the broker has replied, whereas V5's {@code acknowledge} is a synchronous void), and real
+ * {@code Exclusive}/{@code Failover}/{@code Key_Shared} subscription types.
+ */
+@Command(name = "transaction-v4",
+        description = "Test pulsar transaction performance using the v4 client.")
+public class PerformanceTransactionV4 extends PerformanceTransactionBase<PulsarClient, Producer<byte[]>,
+        Consumer<byte[]>, Message<byte[]>, Transaction> {
+
+    @Option(names = {"-sp", "--subscription-position"}, description = "Subscription position")
+    private SubscriptionInitialPosition subscriptionInitialPosition = SubscriptionInitialPosition.Earliest;
+
+    public PerformanceTransactionV4() {
+        super("transaction-v4");
+    }
+
+    @Override
+    protected PulsarClient createClient() throws PulsarClientException {
+        ClientBuilder clientBuilder = PerfClientUtils.createClientBuilderFromArguments(this)
+                .enableTransaction(!this.isDisableTransaction);
+        return clientBuilder.build();
+    }
+
+    @Override
+    protected void closeClient(PulsarClient client) {
+        PerfClientUtils.closeClient(client);
+    }
+
+    @Override
+    protected CompletableFuture<Producer<byte[]>> createProducerAsync(PulsarClient client, String topic) {
+        return client.newProducer(Schema.BYTES)
+                // A send timeout and a transaction are mutually exclusive on the v4 client.
+                .sendTimeout(0, TimeUnit.SECONDS)
+                .topic(topic)
+                .createAsync();
+    }
+
+    @Override
+    protected CompletableFuture<Consumer<byte[]>> subscribeAsync(PulsarClient client, String topic,
+                                                                 String subscription) {
+        ConsumerBuilder<byte[]> consumerBuilder = client.newConsumer(Schema.BYTES)
+                .subscriptionType(
+                        org.apache.pulsar.client.api.SubscriptionType.valueOf(this.subscriptionType.name()))
+                .receiverQueueSize(this.receiverQueueSize)
+                .subscriptionInitialPosition(this.subscriptionInitialPosition)
+                .replicateSubscriptionState(this.replicatedSubscription)
+                .topic(topic)
+                .subscriptionName(subscription);
+        return consumerBuilder.subscribeAsync();
+    }
+
+    @Override
+    protected Transaction newTransaction(PulsarClient client) throws Exception {
+        return client.newTransaction()
+                .withTransactionTimeout(this.transactionTimeout, TimeUnit.SECONDS)
+                .build()
+                .get();
+    }
+
+    @Override
+    protected CompletableFuture<Void> commitTransaction(Transaction transaction) {
+        return transaction.commit();
+    }
+
+    @Override
+    protected CompletableFuture<Void> abortTransaction(Transaction transaction) {
+        return transaction.abort();
+    }
+
+    @Override
+    protected Message<byte[]> receive(Consumer<byte[]> consumer) throws PulsarClientException {
+        return consumer.receive();
+    }
+
+    @Override
+    protected CompletableFuture<Void> acknowledgeAsync(Consumer<byte[]> consumer, Message<byte[]> msg,
+                                                       Transaction transaction) {
+        return transaction != null
+                ? consumer.acknowledgeAsync(msg.getMessageId(), transaction)
+                : consumer.acknowledgeAsync(msg);
+    }
+
+    @Override
+    protected CompletableFuture<?> sendMessage(Producer<byte[]> producer, byte[] payload, Transaction transaction) {
+        TypedMessageBuilder<byte[]> msg = transaction != null
+                ? producer.newMessage(transaction).value(payload)
+                : producer.newMessage().value(payload);
+        return msg.sendAsync();
+    }
+
+    @Override
+    protected boolean isAlreadyClosedException(Throwable cause) {
+        return cause instanceof PulsarClientException.AlreadyClosedException;
+    }
+
+    /** See {@link PerformanceProducerV4#awaitSendsBeforeEndingTransaction()}. */
+    @Override
+    protected boolean awaitSendsBeforeEndingTransaction() {
+        return false;
+    }
+}

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceTransactionV4.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceTransactionV4.java
@@ -72,7 +72,9 @@ public class PerformanceTransactionV4 extends PerformanceTransactionBase<PulsarC
     @Override
     protected CompletableFuture<Producer<byte[]>> createProducerAsync(PulsarClient client, String topic) {
         return client.newProducer(Schema.BYTES)
-                // A send timeout and a transaction are mutually exclusive on the v4 client.
+                // The v4 client has allowed a send timeout inside a transaction since #16519, but a
+                // timeout still fails the send on its own schedule and takes the transaction with
+                // it. Disable it so --txn-timeout is the only deadline.
                 .sendTimeout(0, TimeUnit.SECONDS)
                 .topic(topic)
                 .createAsync();

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PulsarPerfTestTool.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PulsarPerfTestTool.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.testclient;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import com.google.common.annotations.VisibleForTesting;
 import java.io.FileInputStream;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -43,11 +44,18 @@ public class PulsarPerfTestTool {
         commandMap = new HashMap<>();
     }
 
-    private String[] initCommander(String[] args) throws Exception {
+    @VisibleForTesting
+    String[] initCommander(String[] args) throws Exception {
         commandMap.put("produce", PerformanceProducer.class);
         commandMap.put("consume", PerformanceConsumer.class);
         commandMap.put("transaction", PerformanceTransaction.class);
         commandMap.put("read", PerformanceReader.class);
+        // The same benchmarks driven by the v4 (pulsar-client-original) client, for measuring the v4
+        // client and non-scalable topics without the V5 SDK in the path.
+        commandMap.put("produce-v4", PerformanceProducerV4.class);
+        commandMap.put("consume-v4", PerformanceConsumerV4.class);
+        commandMap.put("transaction-v4", PerformanceTransactionV4.class);
+        commandMap.put("read-v4", PerformanceReaderV4.class);
         commandMap.put("monitor-brokers", BrokerMonitor.class);
         commandMap.put("websocket-producer", PerformanceClient.class);
         commandMap.put("managed-ledger", ManagedLedgerWriter.class);

--- a/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerfClientUtilsTest.java
+++ b/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerfClientUtilsTest.java
@@ -234,10 +234,10 @@ public class PerfClientUtilsTest {
     }
 
     /**
-     * The perf clients hold their latency recorders in static fields, so every subcommand allocates them on
-     * startup rather than only the one being run. HdrHistogram grows the counts array by roughly 10x per
-     * significant digit, and at 5 digits these same ranges cost 11-22 MB each. Pin the bound so raising the
-     * precision again fails here instead of silently costing hundreds of megabytes.
+     * Each perf command holds several latency recorders (a live and a cumulative one per measured latency).
+     * HdrHistogram grows the counts array by roughly 10x per significant digit, and at 5 digits a single
+     * recorder over these same ranges costs 14-16 MB. Pin the bound so raising the precision again fails
+     * here instead of silently costing hundreds of megabytes per run.
      */
     @Test
     public void latencyHistogramsStaySmallAtTheConfiguredPrecision() {

--- a/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerformanceTransactionV4Test.java
+++ b/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerformanceTransactionV4Test.java
@@ -99,7 +99,7 @@ public class PerformanceTransactionV4Test extends MockedPulsarServiceBaseTest {
      * <p>The acknowledgement assertion is what stops a run that never acknowledged at all from
      * satisfying {@link #testTransactionV4AbortUndoesBothTheSendAndTheAck()}'s "backlog unchanged".
      */
-    @Test(timeOut = 120000)
+    @Test(timeOut = 180000)
     public void testTransactionV4CommitsWhatItProduced() throws Exception {
         String consumeTopic = testTopic + UUID.randomUUID();
         String produceTopic = testTopic + UUID.randomUUID();
@@ -132,7 +132,7 @@ public class PerformanceTransactionV4Test extends MockedPulsarServiceBaseTest {
      * permanent, so this is what pins the {@code transaction != null} branches of
      * {@code PerformanceTransactionV4.sendMessage} and {@code acknowledgeAsync} onto the transaction.
      */
-    @Test(timeOut = 120000)
+    @Test(timeOut = 180000)
     public void testTransactionV4AbortUndoesBothTheSendAndTheAck() throws Exception {
         String consumeTopic = testTopic + UUID.randomUUID();
         String produceTopic = testTopic + UUID.randomUUID();

--- a/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerformanceTransactionV4Test.java
+++ b/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerformanceTransactionV4Test.java
@@ -1,0 +1,212 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.testclient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import com.google.common.collect.Sets;
+import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.Cleanup;
+import lombok.CustomLog;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
+import org.apache.pulsar.common.naming.NamespaceName;
+import org.apache.pulsar.common.naming.SystemTopicNames;
+import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
+import org.apache.pulsar.common.policies.data.ClusterData;
+import org.apache.pulsar.common.policies.data.TenantInfoImpl;
+import org.awaitility.Awaitility;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * End-to-end coverage of {@code pulsar-perf transaction-v4}, which drives the v4 client and the v4
+ * transaction coordinator against ordinary {@code persistent://} topics. The V5 counterpart lives in
+ * {@link PerformanceTransactionTest}, which needs scalable topics and a V5 SDK client; here the v4
+ * SDK client the base test already provides is the verifier.
+ */
+@CustomLog
+public class PerformanceTransactionV4Test extends MockedPulsarServiceBaseTest {
+
+    private static final int PUBLISHED = 10;
+    private static final int TRANSACTIONS = 5;
+    private static final Duration RUN_TIMEOUT = Duration.ofSeconds(90);
+
+    private final String myNamespace = "pulsar/perf";
+    private final String testTopic = "persistent://" + myNamespace + "/test-";
+    private final AtomicInteger lastExitCode = new AtomicInteger(0);
+
+    @BeforeMethod
+    @Override
+    protected void setup() throws Exception {
+        ServiceConfiguration serviceConfiguration = getDefaultConf();
+        serviceConfiguration.setTopicLevelPoliciesEnabled(false);
+        serviceConfiguration.setTransactionCoordinatorEnabled(true);
+        super.internalSetup(serviceConfiguration);
+        lastExitCode.set(0);
+        PerfClientUtils.setExitProcedure(code -> {
+            log.info().attr("code", code).log("Perf tool requested JVM exit");
+            lastExitCode.set(code);
+        });
+        admin.clusters().createCluster("test",
+                ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+        // SYSTEM_NAMESPACE's tenant is "pulsar", the same tenant myNamespace lives under.
+        admin.tenants().createTenant(NamespaceName.SYSTEM_NAMESPACE.getTenant(),
+                new TenantInfoImpl(Sets.newHashSet("appid1"), Sets.newHashSet("test")));
+        admin.namespaces().createNamespace(myNamespace, Sets.newHashSet("test"));
+        admin.namespaces().createNamespace(NamespaceName.SYSTEM_NAMESPACE.toString());
+        pulsar.getPulsarResources().getNamespaceResources().getPartitionedTopicResources()
+                .createPartitionedTopic(SystemTopicNames.TRANSACTION_COORDINATOR_ASSIGN,
+                        new PartitionedTopicMetadata(1));
+    }
+
+    @AfterMethod(alwaysRun = true)
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+        assertThat(lastExitCode.get()).as("perf tool JVM exit code").isZero();
+    }
+
+    /**
+     * A committed run must make both halves of its unit of work durable. This fails if the client is
+     * not built with {@code enableTransaction}, or if opening or committing the transaction is
+     * broken: in each case nothing is ever committed to the produce topic.
+     *
+     * <p>The acknowledgement assertion is what stops a run that never acknowledged at all from
+     * satisfying {@link #testTransactionV4AbortUndoesBothTheSendAndTheAck()}'s "backlog unchanged".
+     */
+    @Test(timeOut = 120000)
+    public void testTransactionV4CommitsWhatItProduced() throws Exception {
+        String consumeTopic = testTopic + UUID.randomUUID();
+        String produceTopic = testTopic + UUID.randomUUID();
+        String subscription = "sub-" + UUID.randomUUID();
+        publish(consumeTopic, PUBLISHED);
+
+        run("--topics-c %s --topics-p %s -threads 1 -ntxn %d -tto 60 -u %s -ss %s",
+                consumeTopic, produceTopic, TRANSACTIONS, pulsar.getBrokerServiceUrl(), subscription);
+
+        @Cleanup
+        Consumer<byte[]> produced = verifier(produceTopic);
+        for (int i = 0; i < TRANSACTIONS; i++) {
+            assertThat(produced.receive(30, TimeUnit.SECONDS))
+                    .as("message %d committed by transaction-v4", i)
+                    .isNotNull();
+        }
+
+        // One message is consumed and acknowledged per transaction, and committing makes those acks
+        // durable, so the backlog drops by exactly the number of transactions.
+        Awaitility.await().atMost(Duration.ofSeconds(30)).untilAsserted(() ->
+                assertThat(admin.topics().getStats(consumeTopic).getSubscriptions()
+                                .get(subscription).getMsgBacklog())
+                        .as("acknowledgements committed by transaction-v4")
+                        .isEqualTo(PUBLISHED - TRANSACTIONS));
+    }
+
+    /**
+     * {@code -abort} must undo both halves of the unit of work. A send that was not actually bound to
+     * the transaction would still become visible, and an ack that was not bound to it would still be
+     * permanent, so this is what pins the {@code transaction != null} branches of
+     * {@code PerformanceTransactionV4.sendMessage} and {@code acknowledgeAsync} onto the transaction.
+     */
+    @Test(timeOut = 120000)
+    public void testTransactionV4AbortUndoesBothTheSendAndTheAck() throws Exception {
+        String consumeTopic = testTopic + UUID.randomUUID();
+        String produceTopic = testTopic + UUID.randomUUID();
+        String subscription = "sub-" + UUID.randomUUID();
+        publish(consumeTopic, PUBLISHED);
+
+        run("--topics-c %s --topics-p %s -threads 1 -ntxn %d -tto 60 -u %s -ss %s -abort",
+                consumeTopic, produceTopic, TRANSACTIONS, pulsar.getBrokerServiceUrl(), subscription);
+
+        @Cleanup
+        Consumer<byte[]> produced = verifier(produceTopic);
+        assertThat(produced.receive(5, TimeUnit.SECONDS))
+                .as("a message sent under an aborted transaction must never become visible")
+                .isNull();
+        assertThat(admin.topics().getStats(consumeTopic).getSubscriptions()
+                        .get(subscription).getMsgBacklog())
+                .as("an ack made under an aborted transaction must not stay acknowledged")
+                .isEqualTo(PUBLISHED);
+
+        // Aborting *releases* the acknowledgements, so all ten messages are redeliverable on the
+        // tool's own subscription right away. A transaction that was merely never ended would leave
+        // the five it acknowledged pending until the transaction timeout, and only five would
+        // arrive — which is what separates a real abort from a no-op one.
+        @Cleanup
+        Consumer<byte[]> redelivered = pulsarClient.newConsumer().topic(consumeTopic)
+                .subscriptionName(subscription).subscribe();
+        for (int i = 0; i < PUBLISHED; i++) {
+            assertThat(redelivered.receive(15, TimeUnit.SECONDS))
+                    .as("message %d released by the abort", i)
+                    .isNotNull();
+        }
+    }
+
+    /**
+     * Runs the command to completion; the overridden exit procedure records the code rather than
+     * exiting the JVM, and {@link #cleanup()} asserts it was zero. The join is bounded and the
+     * thread is interrupted if it overruns, so a hung command cannot outlive the test and keep
+     * running against a broker that is being torn down.
+     */
+    private void run(String argFormat, Object... argValues) throws InterruptedException {
+        String[] args = String.format(argFormat, argValues).split(" ");
+        AtomicBoolean succeeded = new AtomicBoolean();
+        Thread thread = new Thread(() -> {
+            try {
+                succeeded.set(new PerformanceTransactionV4().run(args));
+            } catch (Exception e) {
+                log.error().exception(e).log("transaction-v4 failed");
+            }
+        }, "transaction-v4");
+        thread.start();
+        thread.join(RUN_TIMEOUT.toMillis());
+        if (thread.isAlive()) {
+            thread.interrupt();
+            thread.join(Duration.ofSeconds(10).toMillis());
+            fail("transaction-v4 did not finish within " + RUN_TIMEOUT);
+        }
+        assertThat(succeeded.get()).as("transaction-v4 exited cleanly").isTrue();
+    }
+
+    private Consumer<byte[]> verifier(String topic) throws Exception {
+        return pulsarClient.newConsumer().topic(topic).subscriptionName("verify")
+                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest).subscribe();
+    }
+
+    /**
+     * Batching is off on purpose: acknowledging part of a batch does not move the mark-delete
+     * position unless batch-index acknowledgement is enabled, which would make the backlog assertion
+     * pass whether or not the acks were transactional.
+     */
+    private void publish(String topic, int numMessages) throws Exception {
+        @Cleanup
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topic).enableBatching(false).create();
+        for (int i = 0; i < numMessages; i++) {
+            producer.send(("message-" + i).getBytes());
+        }
+    }
+}

--- a/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerformanceV4CommandsTest.java
+++ b/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerformanceV4CommandsTest.java
@@ -22,6 +22,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.google.common.collect.Sets;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -45,6 +47,7 @@ import org.apache.pulsar.client.impl.ProducerBuilderImpl;
 import org.apache.pulsar.client.impl.conf.ProducerConfigurationData;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
+import org.awaitility.Awaitility;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -166,12 +169,17 @@ public class PerformanceV4CommandsTest extends MockedPulsarServiceBaseTest {
         new CommandLine(plain).parseArgs(topic);
         plain.sendMessage(producer, "plain".getBytes(), null, null, plain.nextDeliverAfterSeconds()).get();
 
+        // Arrival order is publish order here: the subscription is Exclusive, and
+        // PersistentDispatcherSingleActiveConsumer does not override trackDelayedDelivery, so a
+        // delivery time never routes the message through the delayed-delivery tracker.
         MessageImpl<byte[]> first = (MessageImpl<byte[]>) consumer.receive(30, TimeUnit.SECONDS);
         MessageImpl<byte[]> second = (MessageImpl<byte[]>) consumer.receive(30, TimeUnit.SECONDS);
 
+        assertThat(new String(first.getData(), StandardCharsets.UTF_8)).isEqualTo("delayed");
         assertThat(first.getDeliverAtTime())
                 .as("a zero delay drawn from --delay-range must still mark the message")
                 .isPositive();
+        assertThat(new String(second.getData(), StandardCharsets.UTF_8)).isEqualTo("plain");
         assertThat(second.getDeliverAtTime())
                 .as("a message sent without --delay/--delay-range must carry no delivery time")
                 .isZero();
@@ -209,10 +217,12 @@ public class PerformanceV4CommandsTest extends MockedPulsarServiceBaseTest {
         stop(thread);
 
         // Every consumed message was acknowledged except the one that tripped --num-messages: the
-        // run ends there without acking it, exactly as `consume` does.
-        assertThat(admin.topics().getStats(topic).getSubscriptions().get(subscription).getMsgBacklog())
-                .as("consume-v4 must acknowledge what it consumed")
-                .isLessThanOrEqualTo(1);
+        // run ends there without acking it, exactly as `consume` does. The exit latch is released
+        // before the client is closed, and acks are grouped on a delay, so wait for the flush.
+        Awaitility.await().atMost(Duration.ofSeconds(30)).untilAsserted(() ->
+                assertThat(admin.topics().getStats(topic).getSubscriptions().get(subscription).getMsgBacklog())
+                        .as("consume-v4 must acknowledge what it consumed")
+                        .isLessThanOrEqualTo(1));
     }
 
     @Test(timeOut = 120000)

--- a/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerformanceV4CommandsTest.java
+++ b/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerformanceV4CommandsTest.java
@@ -1,0 +1,306 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.testclient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import com.google.common.collect.Sets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.Cleanup;
+import lombok.CustomLog;
+import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
+import org.apache.pulsar.client.api.CompressionType;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.MessageRoutingMode;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
+import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.client.impl.MessageIdImpl;
+import org.apache.pulsar.client.impl.MessageImpl;
+import org.apache.pulsar.client.impl.ProducerBuilderImpl;
+import org.apache.pulsar.client.impl.conf.ProducerConfigurationData;
+import org.apache.pulsar.common.policies.data.ClusterData;
+import org.apache.pulsar.common.policies.data.TenantInfoImpl;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import picocli.CommandLine;
+
+/**
+ * End-to-end coverage of the v4-client perf subcommands ({@code produce-v4}, {@code consume-v4},
+ * {@code read-v4}), which drive the v4 client against ordinary (non-scalable) topics. The
+ * verification side uses the v4 SDK client provided by the base test.
+ */
+@CustomLog
+public class PerformanceV4CommandsTest extends MockedPulsarServiceBaseTest {
+    private final String testTenant = "prop-xyz";
+    private final String testNamespace = "ns1";
+    private final String myNamespace = testTenant + "/" + testNamespace;
+    private final String testTopic = "persistent://" + myNamespace + "/test-";
+
+    private final AtomicInteger lastExitCode = new AtomicInteger(0);
+    private volatile CountDownLatch exitLatch;
+
+    @BeforeMethod
+    @Override
+    protected void setup() throws Exception {
+        super.internalSetup();
+        exitLatch = new CountDownLatch(1);
+        lastExitCode.set(0);
+        PerfClientUtils.setExitProcedure(code -> {
+            log.info().attr("code", code).log("Perf tool requested JVM exit");
+            lastExitCode.set(code);
+            exitLatch.countDown();
+        });
+        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+        TenantInfoImpl tenantInfo = new TenantInfoImpl(Sets.newHashSet("role1", "role2"), Sets.newHashSet("test"));
+        admin.tenants().createTenant(testTenant, tenantInfo);
+        admin.namespaces().createNamespace(myNamespace, Sets.newHashSet("test"));
+    }
+
+    @AfterMethod(alwaysRun = true)
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+        assertThat(lastExitCode.get()).as("perf tool JVM exit code").isZero();
+    }
+
+    @Test(timeOut = 60000)
+    public void testProduceV4() throws Exception {
+        String topic = testTopic + UUID.randomUUID();
+        @Cleanup
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topic).subscriptionName("sub")
+                .subscriptionType(SubscriptionType.Shared).subscribe();
+
+        Thread thread = runCommand(new PerformanceProducerV4(),
+                "%s -r 100 -u %s -m 10", topic, pulsar.getBrokerServiceUrl());
+
+        for (int i = 0; i < 10; i++) {
+            Message<byte[]> message = consumer.receive(30, TimeUnit.SECONDS);
+            assertThat(message).as("message %d produced by produce-v4", i).isNotNull();
+            consumer.acknowledge(message);
+        }
+        stop(thread);
+    }
+
+    @Test(timeOut = 120000)
+    public void testProduceV4CreatesPartitions() throws Exception {
+        String topic = testTopic + UUID.randomUUID();
+        Thread thread = runCommand(new PerformanceProducerV4(),
+                "%s -r 100 -u %s -au %s -m 10 -np 10",
+                topic, pulsar.getBrokerServiceUrl(), pulsar.getWebServiceAddress());
+        thread.join();
+
+        assertThat(admin.topics().getPartitionedTopicMetadata(topic).partitions).isEqualTo(10);
+    }
+
+    /**
+     * {@code --max-outstanding}, {@code --max-outstanding-across-partitions} and round-robin
+     * partition routing have no equivalent on the V5 producer builder, and being able to drive them
+     * is one of the reasons {@code produce-v4} exists. They are not observable from outside the
+     * client, so assert on the configuration the command builds.
+     */
+    @Test(timeOut = 60000)
+    public void testProduceV4WiresTheProducerKnobsThatV5CannotExpress() {
+        PerformanceProducerV4 command = new PerformanceProducerV4();
+        new CommandLine(command).parseArgs("-o", "500", "-p", "1000", "-db", "-z", "LZ4", "my-topic");
+
+        ProducerBuilderImpl<byte[]> builder =
+                (ProducerBuilderImpl<byte[]>) command.createProducerBuilder(pulsarClient, 0, "my-topic");
+        ProducerConfigurationData conf = builder.getConf();
+
+        assertThat(conf.getMaxPendingMessages()).isEqualTo(500);
+        assertThat(conf.getMaxPendingMessagesAcrossPartitions()).isEqualTo(1000);
+        assertThat(conf.getMessageRoutingMode()).isEqualTo(MessageRoutingMode.RoundRobinPartition);
+        assertThat(conf.isBatchingEnabled()).isFalse();
+        assertThat(conf.getCompressionType()).isEqualTo(CompressionType.LZ4);
+        assertThat(conf.isBlockIfQueueFull()).isTrue();
+    }
+
+    /**
+     * {@code --delay-range} accepts any range, so a drawn delay of {@code 0} is a delay the user
+     * asked for: the message must still be marked with a delivery time. Distinguishing that from
+     * "no delay flag given" is why the delay is carried as a nullable value rather than a number
+     * whose zero means "none".
+     */
+    @Test(timeOut = 60000)
+    public void testProduceV4MarksAMessageEvenWhenTheDrawnDelayIsZero() throws Exception {
+        String topic = testTopic + UUID.randomUUID();
+        @Cleanup
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topic).subscriptionName("sub")
+                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest).subscribe();
+        @Cleanup
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topic).enableBatching(false).create();
+
+        // "0,1" is the only draw ThreadLocalRandom can make, so this is deterministic.
+        PerformanceProducerV4 delayed = new PerformanceProducerV4();
+        new CommandLine(delayed).parseArgs("-dr", "0,1", topic);
+        assertThat(delayed.nextDeliverAfterSeconds()).isEqualTo(0L);
+        delayed.sendMessage(producer, "delayed".getBytes(), null, null, delayed.nextDeliverAfterSeconds()).get();
+
+        PerformanceProducerV4 plain = new PerformanceProducerV4();
+        new CommandLine(plain).parseArgs(topic);
+        plain.sendMessage(producer, "plain".getBytes(), null, null, plain.nextDeliverAfterSeconds()).get();
+
+        MessageImpl<byte[]> first = (MessageImpl<byte[]>) consumer.receive(30, TimeUnit.SECONDS);
+        MessageImpl<byte[]> second = (MessageImpl<byte[]>) consumer.receive(30, TimeUnit.SECONDS);
+
+        assertThat(first.getDeliverAtTime())
+                .as("a zero delay drawn from --delay-range must still mark the message")
+                .isPositive();
+        assertThat(second.getDeliverAtTime())
+                .as("a message sent without --delay/--delay-range must carry no delivery time")
+                .isZero();
+    }
+
+    /** Chunking and batching are mutually exclusive on the v4 producer; chunking wins. */
+    @Test(timeOut = 60000)
+    public void testProduceV4ChunkingDisablesBatching() {
+        PerformanceProducerV4 command = new PerformanceProducerV4();
+        new CommandLine(command).parseArgs("-ch", "my-topic");
+
+        ProducerBuilderImpl<byte[]> builder =
+                (ProducerBuilderImpl<byte[]>) command.createProducerBuilder(pulsarClient, 0, "my-topic");
+        ProducerConfigurationData conf = builder.getConf();
+
+        assertThat(conf.isChunkingEnabled()).isTrue();
+        assertThat(conf.isBatchingEnabled()).isFalse();
+    }
+
+    @Test(timeOut = 120000)
+    public void testConsumeV4() throws Exception {
+        String topic = testTopic + UUID.randomUUID();
+        String subscription = "sub-" + UUID.randomUUID();
+        // Create the subscription up front so the messages published below are within its backlog.
+        pulsarClient.newConsumer().topic(topic).subscriptionName(subscription)
+                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest).subscribe().close();
+        publish(topic, 50);
+
+        Thread thread = runCommand(new PerformanceConsumerV4(),
+                "%s -u %s -m 50 -ss %s -sp Earliest", topic, pulsar.getBrokerServiceUrl(), subscription);
+
+        assertThat(exitLatch.await(60, TimeUnit.SECONDS))
+                .as("consume-v4 must finish once it has consumed --num-messages")
+                .isTrue();
+        stop(thread);
+
+        // Every consumed message was acknowledged except the one that tripped --num-messages: the
+        // run ends there without acking it, exactly as `consume` does.
+        assertThat(admin.topics().getStats(topic).getSubscriptions().get(subscription).getMsgBacklog())
+                .as("consume-v4 must acknowledge what it consumed")
+                .isLessThanOrEqualTo(1);
+    }
+
+    @Test(timeOut = 120000)
+    public void testReadV4() throws Exception {
+        String topic = testTopic + UUID.randomUUID();
+        publish(topic, 20);
+
+        Thread thread = runCommand(new PerformanceReaderV4(),
+                "%s -u %s -n 20 -m earliest", topic, pulsar.getBrokerServiceUrl());
+
+        assertThat(exitLatch.await(60, TimeUnit.SECONDS))
+                .as("read-v4 must finish once it has read --num-messages")
+                .isTrue();
+        stop(thread);
+    }
+
+    /**
+     * The {@code lid:eid} start message id is a v4-reader capability that {@code read} rejects,
+     * because the V5 CheckpointConsumer it drives has no equivalent.
+     *
+     * <p>Starts from the id of the <em>last</em> published message, which the v4 reader treats as
+     * exclusive, so nothing is available until one more message is published. A reader that ignored
+     * the start id and read from the beginning would satisfy {@code -n 1} immediately, which is what
+     * makes this assert the position rather than merely that the argument was accepted.
+     */
+    @Test(timeOut = 120000)
+    public void testReadV4StartsFromASpecificMessageId() throws Exception {
+        String topic = testTopic + UUID.randomUUID();
+        MessageIdImpl lastId = (MessageIdImpl) publish(topic, 20).get(19);
+        String startMessageId = lastId.getLedgerId() + ":" + lastId.getEntryId();
+
+        Thread thread = runCommand(new PerformanceReaderV4(),
+                "%s -u %s -n 1 -m %s", topic, pulsar.getBrokerServiceUrl(), startMessageId);
+
+        assertThat(exitLatch.await(10, TimeUnit.SECONDS))
+                .as("read-v4 must start after the given message id, so the 20 earlier messages "
+                        + "must not satisfy --num-messages")
+                .isFalse();
+
+        publish(topic, 1);
+
+        assertThat(exitLatch.await(60, TimeUnit.SECONDS))
+                .as("read-v4 must read the message published after the given message id")
+                .isTrue();
+        stop(thread);
+    }
+
+    /** {@code read} drives the V5 CheckpointConsumer, which cannot express a {@code lid:eid} start. */
+    @Test(timeOut = 30000)
+    public void testReadRejectsASpecificMessageIdAndPointsAtReadV4() {
+        PerformanceReader reader = new PerformanceReader();
+        new CommandLine(reader).parseArgs("-m", "1:2", "persistent://a/b/c");
+
+        assertThatThrownBy(reader::validate)
+                .as("read must reject the v4 'lid:eid' start message id")
+                .hasMessageContaining("lid:eid");
+
+        // Same arguments, but the v4 reader accepts them.
+        PerformanceReaderV4 readerV4 = new PerformanceReaderV4();
+        new CommandLine(readerV4).parseArgs("-m", "1:2", "persistent://a/b/c");
+        assertThatCode(readerV4::validate).doesNotThrowAnyException();
+    }
+
+    private List<MessageId> publish(String topic, int numMessages) throws Exception {
+        @Cleanup
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topic).create();
+        List<MessageId> ids = new ArrayList<>(numMessages);
+        for (int i = 0; i < numMessages; i++) {
+            ids.add(producer.send(("message-" + i).getBytes()));
+        }
+        return ids;
+    }
+
+    private Thread runCommand(CmdBase command, String argFormat, Object... argValues) {
+        String[] args = String.format(argFormat, argValues).split(" ");
+        Thread thread = new Thread(() -> {
+            try {
+                command.run(args);
+            } catch (Exception e) {
+                log.error().exception(e).log("Perf command failed");
+            }
+        }, command.getClass().getSimpleName());
+        thread.start();
+        return thread;
+    }
+
+    private void stop(Thread thread) throws InterruptedException {
+        thread.interrupt();
+        thread.join(TimeUnit.SECONDS.toMillis(30));
+    }
+}

--- a/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PulsarPerfTestToolTest.java
+++ b/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PulsarPerfTestToolTest.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.testclient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import java.io.File;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import org.apache.pulsar.client.api.ProducerAccessMode;
+import org.apache.pulsar.client.api.SubscriptionType;
+import org.testng.annotations.Test;
+import picocli.CommandLine;
+
+/**
+ * Subcommand registration of {@code pulsar-perf}, including the v4 variants.
+ */
+public class PulsarPerfTestToolTest {
+
+    /**
+     * Every subcommand must carry its own {@code @Command(name = ..., description = ...)}. The name
+     * assertion catches a copy-pasted one (picocli keeps a declared name and would then print the
+     * wrong command in the usage message); the description assertion catches a missing annotation,
+     * whose only symptom is an empty description in the usage message and in {@code gen-doc}.
+     */
+    @Test
+    public void testAllSubcommandsAreRegisteredUnderTheirOwnName() throws Exception {
+        CommandLine commander = initCommander();
+
+        Map<String, CommandLine> subcommands = commander.getSubcommands();
+        assertThat(subcommands.keySet()).contains(
+                "produce", "consume", "read", "transaction",
+                "produce-v4", "consume-v4", "read-v4", "transaction-v4",
+                "monitor-brokers", "websocket-producer", "managed-ledger", "gen-doc");
+
+        subcommands.forEach((name, cmd) -> {
+            assertThat(cmd.getCommandSpec().name())
+                    .as("spec name of subcommand '%s'", name)
+                    .isEqualTo(name);
+            assertThat(cmd.getCommandSpec().usageMessage().description())
+                    .as("description of subcommand '%s'", name)
+                    .isNotEmpty();
+        });
+    }
+
+    /** Each v4 command must offer the same flags as its V5 counterpart, so runs stay comparable. */
+    @Test
+    public void testV4CommandsOfferTheSameFlagsAsTheirV5Counterparts() throws Exception {
+        CommandLine commander = initCommander();
+
+        assertThat(optionNames(commander, "produce-v4"))
+                .isEqualTo(optionNames(commander, "produce"));
+        assertThat(optionNames(commander, "read-v4"))
+                .isEqualTo(optionNames(commander, "read"));
+        // consume and transaction have V5-only flags that the v4 commands must not advertise.
+        assertThat(optionNames(commander, "consume"))
+                .containsAll(optionNames(commander, "consume-v4"))
+                .contains("--scalable-consumer-type");
+        assertThat(optionNames(commander, "consume-v4")).doesNotContain("--scalable-consumer-type");
+        assertThat(optionNames(commander, "transaction"))
+                .containsAll(optionNames(commander, "transaction-v4"))
+                .contains("--scalable");
+        assertThat(optionNames(commander, "transaction-v4")).doesNotContain("--scalable");
+    }
+
+    /** The v4 commands must resolve conf-file defaults and case-insensitive enums like the others. */
+    @Test
+    public void testV4CommandsGetConfFileDefaultsAndCaseInsensitiveEnums() throws Exception {
+        File confFile = writeConfFile("brokerServiceUrl=pulsar://from-conf:6650\n");
+        PulsarPerfTestTool tool = new PulsarPerfTestTool();
+        String[] rest = tool.initCommander(new String[]{confFile.getAbsolutePath(),
+                "produce-v4", "-am", "exclusive", "my-topic"});
+
+        CommandLine commander = tool.commander;
+        commander.parseArgs(rest);
+        PerformanceProducerV4 cmd = commander.getSubcommands().get("produce-v4").getCommand();
+
+        assertThat(cmd.serviceURL).isEqualTo("pulsar://from-conf:6650");
+        assertThat(cmd.producerAccessMode).isEqualTo(ProducerAccessMode.Exclusive);
+    }
+
+    /**
+     * The reports are emitted from the shared base classes, but must keep naming the concrete
+     * subcommand: {@code tests/integration/.../cli/PerfToolTest} matches stdout on
+     * {@code "PerformanceProducer - Aggregated throughput stats"} and friends, which is the
+     * {@code %logger{36}} rendering of the logger the report line came from.
+     */
+    @Test
+    public void testReportsAreLoggedUnderTheConcreteCommandClassName() {
+        assertThat(new PerformanceProducer().log.name()).isEqualTo(PerformanceProducer.class.getName());
+        assertThat(new PerformanceConsumer().log.name()).isEqualTo(PerformanceConsumer.class.getName());
+        assertThat(new PerformanceReader().log.name()).isEqualTo(PerformanceReader.class.getName());
+        assertThat(new PerformanceTransaction().log.name()).isEqualTo(PerformanceTransaction.class.getName());
+        assertThat(new PerformanceProducerV4().log.name()).isEqualTo(PerformanceProducerV4.class.getName());
+        assertThat(new PerformanceConsumerV4().log.name()).isEqualTo(PerformanceConsumerV4.class.getName());
+        assertThat(new PerformanceReaderV4().log.name()).isEqualTo(PerformanceReaderV4.class.getName());
+        assertThat(new PerformanceTransactionV4().log.name())
+                .isEqualTo(PerformanceTransactionV4.class.getName());
+    }
+
+    /**
+     * {@code consume-v4} and {@code transaction-v4} map the shared {@code -st} flag onto the v4
+     * client enum by name, so the two sets of constants must stay identical.
+     */
+    @Test
+    public void testSubscriptionTypeNamesMapOntoTheV4ClientEnum() {
+        assertThat(names(PerformanceConsumerBase.SubscriptionType.values()))
+                .isEqualTo(names(SubscriptionType.values()));
+        assertThat(names(PerformanceTransactionBase.SubscriptionType.values()))
+                .isEqualTo(names(SubscriptionType.values()));
+    }
+
+    private static Set<String> names(Enum<?>[] values) {
+        Set<String> names = new TreeSet<>();
+        for (Enum<?> value : values) {
+            names.add(value.name());
+        }
+        return names;
+    }
+
+    /**
+     * {@code --delay-range} accepts any range, so a drawn delay of {@code 0} is a delay the user
+     * asked for and must be distinguishable from "no delay flag given" — which rules out carrying
+     * the decision in a numeric sentinel.
+     */
+    @Test
+    public void testDeliveryDelayDistinguishesAZeroDelayFromNoDelay() {
+        PerformanceProducer noDelay = new PerformanceProducer();
+        assertThat(noDelay.nextDeliverAfterSeconds()).isNull();
+
+        PerformanceProducer zeroFromRange = new PerformanceProducer();
+        new CommandLine(zeroFromRange).parseArgs("-dr", "0,1", "my-topic");
+        assertThat(zeroFromRange.nextDeliverAfterSeconds()).isEqualTo(0L);
+
+        PerformanceProducerV4 negativeFromRange = new PerformanceProducerV4();
+        new CommandLine(negativeFromRange).parseArgs("-dr", "-5,-4", "my-topic");
+        assertThat(negativeFromRange.nextDeliverAfterSeconds()).isEqualTo(-5L);
+
+        PerformanceProducerV4 fixedDelay = new PerformanceProducerV4();
+        new CommandLine(fixedDelay).parseArgs("-d", "7", "my-topic");
+        assertThat(fixedDelay.nextDeliverAfterSeconds()).isEqualTo(7L);
+    }
+
+    private static CommandLine initCommander() throws Exception {
+        File confFile = writeConfFile("");
+        PulsarPerfTestTool tool = new PulsarPerfTestTool();
+        tool.initCommander(new String[]{confFile.getAbsolutePath(), "produce", "--help"});
+        return tool.commander;
+    }
+
+    private static File writeConfFile(String contents) throws Exception {
+        File confFile = Files.createTempFile("pulsar-perf-test", ".conf").toFile();
+        confFile.deleteOnExit();
+        Files.writeString(confFile.toPath(), contents);
+        return confFile;
+    }
+
+    private static Set<String> optionNames(CommandLine commander, String subcommand) {
+        Set<String> names = new TreeSet<>();
+        commander.getSubcommands().get(subcommand).getCommandSpec().options()
+                .forEach(option -> names.addAll(Arrays.asList(option.names())));
+        return names;
+    }
+}

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/PerfToolTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/PerfToolTest.java
@@ -70,9 +70,50 @@ public class PerfToolTest extends TopicMessagingBase {
                 "PerformanceReader - Aggregated latency stats");
     }
 
+    @Test
+    public void testProduceV4() throws Exception {
+        String serviceUrl = "pulsar://" + pulsarCluster.getProxy().getContainerName() + ":"
+                + PulsarContainer.BROKER_PORT;
+        final String topicName = getNonPartitionedTopic("testProduceV4", true);
+        ZKContainer clientToolContainer = pulsarCluster.getZooKeeper();
+        ContainerExecResult produceResult =
+                produceWithPerfTool(clientToolContainer, "produce-v4", serviceUrl, topicName, MESSAGE_COUNT);
+        checkOutputForLogs(produceResult, "PerformanceProducerV4 - Aggregated throughput stats",
+                "PerformanceProducerV4 - Aggregated latency stats");
+    }
+
+    @Test
+    public void testConsumeV4() throws Exception {
+        String serviceUrl = "pulsar://" + pulsarCluster.getProxy().getContainerName() + ":"
+                + PulsarContainer.BROKER_PORT;
+        final String topicName = getNonPartitionedTopic("testConsumeV4", true);
+        ZKContainer clientToolContainer = pulsarCluster.getZooKeeper();
+        ContainerExecResult consumeResult =
+                consumeWithPerfTool(clientToolContainer, "consume-v4", "produce-v4", serviceUrl, topicName);
+        checkOutputForLogs(consumeResult, "PerformanceConsumerV4 - Aggregated throughput stats",
+                "PerformanceConsumerV4 - Aggregated latency stats");
+    }
+
+    @Test
+    public void testReadV4() throws Exception {
+        String serviceUrl = "pulsar://" + pulsarCluster.getProxy().getContainerName() + ":"
+                + PulsarContainer.BROKER_PORT;
+        final String topicName = getNonPartitionedTopic("testReadV4", true);
+        ZKContainer clientToolContainer = pulsarCluster.getZooKeeper();
+        ContainerExecResult readResult =
+                readWithPerfTool(clientToolContainer, "read-v4", "produce-v4", serviceUrl, topicName);
+        checkOutputForLogs(readResult, "PerformanceReaderV4 - Aggregated throughput stats ",
+                "PerformanceReaderV4 - Aggregated latency stats");
+    }
+
     private ContainerExecResult produceWithPerfTool(ChaosContainer<?> container, String url, String topic,
                                                     int messageCount) throws Exception {
-        ContainerExecResult result = container.execCmd("bin/pulsar-perf", "produce", "-u", url, "-m",
+        return produceWithPerfTool(container, "produce", url, topic, messageCount);
+    }
+
+    private ContainerExecResult produceWithPerfTool(ChaosContainer<?> container, String command, String url,
+                                                    String topic, int messageCount) throws Exception {
+        ContainerExecResult result = container.execCmd("bin/pulsar-perf", command, "-u", url, "-m",
                 String.valueOf(messageCount), topic);
 
         return failOnError("Performance producer", result);
@@ -80,9 +121,15 @@ public class PerfToolTest extends TopicMessagingBase {
 
     private ContainerExecResult consumeWithPerfTool(ChaosContainer<?> container, String url, String topic)
             throws Exception {
-        CompletableFuture<ContainerExecResult> resultFuture = container.execCmdAsync("bin/pulsar-perf", "consume", "-u",
-                url, "-m", String.valueOf(MESSAGE_COUNT), topic);
-        produceWithPerfTool(container, url, topic, MESSAGE_COUNT);
+        return consumeWithPerfTool(container, "consume", "produce", url, topic);
+    }
+
+    private ContainerExecResult consumeWithPerfTool(ChaosContainer<?> container, String consumeCommand,
+                                                    String produceCommand, String url, String topic)
+            throws Exception {
+        CompletableFuture<ContainerExecResult> resultFuture = container.execCmdAsync("bin/pulsar-perf",
+                consumeCommand, "-u", url, "-m", String.valueOf(MESSAGE_COUNT), topic);
+        produceWithPerfTool(container, produceCommand, url, topic, MESSAGE_COUNT);
 
         ContainerExecResult result = resultFuture.get(5, TimeUnit.SECONDS);
         return failOnError("Performance consumer", result);
@@ -90,9 +137,15 @@ public class PerfToolTest extends TopicMessagingBase {
 
     private ContainerExecResult readWithPerfTool(ChaosContainer<?> container, String url, String topic)
             throws Exception {
-        CompletableFuture<ContainerExecResult> resultFuture = container.execCmdAsync("bin/pulsar-perf", "read", "-u",
-                url, "-n", String.valueOf(MESSAGE_COUNT), topic);
-        produceWithPerfTool(container, url, topic, MESSAGE_COUNT);
+        return readWithPerfTool(container, "read", "produce", url, topic);
+    }
+
+    private ContainerExecResult readWithPerfTool(ChaosContainer<?> container, String readCommand,
+                                                 String produceCommand, String url, String topic)
+            throws Exception {
+        CompletableFuture<ContainerExecResult> resultFuture = container.execCmdAsync("bin/pulsar-perf",
+                readCommand, "-u", url, "-n", String.valueOf(MESSAGE_COUNT), topic);
+        produceWithPerfTool(container, produceCommand, url, topic, MESSAGE_COUNT);
 
         ContainerExecResult result = resultFuture.get(5, TimeUnit.SECONDS);
         return failOnError("Performance consumer", result);


### PR DESCRIPTION
### Motivation

`pulsar-perf` was migrated to the V5 client API in #25887 and `pulsar-client` in #25917, so every
subcommand of both tools now drives the V5 SDK. Pulsar 5.0 does not deprecate ordinary
(non-scalable) topics, and the v4 client remains fully supported, so it is still useful to be able
to drive the CLI tools with the v4 client:

- **Comparable benchmark results across broker versions.** A large part of the value of
  `pulsar-perf` is comparing numbers between Pulsar releases. Those comparisons only hold if the
  client under test is the same one, so the v4 commands can also be pointed at **pre-5.0 brokers**,
  which the V5 SDK cannot talk to at all.
- **Testing the v4 client and ordinary topics** without the V5 SDK in the path, so a V5-side change
  cannot influence the result.

Beyond that, the migration left a set of options that are still accepted but no longer do what they
say, with no way to get the behaviour back:

`pulsar-perf`

- `produce`: `--max-outstanding` / `--max-outstanding-across-partitions` have no effect, and
  round-robin partition routing is gone.
- `consume`: `Exclusive` / `Failover` / `Key_Shared` all degrade to work-queue semantics;
  `--auto-scaled-receiver-queue-size`, `--batch-index-ack`, `--pool-messages`,
  `--receiver-queue-size-across-partitions` and the chunked-message knobs are inert. Dispatch moved
  from the client's listener threads to per-consumer poll threads.
- `read`: measures a V5 `CheckpointConsumer`, a different broker-side entity, so nothing exercises
  the v4 `Reader`. The `<ledgerId>:<entryId>` start position is rejected, and `--use-tls` and
  `--receiver-queue-size` are inert.
- `transaction`: the v4 transaction coordinator stays a live broker code path next to the v5 one
  (PIP-473 P5.4) with nothing driving it. Acknowledgement latency is no longer measurable, because
  V5's `acknowledge` is a synchronous void, so the reported figure times a local call rather than the
  broker round trip.

`pulsar-client`

- `produce`: `--key-value-encoding-type` is rejected outright and `-kvk` / `-kvkf` / `-ks` became
  dead flags; `--disable-replication` only warns.
- `consume`: `--subscription-mode NonDurable` silently creates a durable subscription; `--regex` is
  not a regex any more but a namespace subscription over the pattern's `tenant/namespace`;
  `--start-timestamp` was dropped; `-mc` / `-ac` / `-pm` only warn.
- `read`: the `<ledgerId>:<entryId>` start position is rejected (and its WebSocket base64 encoding is
  gone); `-i` and `-q` only warn.
- Root: `loadConf` is gone, so every `client.conf` key without a dedicated CLI flag is silently
  ignored, and `http://` / `https://` service URLs no longer work.

Two `PulsarClientToolTest` cases were disabled by #25917 with a "deferred to a follow-up" note. This
is that follow-up.

### Modifications

Rather than reverting or duplicating the commands, each one is split into an abstract base holding
everything that is not client-specific, plus two thin subclasses that bind the client types — the
existing V5 command and a new v4 one. The V5 and v4 classes are siblings, not parent and child.

```
PerformanceProducerBase    -> PerformanceProducer    / PerformanceProducerV4    (produce-v4)
PerformanceConsumerBase    -> PerformanceConsumer    / PerformanceConsumerV4    (consume-v4)
PerformanceReaderBase      -> PerformanceReader      / PerformanceReaderV4      (read-v4)
PerformanceTransactionBase -> PerformanceTransaction / PerformanceTransactionV4 (transaction-v4)

AbstractCmdProduce         -> CmdProduce             / CmdProduceV4             (produce-v4)
AbstractCmdConsumeCommand  -> CmdConsume             / CmdConsumeV4             (consume-v4)
AbstractCmdReadCommand     -> CmdRead                / CmdReadV4                (read-v4)
```

The bases hold the CLI options, the argument validation, the accounting and reports (perf) and the
WebSocket paths (client), so the improvements made since the migration are shared rather than
duplicated — instance recorders, the 3-significant-digit histograms and the latency clamps from
#26466, and the class-based subcommand registration from #26467. Each perf base logs through a
logger named after the *concrete* subclass, so the report lines keep naming the subcommand that
produced them.

Where the two clients genuinely differ, the seam is explicit rather than papered over:

- the v4 consumer and reader keep `MessageListener` / `ReaderListener` dispatch, while V5 keeps its
  poll threads;
- the v4 producer does not await a transaction's sends before committing (V5 must, because its
  transactional sends are queued onto an internal dispatch chain);
- only the *first* transaction of a V5 perf thread waits out the coordinator's asynchronous connect,
  so the rollover loop still counts every failed open;
- `pulsar-client`'s message rendering is not forced into one shape: the v4 output keeps the
  encryption context, the formatted broker publish and event times, the ordering key, the schema
  version and the index, none of which the V5 `Message` exposes.

`PulsarClientTool` builds a second, v4 `ClientBuilder` for the `*-v4` commands. It keeps `loadConf`,
so every `client.conf` key still applies without a hand-written translation, and it accepts
`http://` service URLs. It is supplied lazily, because `updateConfig()` is the `preRun()` hook and
runs for every invocation — building it eagerly would make `--help`, `generate_documentation` and
the V5 commands depend on a service URL and on `client.conf` keys only the v4 client parses.

`pulsar-shell` picks the new `pulsar-client` commands up for free, and both tools'
`gen-doc` / `generate_documentation` render them.

Also wires `--jsse-provider` / `--jca-provider` into the v4 client builder in `PerfClientUtils`,
which previously read them only for the admin and V5 legs.

The V5 commands are unchanged in behaviour except for the following, all of which are deliberate and
were verified line by line against the pre-split code:

- `ProducerSocket.send()` now installs the completion future *before* `sendText(...)`. The old order
  raced: an ack delivered on the Jetty read thread in between completed the previous future and left
  the new one uncompleted, so the caller blocked the full 30s and the produce loop aborted with -1.
  Latent since #3835.
- `ProducerSocket.close()` gained a `session != null` guard. `onClose` nulls the session, so a
  remote-initiated close before `close()` used to NPE and turn a successful publish into exit -1.
- The transaction receive-failure path catches `Exception` rather than `PulsarClientException` and
  returns after `exit(1)`. The widening is forced — the v4 and V5 overrides throw two different
  `PulsarClientException` classes — and the `return` stops a fall-through into `message.id()` on a
  null message under a test exit procedure.
- New user-visible output on nine sites: `--queue-size` is now reported as inert on `read` instead of
  silently ignored; the existing "no effect" warnings on `produce` / `consume` / `read` (both tools)
  and on `transaction` gained a "use the `-v4` command" pointer; and `pulsar-perf consume` logs one
  new unconditional INFO line naming the V5 consumer API.

### Verifying this change

This change added tests and can be verified as follows:

`pulsar-testclient`

- `PulsarPerfTestToolTest` — subcommand registration and per-command naming, conf-file defaults and
  case-insensitive enums on the v4 commands, the shared `-st` enum mapping onto the v4 client enum,
  the logger naming the report lines depend on, and that a `--delay-range` draw of `0` is
  distinguishable from "no delay flag".
- `PerformanceV4CommandsTest` — end-to-end produce / consume / read round trips through the v4
  commands against a mocked broker, partitioned-topic creation, the v4-only producer knobs asserted
  on the built configuration, the `<ledgerId>:<entryId>` start position (asserted *positionally*, so
  a reader that ignored it fails), and that `read` rejects that form while `read-v4` accepts it.
- `PerfToolTest` (integration, `CLI` group) gains `produce-v4` / `consume-v4` / `read-v4` cases that
  run the commands from `bin/pulsar-perf` in a container.

`pulsar-client-tools`

- `CmdV4CommandsTest` — subcommand registration and naming, case-insensitive enums on the v4
  subcommands, KeyValue schema building, the `lid:eid` start position including its WebSocket
  encoding, the `--start-timestamp` validation, and that commands needing no v4 client (`--help`,
  `generate_documentation`) still run without a service URL and with `client.conf` keys only the v4
  loader parses.
- `PulsarClientToolTest` — the three KeyValue cases disabled by #25917 are re-enabled against
  `produce-v4`, and a new `testNonDurableSubscribeWithV4Client` asserts that `consume-v4` really
  creates a non-durable subscription, i.e. it disappears when the consumer disconnects.

The full pipeline is green in Personal CI for both halves (43/43 checks each).

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [x] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

New subcommands only; no existing command's options or behaviour change.
`pulsar-perf` gains `produce-v4`, `consume-v4`, `read-v4`, `transaction-v4`, and `pulsar-client`
gains `produce-v4`, `consume-v4`, `read-v4`.

### Documentation

- [ ] `doc` <!-- Your PR contains doc changes -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

The generated CLI reference on the website is produced from the commands themselves
(`pulsar-perf gen-doc` / `pulsar-client generate_documentation`), so the new subcommands are picked
up automatically.

