### PR TITLE
[improve][cli] Default the pulsar-perf client memory limit to half of the JVM max direct memory

### DIFF
--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceBaseArguments.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceBaseArguments.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.testclient;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import org.apache.pulsar.cli.converters.picocli.ByteUnitToLongConverter;
 import org.apache.pulsar.client.api.ProxyProtocol;
+import org.apache.pulsar.common.util.DirectMemoryUtils;
 import picocli.CommandLine.Option;
 
 /**
@@ -110,9 +111,21 @@ public abstract class PerformanceBaseArguments extends CmdBase{
     @Option(names = { "--auth_plugin" }, description = "Authentication plugin class name", hidden = true)
     public String deprecatedAuthPluginClassName;
 
+    /**
+     * Default Pulsar client memory limit for the performance tools: half of the JVM's max direct memory.
+     *
+     * <p>The performance tools do not use direct memory for anything other than Netty, so bounding the client
+     * at a fraction of what the JVM can actually allocate keeps the tool from dying with
+     * {@code OutOfDirectMemoryError} while still letting it use the memory it was given. Being proportional
+     * rather than a fixed value also avoids silently changing results for runs that were sized with a larger
+     * {@code -XX:MaxDirectMemorySize}.
+     */
+    public static final long DEFAULT_MEMORY_LIMIT_BYTES = (long) (0.5d * DirectMemoryUtils.jvmMaxDirectMemory());
+
     @Option(names = { "-ml", "--memory-limit", }, description = "Configure the Pulsar client memory limit "
-            + "(eg: 32M, 64M)", converter = ByteUnitToLongConverter.class)
-    public long memoryLimit;
+            + "(eg: 32M, 64M). Defaults to half of the JVM's max direct memory. Use 0 to disable the limit.",
+            converter = ByteUnitToLongConverter.class)
+    public long memoryLimit = DEFAULT_MEMORY_LIMIT_BYTES;
     public PerformanceBaseArguments(String cmdName) {
         super(cmdName);
     }

--- a/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerformanceBaseArgumentsTest.java
+++ b/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerformanceBaseArgumentsTest.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.pulsar.common.util.DirectMemoryUtils;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -245,6 +246,39 @@ public class PerformanceBaseArgumentsTest {
             }
             baseArgument.getCommander().setDefaultValueProvider(PulsarPerfTestPropertiesProvider.create(prop));
             baseArgument.parse(new String[]{});
+
+            // Act
+            baseArgument.parseCLI();
+
+            // Assert
+            assertEquals(baseArgument.memoryLimit, PerformanceBaseArguments.DEFAULT_MEMORY_LIMIT_BYTES);
+            assertEquals(baseArgument.memoryLimit, (long) (0.5d * DirectMemoryUtils.jvmMaxDirectMemory()));
+        }
+    }
+
+    @Test
+    public void testMemoryLimitCanBeDisabled() throws Exception {
+        for (String cmd : List.of(
+                "pulsar-perf read",
+                "pulsar-perf produce",
+                "pulsar-perf consume",
+                "pulsar-perf transaction"
+        )) {
+            // Arrange
+            final PerformanceBaseArguments baseArgument = new PerformanceBaseArguments("") {
+                @Override
+                public void run() throws Exception {
+
+                }
+
+            };
+            String confFile = "./src/test/resources/perf_client1.conf";
+            Properties prop = new Properties(System.getProperties());
+            try (FileInputStream fis = new FileInputStream(confFile)) {
+                prop.load(fis);
+            }
+            baseArgument.getCommander().setDefaultValueProvider(PulsarPerfTestPropertiesProvider.create(prop));
+            baseArgument.parse(new String[]{"-ml", "0"});
 
             // Act
             baseArgument.parseCLI();


### PR DESCRIPTION
Main Issue: #26340

Follow-up to #26341, which is closed. That PR proposed a fixed 64M default; this one takes the approach recommended in review instead: https://github.com/apache/pulsar/pull/26341#discussion_r3799392777

### Motivation

`pulsar-perf` passes its `--memory-limit` option to the client unconditionally, but the backing field has no initializer:

```java
@Option(names = { "-ml", "--memory-limit", }, ...)
public long memoryLimit;
```

and `0` is not "no override", it is "no limit":

```java
public boolean isMemoryLimited() {
    return memoryLimit > 0;
}
```

So since #20663 the performance tools run with client memory limiting disabled unless the user passes `-ml` explicitly. With no limit there is no client-side bound on outbound buffers, and a producer that outruns the brokers can exhaust direct memory and die with `OutOfDirectMemoryError` (#26340) instead of throttling and reporting the achievable rate.

#26342 fixes the root cause of #26340 by making `NO_MEMORY_LIMIT_DEFAULT_MAX_PENDING_MESSAGES` / `NO_MEMORY_LIMIT_DEFAULT_MAX_PENDING_MESSAGES_ACROSS_PARTITIONS` apply to non-partitioned topics as well. This PR is the follow-up @lhotari suggested in the review of #26341: give the tool a memory limit default that caps memory without silently changing benchmark results.

A fixed 64M default (the approach in the now-closed #26341) was rejected for good reason: since there has effectively been no limit, imposing 64M changes behaviour significantly for workloads with many partitions and larger messages (for example 100 partitions, 32kB messages, high rate), because far fewer messages stay in flight. Making the default proportional to the direct memory the JVM was actually given avoids that: results stay comparable across versions, the tool uses the memory it was handed, and it is still bounded.

### Modifications

- Add `PerformanceBaseArguments.DEFAULT_MEMORY_LIMIT_BYTES`, computed as `(long) (0.5d * DirectMemoryUtils.jvmMaxDirectMemory())`, and use it as the initial value of `memoryLimit`. `pulsar-perf` uses direct memory only for Netty, so half of the available direct memory leaves ample headroom. This follows the existing convention in `ManagedLedgerClientFactory`, which derives `managedLedgerMaxReadsInFlightSizeInMB` from a fraction of `DirectMemoryUtils.jvmMaxDirectMemory()`.
- Update the `--memory-limit` option description to state the default and to document that `0` disables the limit.

This applies to `PerformanceProducer`, `PerformanceConsumer`, `PerformanceReader`, `PerformanceTransaction` and `LoadSimulationClient`, which share `PerformanceBaseArguments`, and it reaches both the existing `ClientBuilder` call site and the v5 `PulsarClientBuilder` one in `PerfClientUtils`.

`--memory-limit 0` still disables the limit explicitly, so the capability added by #20663 is retained. Only the unset behaviour changes.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is covered by existing tests. `PerformanceBaseArgumentsTest#testMemoryLimitCliArgument` continues to verify that explicit values (`-ml 1`, `-ml 1K`, `--memory-limit 1G`) are parsed correctly.

`PerformanceBaseArgumentsTest#testMemoryLimitCliArgumentDefault` asserted the previous `0` default and now asserts the direct-memory-proportional default.

Added `PerformanceBaseArgumentsTest#testMemoryLimitCanBeDisabled` to pin the escape hatch, so a future change cannot quietly remove the ability to run unbounded via `-ml 0`.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [x] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

The default of the `pulsar-perf` `--memory-limit` option changes from `0` (unlimited) to half of the JVM's max direct memory. Runs that need unbounded client memory can pass `--memory-limit 0`.
