### PR TITLE
[fix][ml] Parse the cached entry's message metadata from the buffer the cache keeps

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerConfig.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerConfig.java
@@ -88,6 +88,24 @@ public class ManagedLedgerConfig {
     @Getter
     @Setter
     private boolean cacheEvictionByExpectedReadCount = true;
+    /**
+     * Whether the entries of this managed ledger are Pulsar messages, so that an entry's payload begins with the
+     * headers that parse into a {@code MessageMetadata}.
+     *
+     * <p>This holds for the managed ledger backing a topic. It doesn't hold for managed ledgers that store some
+     * other binary format, such as the transaction log and the transaction pending ack store, whose entries can
+     * never parse into valid message metadata.
+     *
+     * <p>When this is false the entry cache doesn't parse the message metadata of the entries it caches or reads.
+     * Nothing else changes: code that needs the metadata of an individual entry can still parse it on demand.
+     *
+     * <p>Set this before the managed ledger is opened for the first time, and keep it when replacing the config
+     * of an open managed ledger: {@link ManagedLedgerFactory} caches managed ledgers by name and hands back an
+     * already open one without applying the config of the later caller.
+     */
+    @Getter
+    @Setter
+    private boolean pulsarMessageEntries = true;
     @Getter
     private long continueCachingAddedEntriesAfterLastActiveCursorLeavesMillis;
     private int minimumBacklogCursorsForCaching = 0;

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/EntryCacheDisabled.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/EntryCacheDisabled.java
@@ -148,7 +148,9 @@ public class EntryCacheDisabled implements EntryCache {
                         for (LedgerEntry e : ledgerEntries) {
                             // Insert the entries at the end of the list (they will be unsorted for now)
                             EntryImpl entry = EntryImpl.create(e, interceptor, 0);
-                            entry.initializeMessageMetadataIfNeeded(ml.getName());
+                            if (ml.getConfig().isPulsarMessageEntries()) {
+                                entry.initializeMessageMetadataIfNeeded(ml.getName());
+                            }
                             entries.add(entry);
                             totalSize += entry.getLength();
                         }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeCache.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeCache.java
@@ -18,7 +18,6 @@
  */
 package org.apache.bookkeeper.mledger.impl.cache;
 
-import com.google.common.annotations.VisibleForTesting;
 import io.netty.util.IllegalReferenceCountException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -48,22 +47,12 @@ class RangeCache {
     private final ConcurrentNavigableMap<Position, RangeCacheEntryWrapper> entries;
     private final RangeCacheRemovalQueue removalQueue;
     private final AtomicLong size; // Total size of values stored in cache
-    private final String managedLedgerName;
 
     /**
      * Construct a new RangeCache.
      */
     public RangeCache(RangeCacheRemovalQueue removalQueue) {
-        this(removalQueue, null);
-    }
-
-    /**
-     * Construct a new RangeCache.
-     * @param managedLedgerName the name of the managed ledger this cache belongs to
-     */
-    public RangeCache(RangeCacheRemovalQueue removalQueue, String managedLedgerName) {
         this.removalQueue = removalQueue;
-        this.managedLedgerName = managedLedgerName;
         this.entries = new ConcurrentSkipListMap<>();
         this.size = new AtomicLong(0);
     }
@@ -122,22 +111,11 @@ class RangeCache {
         return getValueFromWrapper(key, entries.get(key));
     }
 
-    /**
-     * Returns whether the entry stored under the key already carried parsed message metadata when it was put in
-     * the cache, so that reads don't have to initialize it lazily. Unlike {@link #get(Position)} this doesn't
-     * trigger that lazy initialization, which is what makes it usable to tell the two apart.
-     */
-    @VisibleForTesting
-    boolean isMessageMetadataInitialized(Position key) {
-        RangeCacheEntryWrapper wrapper = entries.get(key);
-        return wrapper != null && wrapper.messageMetadataInitialized;
-    }
-
     private ReferenceCountedEntry getValueFromWrapper(Position key, RangeCacheEntryWrapper valueWrapper) {
         if (valueWrapper == null) {
             return null;
         } else {
-            ReferenceCountedEntry value = valueWrapper.getValue(key, managedLedgerName);
+            ReferenceCountedEntry value = valueWrapper.getValue(key);
             return getRetainedValueMatchingKey(key, value);
         }
     }
@@ -147,7 +125,7 @@ class RangeCache {
      */
     private ReferenceCountedEntry getValueMatchingEntry(Map.Entry<Position, RangeCacheEntryWrapper> entry) {
         ReferenceCountedEntry valueMatchingEntry =
-                RangeCacheEntryWrapper.getValueMatchingMapEntry(entry, managedLedgerName);
+                RangeCacheEntryWrapper.getValueMatchingMapEntry(entry);
         return getRetainedValueMatchingKey(entry.getKey(), valueMatchingEntry);
     }
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeCache.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeCache.java
@@ -18,6 +18,7 @@
  */
 package org.apache.bookkeeper.mledger.impl.cache;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.netty.util.IllegalReferenceCountException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -119,6 +120,17 @@ class RangeCache {
      */
     public ReferenceCountedEntry get(Position key) {
         return getValueFromWrapper(key, entries.get(key));
+    }
+
+    /**
+     * Returns whether the entry stored under the key already carried parsed message metadata when it was put in
+     * the cache, so that reads don't have to initialize it lazily. Unlike {@link #get(Position)} this doesn't
+     * trigger that lazy initialization, which is what makes it usable to tell the two apart.
+     */
+    @VisibleForTesting
+    boolean isMessageMetadataInitialized(Position key) {
+        RangeCacheEntryWrapper wrapper = entries.get(key);
+        return wrapper != null && wrapper.messageMetadataInitialized;
     }
 
     private ReferenceCountedEntry getValueFromWrapper(Position key, RangeCacheEntryWrapper valueWrapper) {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeCacheEntryWrapper.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeCacheEntryWrapper.java
@@ -25,7 +25,6 @@ import java.util.function.Function;
 import lombok.CustomLog;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.ReferenceCountedEntry;
-import org.apache.bookkeeper.mledger.impl.EntryImpl;
 
 /**
  * Wrapper around the value to store in Map. This is needed to ensure that a specific instance can be removed from
@@ -48,7 +47,6 @@ class RangeCacheEntryWrapper {
     long size;
     long timestampNanos;
     int requeueCount;
-    boolean messageMetadataInitialized;
     volatile boolean accessed;
 
     private RangeCacheEntryWrapper(Recycler.Handle<RangeCacheEntryWrapper> recyclerHandle) {
@@ -65,9 +63,6 @@ class RangeCacheEntryWrapper {
             entryWrapper.key = key;
             entryWrapper.value = value;
             entryWrapper.size = size;
-            // When the value already carries parsed message metadata, there's no need to lazily initialize it
-            // under the write lock on the first read
-            entryWrapper.messageMetadataInitialized = value.getMessageMetadata() != null;
             // Set the timestamp to the current time in nanoseconds
             // This is used for time-based eviction of entries
             entryWrapper.timestampNanos = System.nanoTime();
@@ -80,13 +75,12 @@ class RangeCacheEntryWrapper {
     /**
      * Get the value associated with the key. Returns null if the key does not match the key.
      *
-     * @param key               the key to match
-     * @param managedLedgerName
+     * @param key the key to match
      * @return the value associated with the key, or null if the value has already been recycled or the key does not
      * match
      */
-    ReferenceCountedEntry getValue(Position key, String managedLedgerName) {
-        return getValueInternal(key, false, managedLedgerName);
+    ReferenceCountedEntry getValue(Position key) {
+        return getValueInternal(key, false);
     }
 
     /**
@@ -96,9 +90,8 @@ class RangeCacheEntryWrapper {
      * @return the value associated with the key, or null if the value has already been recycled or the key does not
      * exactly match the same instance
      */
-    static ReferenceCountedEntry getValueMatchingMapEntry(Map.Entry<Position, RangeCacheEntryWrapper> entry,
-                                                          String managedLedgerName) {
-        return entry.getValue().getValueInternal(entry.getKey(), true, managedLedgerName);
+    static ReferenceCountedEntry getValueMatchingMapEntry(Map.Entry<Position, RangeCacheEntryWrapper> entry) {
+        return entry.getValue().getValueInternal(entry.getKey(), true);
     }
 
     /**
@@ -110,20 +103,16 @@ class RangeCacheEntryWrapper {
      *                               key as the one stored in the wrapper. This is used to avoid any races
      *                               when retrieving or removing the entries from the cache when the key and value
      *                               instances are available.
-     * @param managedLedgerName
      * @return the value associated with the key, or null if the key does not match
      */
-    private ReferenceCountedEntry getValueInternal(Position key, boolean requireSameKeyInstance,
-                                                   String managedLedgerName) {
+    private ReferenceCountedEntry getValueInternal(Position key, boolean requireSameKeyInstance) {
         long stamp = lock.tryOptimisticRead();
         Position localKey = this.key;
         ReferenceCountedEntry localValue = this.value;
-        boolean messageMetadataInitialized = this.messageMetadataInitialized;
         if (!lock.validate(stamp)) {
             stamp = lock.readLock();
             localKey = this.key;
             localValue = this.value;
-            messageMetadataInitialized = this.messageMetadataInitialized;
             lock.unlockRead(stamp);
         }
         // check that the given key matches the key associated with the value in the entry
@@ -132,20 +121,6 @@ class RangeCacheEntryWrapper {
         // entry to match
         if (localKey != key && (requireSameKeyInstance || localKey == null || !localKey.equals(key))) {
             return null;
-        }
-        // Initialize the metadata if it's not already initialized
-        if (localValue != null && !messageMetadataInitialized) {
-            localValue = withWriteLock(wrapper -> {
-                // ensure that the key still matches
-                if (wrapper.key != key && (requireSameKeyInstance || wrapper.key == null || !wrapper.key.equals(key))) {
-                    return null;
-                }
-                if (wrapper.value instanceof EntryImpl entry && !this.messageMetadataInitialized) {
-                    entry.initializeMessageMetadataIfNeeded(managedLedgerName);
-                    this.messageMetadataInitialized = true;
-                }
-                return wrapper.value;
-            });
         }
         accessed = true;
         return localValue;
@@ -194,7 +169,6 @@ class RangeCacheEntryWrapper {
         size = 0;
         timestampNanos = 0;
         requeueCount = 0;
-        messageMetadataInitialized = false;
         accessed = false;
         recyclerHandle.recycle(this);
     }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImpl.java
@@ -123,6 +123,11 @@ public class RangeEntryCacheImpl implements EntryCache {
         return ml.getConfig();
     }
 
+    @VisibleForTesting
+    RangeCache getEntries() {
+        return entries;
+    }
+
     @Override
     public String getName() {
         return ml.getName();
@@ -151,16 +156,19 @@ public class RangeEntryCacheImpl implements EntryCache {
             cachedData = entry.getDataBuffer().retain();
         }
 
-        // Parse the message metadata once at insert time so that cache reads don't have to do it lazily while
-        // holding the RangeCacheEntryWrapper write lock
-        if (entry instanceof EntryImpl entryImpl) {
-            entryImpl.initializeMessageMetadataIfNeeded(ml.getName());
-        }
-
         Position position = entry.getPosition();
+        // A MessageMetadata instance keeps a reference to the buffer it was parsed from and decodes its string and
+        // bytes fields from it lazily, so it may only be shared with the cached entry when that entry keeps the
+        // same buffer alive. When the payload is copied into a cache owned buffer, the source buffer is released
+        // while the cached entry is still in the cache, so the metadata has to be parsed from the copy instead.
         ReferenceCountedEntry cacheEntry =
                 EntryImpl.createWithRetainedDuplicate(position, cachedData, entry.getReadCountHandler(),
-                            entry.getMessageMetadata());
+                            copyEntries ? null : entry.getMessageMetadata());
+        // Parse the message metadata once at insert time so that cache reads don't have to do it lazily while
+        // holding the RangeCacheEntryWrapper write lock
+        if (cacheEntry instanceof EntryImpl cacheEntryImpl) {
+            cacheEntryImpl.initializeMessageMetadataIfNeeded(ml.getName());
+        }
         cachedData.release();
         if (entries.put(position, cacheEntry, entryLength)) {
             totalAddedEntriesSize.add(entryLength);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImpl.java
@@ -161,14 +161,12 @@ public class RangeEntryCacheImpl implements EntryCache {
         // bytes fields from it lazily, so it may only be shared with the cached entry when that entry keeps the
         // same buffer alive. When the payload is copied into a cache owned buffer, the source buffer is released
         // while the cached entry is still in the cache, so the metadata has to be parsed from the copy instead.
-        ReferenceCountedEntry cacheEntry =
+        EntryImpl cacheEntry =
                 EntryImpl.createWithRetainedDuplicate(position, cachedData, entry.getReadCountHandler(),
                             copyEntries ? null : entry.getMessageMetadata());
         // Parse the message metadata once at insert time so that cache reads don't have to do it lazily while
         // holding the RangeCacheEntryWrapper write lock
-        if (cacheEntry instanceof EntryImpl cacheEntryImpl) {
-            cacheEntryImpl.initializeMessageMetadataIfNeeded(ml.getName());
-        }
+        cacheEntry.initializeMessageMetadataIfNeeded(ml.getName());
         cachedData.release();
         if (entries.put(position, cacheEntry, entryLength)) {
             totalAddedEntriesSize.add(entryLength);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImpl.java
@@ -164,9 +164,10 @@ public class RangeEntryCacheImpl implements EntryCache {
         EntryImpl cacheEntry =
                 EntryImpl.createWithRetainedDuplicate(position, cachedData, entry.getReadCountHandler(),
                             copyEntries ? null : entry.getMessageMetadata());
-        // Parse the message metadata once at insert time so that cache reads don't have to do it lazily while
-        // holding the RangeCacheEntryWrapper write lock
-        cacheEntry.initializeMessageMetadataIfNeeded(ml.getName());
+        if (ml.getConfig().isPulsarMessageEntries()) {
+            // Parse the message metadata once at insert time so that cache reads don't have to do it lazily
+            cacheEntry.initializeMessageMetadataIfNeeded(ml.getName());
+        }
         cachedData.release();
         if (entries.put(position, cacheEntry, entryLength)) {
             totalAddedEntriesSize.add(entryLength);
@@ -560,7 +561,9 @@ public class RangeEntryCacheImpl implements EntryCache {
                                 final List<Entry> entriesToReturn = new ArrayList<>(entriesToRead);
                                 for (LedgerEntry e : ledgerEntries) {
                                     EntryImpl entry = EntryImpl.create(e, interceptor, expectedReadCountVal);
-                                    entry.initializeMessageMetadataIfNeeded(ml.getName());
+                                    if (ml.getConfig().isPulsarMessageEntries()) {
+                                        entry.initializeMessageMetadataIfNeeded(ml.getName());
+                                    }
                                     entriesToReturn.add(entry);
                                     totalSize += entry.getLength();
                                     if (expectedReadCountVal > 0) {

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/cache/EntryCacheDisabledTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/cache/EntryCacheDisabledTest.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.mledger.impl.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import com.google.common.util.concurrent.MoreExecutors;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.apache.bookkeeper.client.api.LedgerEntries;
+import org.apache.bookkeeper.client.api.LedgerEntry;
+import org.apache.bookkeeper.client.api.ReadHandle;
+import org.apache.bookkeeper.client.impl.LedgerEntryImpl;
+import org.apache.bookkeeper.mledger.AsyncCallbacks;
+import org.apache.bookkeeper.mledger.Entry;
+import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
+import org.apache.bookkeeper.mledger.ManagedLedgerException;
+import org.apache.bookkeeper.mledger.PositionFactory;
+import org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl;
+import org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryMBeanImpl;
+import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
+import org.apache.bookkeeper.mledger.impl.ManagedLedgerMBeanImpl;
+import org.apache.pulsar.common.api.proto.MessageMetadata;
+import org.apache.pulsar.common.protocol.Commands;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class EntryCacheDisabledTest {
+    private ManagedLedgerImpl mockManagedLedger;
+    private ManagedLedgerConfig managedLedgerConfig;
+    private ReadHandle lh;
+
+    @BeforeMethod
+    public void setup() {
+        mockManagedLedger = mock(ManagedLedgerImpl.class);
+        when(mockManagedLedger.getName()).thenReturn("testManagedLedger");
+        managedLedgerConfig = new ManagedLedgerConfig();
+        when(mockManagedLedger.getConfig()).thenReturn(managedLedgerConfig);
+        when(mockManagedLedger.getMbean()).thenReturn(mock(ManagedLedgerMBeanImpl.class));
+        // a same-thread executor, so the read completes before the assertions run
+        when(mockManagedLedger.getExecutor()).thenReturn(MoreExecutors.newDirectExecutorService());
+        when(mockManagedLedger.getOptionalLedgerInfo(1L)).thenReturn(Optional.empty());
+        ManagedLedgerFactoryImpl mockFactory = mock(ManagedLedgerFactoryImpl.class);
+        when(mockFactory.getMbean()).thenReturn(mock(ManagedLedgerFactoryMBeanImpl.class));
+        when(mockManagedLedger.getFactory()).thenReturn(mockFactory);
+        lh = mock(ReadHandle.class);
+        when(lh.getId()).thenReturn(1L);
+    }
+
+    private static ByteBuf serializeMessage(String producerName) {
+        MessageMetadata metadata = new MessageMetadata()
+                .setProducerName(producerName)
+                .setSequenceId(7)
+                .setPublishTime(123456789L);
+        ByteBuf payload = Unpooled.copiedBuffer("payload", StandardCharsets.UTF_8);
+        try {
+            // serializeMetadataAndPayload copies the payload instead of taking ownership of it
+            return Commands.serializeMetadataAndPayload(Commands.ChecksumType.Crc32c, metadata, payload);
+        } finally {
+            payload.release();
+        }
+    }
+
+    @Test
+    public void testReadDoesNotParseMessageMetadataWhenTheEntriesArentPulsarMessages() throws Exception {
+        EntryCacheDisabled entryCache = new EntryCacheDisabled(mockManagedLedger);
+
+        // the transaction log and the pending ack store keep entries that are not Pulsar messages, so the read
+        // must not try to parse message metadata out of them
+        managedLedgerConfig.setPulsarMessageEntries(false);
+        Entry entryWithoutParsing = readSingleEntry(entryCache, 0L);
+        assertThat(entryWithoutParsing.getMessageMetadata()).isNull();
+        entryWithoutParsing.release();
+
+        // control: the same bytes read over the same path do get parsed when the entries are Pulsar messages, so
+        // the assertion above can't pass merely because the payload happens to be unparseable
+        managedLedgerConfig.setPulsarMessageEntries(true);
+        Entry entryWithParsing = readSingleEntry(entryCache, 1L);
+        assertThat(entryWithParsing.getMessageMetadata()).isNotNull();
+        assertThat(entryWithParsing.getMessageMetadata().getProducerName()).isEqualTo("producer");
+        entryWithParsing.release();
+    }
+
+    /**
+     * Reads a single freshly serialized Pulsar message back through the cache.
+     *
+     * @apiNote the returned entry must be released by the caller
+     */
+    private Entry readSingleEntry(EntryCacheDisabled entryCache, long entryId) throws Exception {
+        ByteBuf headersAndPayload = serializeMessage("producer");
+        LedgerEntryImpl ledgerEntry =
+                LedgerEntryImpl.create(1L, entryId, headersAndPayload.readableBytes(), headersAndPayload);
+        LedgerEntries ledgerEntries = mock(LedgerEntries.class);
+        when(ledgerEntries.iterator()).thenReturn(List.<LedgerEntry>of(ledgerEntry).iterator());
+        when(lh.readAsync(entryId, entryId)).thenReturn(CompletableFuture.completedFuture(ledgerEntries));
+
+        CompletableFuture<Entry> future = new CompletableFuture<>();
+        entryCache.asyncReadEntry(lh, PositionFactory.create(1L, entryId), new AsyncCallbacks.ReadEntryCallback() {
+            @Override
+            public void readEntryComplete(Entry entry, Object ctx) {
+                future.complete(entry);
+            }
+
+            @Override
+            public void readEntryFailed(ManagedLedgerException exception, Object ctx) {
+                future.completeExceptionally(exception);
+            }
+        }, null);
+        Entry entry = future.get(10, TimeUnit.SECONDS);
+        // the LedgerEntries mock doesn't release what it holds, so that reference is dropped explicitly instead
+        ledgerEntry.close();
+        return entry;
+    }
+}

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImplTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImplTest.java
@@ -125,7 +125,11 @@ public class RangeEntryCacheImplTest {
         assertThat(rangeEntryCache.insert(entry)).isTrue();
         entry.release();
 
-        // the metadata is parsed once at insert time instead of lazily on the first cache read
+        // the metadata is parsed once at insert time instead of lazily on the first cache read. This has to be
+        // asserted before reading the entry back, because reading it would itself trigger the lazy path
+        assertThat(rangeEntryCache.getEntries().isMessageMetadataInitialized(PositionFactory.create(1, 50)))
+                .isTrue();
+
         ReferenceCountedEntry cached = rangeEntryCache.getEntries().get(PositionFactory.create(1, 50));
         assertThat(cached).isNotNull();
         assertThat(cached.getMessageMetadata()).isNotNull();

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImplTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImplTest.java
@@ -43,6 +43,8 @@ import org.apache.bookkeeper.client.impl.LedgerEntryImpl;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
+import org.apache.bookkeeper.mledger.PositionFactory;
+import org.apache.bookkeeper.mledger.ReferenceCountedEntry;
 import org.apache.bookkeeper.mledger.impl.EntryImpl;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryMBeanImpl;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
@@ -54,20 +56,23 @@ import org.testng.annotations.Test;
 
 public class RangeEntryCacheImplTest {
     private RangeEntryCacheImpl rangeEntryCache;
+    private RangeEntryCacheManagerImpl mockEntryCacheManager;
+    private ManagedLedgerImpl mockManagedLedger;
+    private RangeCacheRemovalQueue mockRangeCacheRemovalQueue;
     private PendingReadsManager pendingReadsManager;
     private ReadHandle lh;
     private IntSupplier expectedReadCount;
 
     @BeforeMethod
     public void setup() {
-        RangeEntryCacheManagerImpl mockEntryCacheManager = mock(RangeEntryCacheManagerImpl.class);
+        mockEntryCacheManager = mock(RangeEntryCacheManagerImpl.class);
         ManagedLedgerFactoryMBeanImpl mlFactoryMBean = mock(ManagedLedgerFactoryMBeanImpl.class);
         when(mockEntryCacheManager.getMlFactoryMBean()).thenReturn(mlFactoryMBean);
-        ManagedLedgerImpl mockManagedLedger = mock(ManagedLedgerImpl.class);
+        mockManagedLedger = mock(ManagedLedgerImpl.class);
         ManagedLedgerMBeanImpl mockManagedLedgerMBean = mock(ManagedLedgerMBeanImpl.class);
         when(mockManagedLedger.getMbean()).thenReturn(mockManagedLedgerMBean);
         when(mockManagedLedger.getName()).thenReturn("testManagedLedger");
-        RangeCacheRemovalQueue mockRangeCacheRemovalQueue = mock(RangeCacheRemovalQueue.class);
+        mockRangeCacheRemovalQueue = mock(RangeCacheRemovalQueue.class);
         when(mockRangeCacheRemovalQueue.addEntry(any())).thenReturn(true);
         InflightReadsLimiter inflightReadsLimiter = mock(InflightReadsLimiter.class);
         when(mockEntryCacheManager.getInflightReadsLimiter()).thenReturn(inflightReadsLimiter);
@@ -90,33 +95,89 @@ public class RangeEntryCacheImplTest {
             callback.readEntriesComplete(entries, ctx);
             return null;
         }).when(pendingReadsManager).readEntries(any(), anyLong(), anyLong(), any(), any(), any());
-        rangeEntryCache =
-                new RangeEntryCacheImpl(mockEntryCacheManager, mockManagedLedger, false, mockRangeCacheRemovalQueue,
-                        EntryLengthFunction.DEFAULT, pendingReadsManager);
+        rangeEntryCache = createRangeEntryCache(false);
         lh = mock(ReadHandle.class);
         when(lh.getId()).thenReturn(1L);
         expectedReadCount = () -> 1;
     }
 
-    @Test
-    public void testInsertParsesMessageMetadata() {
+    private RangeEntryCacheImpl createRangeEntryCache(boolean copyEntries) {
+        return new RangeEntryCacheImpl(mockEntryCacheManager, mockManagedLedger, copyEntries,
+                mockRangeCacheRemovalQueue, EntryLengthFunction.DEFAULT, pendingReadsManager);
+    }
+
+    private static ByteBuf serializeMessage(String producerName) {
         MessageMetadata metadata = new MessageMetadata()
-                .setProducerName("producer")
+                .setProducerName(producerName)
                 .setSequenceId(7)
                 .setPublishTime(123456789L);
-        ByteBuf headersAndPayload = Commands.serializeMetadataAndPayload(Commands.ChecksumType.Crc32c, metadata,
+        return Commands.serializeMetadataAndPayload(Commands.ChecksumType.Crc32c, metadata,
                 Unpooled.copiedBuffer("payload", StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void testInsertParsesMessageMetadata() {
+        ByteBuf headersAndPayload = serializeMessage("producer");
         EntryImpl entry = EntryImpl.create(1, 50, headersAndPayload);
         headersAndPayload.release();
         assertThat(entry.getMessageMetadata()).isNull();
 
         assertThat(rangeEntryCache.insert(entry)).isTrue();
+        entry.release();
 
         // the metadata is parsed once at insert time instead of lazily on the first cache read
-        assertThat(entry.getMessageMetadata()).isNotNull();
-        assertThat(entry.getMessageMetadata().getProducerName()).isEqualTo("producer");
-        assertThat(entry.getMessageMetadata().getSequenceId()).isEqualTo(7);
+        ReferenceCountedEntry cached = rangeEntryCache.getEntries().get(PositionFactory.create(1, 50));
+        assertThat(cached).isNotNull();
+        assertThat(cached.getMessageMetadata()).isNotNull();
+        assertThat(cached.getMessageMetadata().getProducerName()).isEqualTo("producer");
+        assertThat(cached.getMessageMetadata().getSequenceId()).isEqualTo(7);
+        cached.release();
+    }
+
+    @Test
+    public void testInsertReusesTheMessageMetadataTheEntryAlreadyCarries() {
+        ByteBuf headersAndPayload = serializeMessage("in-buffer");
+        EntryImpl entry = EntryImpl.create(1, 50, headersAndPayload);
+        headersAndPayload.release();
+        // deliberately disagrees with the buffer, so that a silent re-parse cannot pass this test
+        MessageMetadata suppliedByTheCaller = new MessageMetadata()
+                .setProducerName("from-publish-path")
+                .setSequenceId(7)
+                .setPublishTime(123456789L);
+        entry.setMessageMetadata(suppliedByTheCaller);
+
+        assertThat(rangeEntryCache.insert(entry)).isTrue();
         entry.release();
+
+        // the cached entry reuses the instance instead of parsing the same bytes a second time
+        ReferenceCountedEntry cached = rangeEntryCache.getEntries().get(PositionFactory.create(1, 50));
+        assertThat(cached).isNotNull();
+        assertThat(cached.getMessageMetadata()).isSameAs(suppliedByTheCaller);
+        assertThat(cached.getMessageMetadata().getProducerName()).isEqualTo("from-publish-path");
+        cached.release();
+    }
+
+    @Test
+    public void testCachedEntryMetadataStaysReadableWhenEntriesAreCopied() {
+        RangeEntryCacheImpl copyingCache = createRangeEntryCache(true);
+        ByteBuf headersAndPayload = serializeMessage("producer");
+        EntryImpl entry = EntryImpl.create(1, 50, headersAndPayload);
+        headersAndPayload.release();
+
+        assertThat(copyingCache.insert(entry)).isTrue();
+        // the source entry, and with it the buffer the metadata was parsed from, is released right after the
+        // insert, exactly as OpAddEntry does on the write path
+        entry.release();
+        assertThat(headersAndPayload.refCnt()).isZero();
+
+        ReferenceCountedEntry cached = copyingCache.getEntries().get(PositionFactory.create(1, 50));
+        assertThat(cached).isNotNull();
+        // MessageMetadata decodes its string and bytes fields lazily from the buffer it was parsed from, so the
+        // cached entry must not share metadata that was parsed from the now released source buffer
+        assertThat(cached.getMessageMetadata()).isNotNull();
+        assertThat(cached.getMessageMetadata().getProducerName()).isEqualTo("producer");
+        assertThat(cached.getMessageMetadata().getSequenceId()).isEqualTo(7);
+        cached.release();
     }
 
     @Test

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImplTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImplTest.java
@@ -24,6 +24,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -43,6 +44,7 @@ import org.apache.bookkeeper.client.api.ReadHandle;
 import org.apache.bookkeeper.client.impl.LedgerEntryImpl;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
 import org.apache.bookkeeper.mledger.Entry;
+import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.PositionFactory;
 import org.apache.bookkeeper.mledger.ReferenceCountedEntry;
@@ -60,6 +62,7 @@ public class RangeEntryCacheImplTest {
     private RangeEntryCacheManagerImpl mockEntryCacheManager;
     private ManagedLedgerImpl mockManagedLedger;
     private RangeCacheRemovalQueue mockRangeCacheRemovalQueue;
+    private ManagedLedgerConfig managedLedgerConfig;
     private PendingReadsManager pendingReadsManager;
     private ReadHandle lh;
     private IntSupplier expectedReadCount;
@@ -73,6 +76,8 @@ public class RangeEntryCacheImplTest {
         ManagedLedgerMBeanImpl mockManagedLedgerMBean = mock(ManagedLedgerMBeanImpl.class);
         when(mockManagedLedger.getMbean()).thenReturn(mockManagedLedgerMBean);
         when(mockManagedLedger.getName()).thenReturn("testManagedLedger");
+        managedLedgerConfig = new ManagedLedgerConfig();
+        when(mockManagedLedger.getConfig()).thenReturn(managedLedgerConfig);
         mockRangeCacheRemovalQueue = mock(RangeCacheRemovalQueue.class);
         when(mockRangeCacheRemovalQueue.addEntry(any())).thenReturn(true);
         InflightReadsLimiter inflightReadsLimiter = mock(InflightReadsLimiter.class);
@@ -112,8 +117,13 @@ public class RangeEntryCacheImplTest {
                 .setProducerName(producerName)
                 .setSequenceId(7)
                 .setPublishTime(123456789L);
-        return Commands.serializeMetadataAndPayload(Commands.ChecksumType.Crc32c, metadata,
-                Unpooled.copiedBuffer("payload", StandardCharsets.UTF_8));
+        ByteBuf payload = Unpooled.copiedBuffer("payload", StandardCharsets.UTF_8);
+        try {
+            // serializeMetadataAndPayload copies the payload instead of taking ownership of it
+            return Commands.serializeMetadataAndPayload(Commands.ChecksumType.Crc32c, metadata, payload);
+        } finally {
+            payload.release();
+        }
     }
 
     @Test
@@ -126,11 +136,8 @@ public class RangeEntryCacheImplTest {
         assertThat(rangeEntryCache.insert(entry)).isTrue();
         entry.release();
 
-        // the metadata is parsed once at insert time instead of lazily on the first cache read. This has to be
-        // asserted before reading the entry back, because reading it would itself trigger the lazy path
-        assertThat(rangeEntryCache.getEntries().isMessageMetadataInitialized(PositionFactory.create(1, 50)))
-                .isTrue();
-
+        // the metadata is parsed once at insert time. Reading the entry back out of the cache doesn't parse
+        // anything any more, so this asserts what insert actually stored
         ReferenceCountedEntry cached = rangeEntryCache.getEntries().get(PositionFactory.create(1, 50));
         assertThat(cached).isNotNull();
         assertThat(cached.getMessageMetadata()).isNotNull();
@@ -213,11 +220,6 @@ public class RangeEntryCacheImplTest {
         assertThat(sourceMetadata).isNotNull();
         assertThat(sourceMetadata.getSequenceId()).isEqualTo(7);
 
-        // the metadata of the cached entry is parsed at insert time and not lazily under the write lock of the
-        // first cache read. This has to be asserted before reading the entry back, because reading it would
-        // itself trigger the lazy path
-        assertThat(copyingCache.getEntries().isMessageMetadataInitialized(PositionFactory.create(1, 0))).isTrue();
-
         ReferenceCountedEntry cached = copyingCache.getEntries().get(PositionFactory.create(1, 0));
         assertThat(cached).isNotNull();
         // the cached entry is backed by a copy of the payload, so it must not share the metadata that was parsed
@@ -244,6 +246,117 @@ public class RangeEntryCacheImplTest {
         assertThat(cached.getMessageMetadata().getProducerName()).isEqualTo("producer");
         assertThat(cached.getMessageMetadata().getSequenceId()).isEqualTo(7);
         cached.release();
+    }
+
+    @Test
+    public void testInsertDoesNotParseMessageMetadataWhenTheEntriesArentPulsarMessages() {
+        // the transaction log and the pending ack store keep entries that are not Pulsar messages, so the entry
+        // cache must not try to parse message metadata out of them
+        managedLedgerConfig.setPulsarMessageEntries(false);
+
+        ByteBuf headersAndPayload = serializeMessage("producer");
+        EntryImpl entry = EntryImpl.create(1, 50, headersAndPayload);
+        headersAndPayload.release();
+
+        assertThat(rangeEntryCache.insert(entry)).isTrue();
+        entry.release();
+
+        ReferenceCountedEntry cached = rangeEntryCache.getEntries().get(PositionFactory.create(1, 50));
+        assertThat(cached).isNotNull();
+        assertThat(cached.getMessageMetadata()).isNull();
+        cached.release();
+
+        // reading the entry back through the cache must not parse it either. This is what pins the removal of
+        // the lazy initialization that RangeCacheEntryWrapper used to do under its write lock, which would have
+        // defeated skipping the parse at insert time
+        Entry readBack = readSingleEntryFromCache(1, 50);
+        assertThat(readBack.getMessageMetadata()).isNull();
+        readBack.release();
+        // the read has to have been served from the cache. A miss would fall through to the mocked storage,
+        // which hands back an entry that carries no metadata either, making the assertion above vacuous
+        verify(pendingReadsManager, never()).readEntries(any(), anyLong(), anyLong(), any(), any(), any());
+
+        // control: the very same bytes are parsed when the managed ledger does hold Pulsar messages, so the
+        // assertions above can't pass merely because the payload happens to be unparseable
+        managedLedgerConfig.setPulsarMessageEntries(true);
+        ByteBuf controlHeadersAndPayload = serializeMessage("producer");
+        EntryImpl controlEntry = EntryImpl.create(1, 51, controlHeadersAndPayload);
+        controlHeadersAndPayload.release();
+        assertThat(rangeEntryCache.insert(controlEntry)).isTrue();
+        controlEntry.release();
+
+        ReferenceCountedEntry cachedControl = rangeEntryCache.getEntries().get(PositionFactory.create(1, 51));
+        assertThat(cachedControl).isNotNull();
+        assertThat(cachedControl.getMessageMetadata()).isNotNull();
+        assertThat(cachedControl.getMessageMetadata().getProducerName()).isEqualTo("producer");
+        cachedControl.release();
+    }
+
+    @Test
+    public void testReadFromStorageDoesNotParseMessageMetadataWhenTheEntriesArentPulsarMessages() {
+        when(mockManagedLedger.getExecutor()).thenReturn(mock(ExecutorService.class));
+        // without ledger info, ReadEntryUtils reads through ReadHandle#readAsync
+        when(mockManagedLedger.getOptionalLedgerInfo(1L)).thenReturn(Optional.empty());
+        managedLedgerConfig.setPulsarMessageEntries(false);
+
+        Entry entryWithoutParsing = readSingleEntryFromStorage(0L);
+        assertThat(entryWithoutParsing.getMessageMetadata()).isNull();
+        entryWithoutParsing.release();
+
+        // control: the same bytes read over the same path do get parsed when the entries are Pulsar messages
+        managedLedgerConfig.setPulsarMessageEntries(true);
+        Entry entryWithParsing = readSingleEntryFromStorage(1L);
+        assertThat(entryWithParsing.getMessageMetadata()).isNotNull();
+        assertThat(entryWithParsing.getMessageMetadata().getProducerName()).isEqualTo("producer");
+        entryWithParsing.release();
+    }
+
+    /**
+     * Reads a single entry back through the cache read path, which is the caller that used to trigger the lazy
+     * metadata initialization inside {@link RangeCacheEntryWrapper}.
+     *
+     * @apiNote the returned entry must be released by the caller
+     */
+    private Entry readSingleEntryFromCache(long ledgerId, long entryId) {
+        CompletableFuture<Entry> future = new CompletableFuture<>();
+        rangeEntryCache.asyncReadEntry(lh, PositionFactory.create(ledgerId, entryId),
+                new AsyncCallbacks.ReadEntryCallback() {
+                    @Override
+                    public void readEntryComplete(Entry entry, Object ctx) {
+                        future.complete(entry);
+                    }
+
+                    @Override
+                    public void readEntryFailed(ManagedLedgerException exception, Object ctx) {
+                        future.completeExceptionally(exception);
+                    }
+                }, null);
+        assertThat(future).isCompleted();
+        return future.getNow(null);
+    }
+
+    /**
+     * Reads a single freshly serialized Pulsar message through {@link RangeEntryCacheImpl#readFromStorage}.
+     *
+     * @apiNote the returned entry must be released by the caller
+     */
+    private Entry readSingleEntryFromStorage(long entryId) {
+        ByteBuf headersAndPayload = serializeMessage("producer");
+        LedgerEntryImpl ledgerEntry =
+                LedgerEntryImpl.create(1L, entryId, headersAndPayload.readableBytes(), headersAndPayload);
+        LedgerEntries ledgerEntries = mock(LedgerEntries.class);
+        when(ledgerEntries.iterator()).thenReturn(List.<LedgerEntry>of(ledgerEntry).iterator());
+        when(lh.readAsync(entryId, entryId)).thenReturn(CompletableFuture.completedFuture(ledgerEntries));
+
+        CompletableFuture<List<Entry>> future = rangeEntryCache.readFromStorage(lh, entryId, entryId,
+                expectedReadCount);
+        assertThat(future).isCompleted();
+        List<Entry> readEntries = future.getNow(null);
+        assertThat(readEntries).hasSize(1);
+        // readFromStorage closes the LedgerEntries, but that is a mock here, so the reference the read result
+        // holds is dropped explicitly instead
+        ledgerEntry.close();
+        return readEntries.get(0);
     }
 
     @Test
@@ -348,6 +461,7 @@ public class RangeEntryCacheImplTest {
         ManagedLedgerMBeanImpl mockManagedLedgerMBean = mock(ManagedLedgerMBeanImpl.class);
         when(mockManagedLedger.getMbean()).thenReturn(mockManagedLedgerMBean);
         when(mockManagedLedger.getName()).thenReturn("testManagedLedger");
+        when(mockManagedLedger.getConfig()).thenReturn(new ManagedLedgerConfig());
         when(mockManagedLedger.getExecutor()).thenReturn(mock(java.util.concurrent.ExecutorService.class));
         when(mockManagedLedger.getOptionalLedgerInfo(1L)).thenReturn(Optional.empty());
         RangeCacheRemovalQueue mockRangeCacheRemovalQueue = mock(RangeCacheRemovalQueue.class);

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImplTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImplTest.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.IntSupplier;
 import org.apache.bookkeeper.client.api.LedgerEntries;
@@ -179,6 +180,67 @@ public class RangeEntryCacheImplTest {
         // MessageMetadata decodes its string and bytes fields lazily from the buffer it was parsed from, so the
         // cached entry must not share metadata that was parsed from the now released source buffer
         assertThat(cached.getMessageMetadata()).isNotNull();
+        assertThat(cached.getMessageMetadata().getProducerName()).isEqualTo("producer");
+        assertThat(cached.getMessageMetadata().getSequenceId()).isEqualTo(7);
+        cached.release();
+    }
+
+    @Test
+    public void testReadFromStorageDoesNotShareSourceMetadataWithTheCopiedCacheEntry() {
+        RangeEntryCacheImpl copyingCache = createRangeEntryCache(true);
+        when(mockManagedLedger.getExecutor()).thenReturn(mock(ExecutorService.class));
+        // without ledger info, ReadEntryUtils reads through ReadHandle#readAsync
+        when(mockManagedLedger.getOptionalLedgerInfo(1L)).thenReturn(Optional.empty());
+
+        ByteBuf headersAndPayload = serializeMessage("producer");
+        LedgerEntryImpl ledgerEntry =
+                LedgerEntryImpl.create(1L, 0L, headersAndPayload.readableBytes(), headersAndPayload);
+        LedgerEntries ledgerEntries = mock(LedgerEntries.class);
+        when(ledgerEntries.iterator()).thenReturn(List.<LedgerEntry>of(ledgerEntry).iterator());
+        when(lh.readAsync(0L, 0L)).thenReturn(CompletableFuture.completedFuture(ledgerEntries));
+
+        CompletableFuture<List<Entry>> future = copyingCache.readFromStorage(lh, 0L, 0L, expectedReadCount);
+        assertThat(future).isCompleted();
+        List<Entry> readEntries = future.getNow(null);
+        assertThat(readEntries).hasSize(1);
+        Entry sourceEntry = readEntries.get(0);
+
+        // unlike the write path, the read path parses the metadata of the entry it returns before inserting it,
+        // so this is the case where insert receives an entry that already carries a MessageMetadata. Only the
+        // eagerly decoded sequenceId is read from it here, since reading a string field would decode it from
+        // the buffer and keep the decoded value, hiding the very problem this test is about
+        MessageMetadata sourceMetadata = sourceEntry.getMessageMetadata();
+        assertThat(sourceMetadata).isNotNull();
+        assertThat(sourceMetadata.getSequenceId()).isEqualTo(7);
+
+        // the metadata of the cached entry is parsed at insert time and not lazily under the write lock of the
+        // first cache read. This has to be asserted before reading the entry back, because reading it would
+        // itself trigger the lazy path
+        assertThat(copyingCache.getEntries().isMessageMetadataInitialized(PositionFactory.create(1, 0))).isTrue();
+
+        ReferenceCountedEntry cached = copyingCache.getEntries().get(PositionFactory.create(1, 0));
+        assertThat(cached).isNotNull();
+        // the cached entry is backed by a copy of the payload, so it must not share the metadata that was parsed
+        // from the source buffer
+        assertThat(cached.getMessageMetadata()).isNotNull().isNotSameAs(sourceMetadata);
+
+        // overwrite the source payload while it is still referenced, the way the pooled buffer behind it gets
+        // overwritten once it has been recycled. This turns a leftover dependency on the source buffer into a
+        // wrong value rather than into a read that only fails when the released memory happens to be reused
+        headersAndPayload.setZero(headersAndPayload.readerIndex(), headersAndPayload.readableBytes());
+        // metadata parsed from the source buffer does decode the overwritten bytes, which keeps the assertions
+        // below from turning vacuous should MessageMetadata ever stop decoding these fields lazily
+        assertThat(sourceMetadata.getProducerName()).isNotEqualTo("producer");
+
+        // the read path releases the entries it returned once dispatch is done, while the cached copy stays
+        sourceEntry.release();
+        // readFromStorage closes the LedgerEntries, but that is a mock here, so the reference the read result
+        // holds is dropped explicitly instead
+        ledgerEntry.close();
+        assertThat(headersAndPayload.refCnt()).isZero();
+
+        // MessageMetadata decodes its string and bytes fields lazily from the buffer it was parsed from, so the
+        // cached entry stays readable only because its metadata was parsed from the buffer the cache owns
         assertThat(cached.getMessageMetadata().getProducerName()).isEqualTo("producer");
         assertThat(cached.getMessageMetadata().getSequenceId()).isEqualTo(7);
         cached.release();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/MLPendingAckStoreProvider.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/MLPendingAckStoreProvider.java
@@ -164,6 +164,8 @@ public class MLPendingAckStoreProvider implements TransactionPendingAckStoreProv
                                                    Timer brokerClientSharedTimer,
                                                    PersistentTopic originPersistentTopic) {
         config.setCreateIfMissing(true);
+        // the pending ack store keeps PendingAckMetadataEntry records, not Pulsar messages
+        config.setPulsarMessageEntries(false);
         config.setLoggerContext(log.with()
                 .attr("topic", topicName.toString())
                 .attr("subscription", subscription.getName())

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
@@ -72,6 +72,7 @@ import lombok.Lombok;
 import org.apache.bookkeeper.common.util.Bytes;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
 import org.apache.bookkeeper.mledger.ManagedCursor;
+import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.ManagedLedgerFactory;
@@ -603,6 +604,35 @@ public class TransactionTest extends TransactionTestBase {
                 );
             });
         });
+    }
+
+    @Test
+    public void testPendingAckStoreEntriesArentPulsarMessages() throws Exception {
+        String topicName = TopicName.get(NAMESPACE1 + "/" + "testPendingAckStoreEntriesArentPulsarMessages")
+                .toString();
+        String subName = "test";
+        // acknowledging inside a transaction initializes the pending ack store, and with it its managed ledger
+        @Cleanup
+        Consumer<byte[]> consumer = getConsumer(topicName, subName);
+        Transaction transaction = pulsarClient.newTransaction()
+                .withTransactionTimeout(10, TimeUnit.SECONDS).build().get();
+        try {
+            consumer.acknowledgeAsync(new MessageIdImpl(10, 10, 10), transaction).get();
+        } catch (ExecutionException e) {
+            // the acknowledged message id doesn't exist, which is enough to initialize the store
+            assertTrue(e.getCause() instanceof PulsarClientException.TransactionConflictException);
+        }
+
+        PersistentTopic originPersistentTopic = (PersistentTopic) getPulsarServiceList().get(0)
+                .getBrokerService().getTopic(topicName, false).get().get();
+        PersistentSubscription subscription = originPersistentTopic.getSubscription(subName);
+
+        // the pending ack store keeps PendingAckMetadataEntry records, which can never parse as message metadata,
+        // so its managed ledger must be marked as not holding Pulsar messages
+        ManagedLedger pendingAckManagedLedger = subscription.getPendingAckManageLedger().get();
+        assertFalse(pendingAckManagedLedger.getConfig().isPulsarMessageEntries());
+        // control: the topic's own managed ledger does hold Pulsar messages, which is the default
+        assertTrue(originPersistentTopic.getManagedLedger().getConfig().isPulsarMessageEntries());
     }
 
     @Test

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionLogImpl.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionLogImpl.java
@@ -97,6 +97,8 @@ public class MLTransactionLogImpl implements TransactionLog {
         if (txnLogBufferedWriterConfig.isBatchEnabled()) {
             this.managedLedgerConfig.setDeletionAtBatchIndexLevelEnabled(true);
         }
+        // the transaction log keeps TransactionMetadataEntry records, not Pulsar messages
+        this.managedLedgerConfig.setPulsarMessageEntries(false);
         this.entryQueue = new SpscArrayQueue<>(2000);
         this.bufferedWriterMetrics = bufferedWriterMetrics;
     }

--- a/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionLogImplTest.java
+++ b/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionLogImplTest.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.transaction.coordinator.impl;
 
 import static org.apache.pulsar.transaction.coordinator.impl.DisabledTxnLogBufferedWriterMetricsStats.DISABLED_BUFFERED_WRITER_METRICS;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import com.google.common.collect.ComparisonChain;
 import io.netty.util.HashedWheelTimer;
@@ -65,6 +66,30 @@ public class MLTransactionLogImplTest extends MockedBookKeeperTestCase {
                 {false, true}
         };
     }
+    @Test
+    public void testTransactionLogEntriesArentPulsarMessages() throws Exception {
+        // control: a plain managed ledger holds Pulsar messages, which is the default and what pins that the
+        // assertion below is about the transaction log rather than about the default
+        assertThat(new ManagedLedgerConfig().isPulsarMessageEntries()).isTrue();
+
+        HashedWheelTimer transactionTimer = new HashedWheelTimer(new DefaultThreadFactory("transaction-timer"),
+                1, TimeUnit.MILLISECONDS);
+        ManagedLedgerConfig managedLedgerConfig = new ManagedLedgerConfig();
+        MLTransactionLogImpl transactionLog = new MLTransactionLogImpl(TransactionCoordinatorID.get(0), factory,
+                managedLedgerConfig, new TxnLogBufferedWriterConfig(), transactionTimer,
+                DISABLED_BUFFERED_WRITER_METRICS);
+        try {
+            transactionLog.initialize().get(3, TimeUnit.SECONDS);
+            // the transaction log stores TransactionMetadataEntry records, which can never parse as message
+            // metadata, so the entry cache must not try
+            assertThat(managedLedgerConfig.isPulsarMessageEntries()).isFalse();
+            assertThat(transactionLog.getManagedLedger().getConfig().isPulsarMessageEntries()).isFalse();
+        } finally {
+            transactionLog.closeAsync().get(3, TimeUnit.SECONDS);
+            transactionTimer.stop();
+        }
+    }
+
     /**
      * 1. Add some transaction logs.
      * 2. Create a new transaction meta store and execute recover, assert that the txn-mapping built by Recover is as


### PR DESCRIPTION
Fixes #26493

This PR carries two related changes to how the managed ledger entry cache handles message metadata. The first is the fix for #26493; the second removes a per-entry metadata parse that can never succeed on the transaction log and the transaction pending ack store.

## 1. Parse the cached entry's metadata from the buffer the cache keeps

### Motivation

`RangeEntryCacheImpl.insert` stores on the **cached** entry a `MessageMetadata` instance that was parsed from the **incoming** entry's buffer. That is only sound when the two share a buffer, and with `managedLedgerCacheCopyEntries=true` they don't: the cached entry is backed by a fresh copy from `copyEntry(entry)` while the incoming entry is released right after the insert returns.

It matters because a `MessageMetadata` keeps a reference to the buffer it was parsed from and decodes part of itself out of it lazily. lightproto's generated `parseFrom` ends with

```java
_parsedBuffer = _buffer;   // no retain, no copy
```

and `producerName`, `replicatedFrom`, `partitionKey`, `replicateTo`, `encryptionAlgo`, `encryptionParam`, `schemaVersion`, `orderingKey`, `uuid`, `schemaId` and every `properties` key/value are decoded from `_parsedBuffer` on first access. Scalars such as `sequenceId` and `publishTime` are decoded eagerly by `parseFrom`, which is what makes the failure selective rather than obvious.

So for as long as the entry stays cached, those fields are read out of a released, pool-recycled buffer. They are read on hot paths — `Commands.resolveStickyKey` via `AbstractBaseDispatcher.peekStickyKey`, the metadata handed to entry filters in `filterEntriesForConsumer`, and `PersistentTopicsBase`'s `peek`/`examine` — so the symptoms are wrong Key_Shared routing or wrong filter decisions rather than anything that points at a buffer lifetime problem.

Two paths reach it:

* **Read path** — `readFromStorage` parses the metadata on each entry it creates and then inserts that entry into the cache, while the entries it returns are released once dispatch completes. Present since #24682 + #24836, so `branch-4.2` is affected too.
* **Write path** — since #26463 `insert` also parses the metadata on the incoming entry, and `OpAddEntry.run` releases that entry, and then its buffer in `completeAdd`, right after inserting. `master` only.

`managedLedgerCacheCopyEntries` defaults to `false`, so a default broker is not affected.

### Modifications

- Parse the metadata on the **cache** entry rather than on the incoming one, and only inherit the incoming entry's instance when the cache retains that same buffer (`copyEntries == false`).
- Nothing depended on `insert` parsing the *source* entry: `readFromStorage` already parses the entries it returns, and the write path releases the incoming entry immediately. With `managedLedgerCacheCopyEntries=true` the read path now parses twice, once for the entry it returns and once for the cache's own copy. That is unavoidable, since a `MessageMetadata` cannot be rebound to another buffer, and the default `copyEntries=false` path is unchanged: the cached entry keeps the same buffer and inherits the instance.
- Added a package-private `@VisibleForTesting RangeEntryCacheImpl#getEntries()` so tests can assert on what the cache actually holds rather than on the entry that was handed to it.

`MessageMetadata#materialize()` was considered as an alternative (thanks @merlimat for the pointer) and rejected: on the read path the instance `insert` receives still belongs to the entry being handed to the dispatcher, so it can't be mutated in place, and re-parsing from the buffer the cache already owns is a cheaper copy than `materialize()`/`copyFrom` since it leaves the string and bytes fields lazy. See the discussion below.

The invariant this establishes, and which is worth keeping in mind when touching `EntryImpl.messageMetadata`, is that an entry's message metadata must always have been parsed from that entry's own `data` buffer.

## 2. Skip metadata parsing for managed ledgers that don't hold Pulsar messages

### Motivation

`MLTransactionLogImpl` and `MLPendingAckStore` open their own managed ledgers and store bare lightproto `TransactionMetadataEntry` / `PendingAckMetadataEntry` records rather than Pulsar messages. Since #24682 the entry cache parses every entry as a `MessageMetadata` at insert and read time, which for these ledgers can never succeed: `Commands.parseMessageMetadata` reads a 4-byte big-endian metadata length off the front of the payload, and the first byte of one of these records is a protobuf tag, so the length always decodes to at least 128 MiB and the lightproto parse walks off the end of the buffer.

`EntryImpl.initializeMessageMetadataIfNeeded` catches the resulting exception and leaves `messageMetadata` null, so no wrong metadata is ever produced, but it logs a warning with a stack trace for every entry. A broker with transactions enabled therefore warns once per transaction log and pending ack entry it writes, and once per entry it replays during recovery.

### Modifications

- Added `ManagedLedgerConfig.pulsarMessageEntries`, defaulting to true. The transaction log and the pending ack store set it to false on the config they already build before `asyncOpen`, so the value is fixed before the managed ledger and its entry cache exist. The field is additive and defaults to the existing behaviour.
- `RangeEntryCacheImpl.insert`, `RangeEntryCacheImpl.readFromStorage` and `EntryCacheDisabled` skip `initializeMessageMetadataIfNeeded` when the flag is false. These are the only three places that parse an entry's metadata; every other reader falls back to peeking the buffer when `Entry#getMessageMetadata()` is null, which is already a normal condition (`CompactedTopicImpl`, `NonPersistentTopic` and `ManagedLedgerImpl` all hand out entries with null metadata today).
- Dropped the lazy metadata initialization from `RangeCacheEntryWrapper`. With the parse skipped for these ledgers it would have re-introduced it on the first cache read, and for the ledgers that do hold messages `insert` has parsed the metadata eagerly since #26463. Removing it also makes the `managedLedgerName` that was threaded through `RangeCache` and `RangeCacheEntryWrapper` for its warning message dead, so that goes too, along with the two-argument `RangeCache` constructor which never had a caller.

### Verifying this change

**For the buffer lifetime fix.** `RangeEntryCacheImplTest.testCachedEntryMetadataStaysReadableWhenEntriesAreCopied` inserts into a `copyEntries=true` cache, releases the source entry exactly as `OpAddEntry` does on the write path, and then reads a lazily decoded field off the cached entry. Against the pre-fix `insert` it fails with:

```
io.netty.util.IllegalReferenceCountException: refCnt: 0
	at org.apache.bookkeeper.mledger.impl.cache.RangeEntryCacheImplTest
	        .testCachedEntryMetadataStaysReadableWhenEntriesAreCopied(RangeEntryCacheImplTest.java:190)
```

An exception is the lucky outcome — the cached metadata holds an unretained duplicate that shares its parent's reference count, so once the pooled parent has been released and reused the duplicate sees a healthy `refCnt` again and simply decodes whatever now occupies that memory.

`testReadFromStorageDoesNotShareSourceMetadataWithTheCopiedCacheEntry` covers the read path shape, where `insert` receives an entry whose metadata was already parsed from the source buffer (thanks @void-ptr974 for catching that the original test didn't reach it: it hands `insert` an entry whose metadata is still null, so both arms of the `copyEntries ? null :` guard evaluate to null and the guard itself was unpinned). It drives the real `readFromStorage` path, asserts the cached entry's `MessageMetadata` is a different instance from the source entry's, and reads a lazily decoded string field back off the cached entry after the source has been released; the source payload is overwritten while it is still referenced, so a leftover dependency on it shows up as a wrong value rather than depending on when the pooled buffer happens to be reused.

`testInsertReusesTheMessageMetadataTheEntryAlreadyCarries` supplies a sentinel instance whose `producerName` deliberately disagrees with the serialized buffer, so that a silent re-parse cannot pass it.

**For the parse skipping.** A test per guarded site asserts that the metadata isn't parsed when the entries aren't Pulsar messages, each carrying an in-test control that pushes the same bytes through the same path with the flag on, so the assertion can't pass merely because the payload is unparseable. `testInsertDoesNotParseMessageMetadataWhenTheEntriesArentPulsarMessages` also reads the entry back through the cache, which is what pins the removal of the wrapper's lazy initialization. `MLTransactionLogImplTest` and `TransactionTest` assert that the two stores mark their managed ledgers and that a plain one keeps the default.

Every guard and both setters were mutation-tested: removing any one of them fails exactly the test that covers it, and restoring the wrapper's lazy initialization fails only the insert test.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

- [ ] `doc`
- [ ] `doc-required`
- [x] `doc-not-needed`
- [ ] `doc-complete`

### Matching PR in forked repository

PR in forked repository: N/A — the change is covered by the unit tests above.
