### PR TITLE
[fix][broker] Fix NPE in ManagedLedgerInterceptorImpl when AppendIndexMetadataInterceptor isn't configured

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/intercept/ManagedLedgerInterceptorImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/intercept/ManagedLedgerInterceptorImpl.java
@@ -31,13 +31,14 @@ import org.apache.pulsar.common.intercept.AppendIndexMetadataInterceptor;
 import org.apache.pulsar.common.intercept.BrokerEntryMetadataInterceptor;
 import org.apache.pulsar.common.intercept.ManagedLedgerPayloadProcessor;
 import org.apache.pulsar.common.protocol.Commands;
+import org.jspecify.annotations.Nullable;
 
 @CustomLog
 public class ManagedLedgerInterceptorImpl implements ManagedLedgerInterceptor {
     private static final String INDEX = "index";
     private final Set<BrokerEntryMetadataInterceptor> brokerEntryMetadataInterceptors;
 
-    private final AppendIndexMetadataInterceptor appendIndexMetadataInterceptor;
+    private final @Nullable AppendIndexMetadataInterceptor appendIndexMetadataInterceptor;
     private final Set<ManagedLedgerPayloadProcessor.Processor> inputProcessors;
     private final Set<ManagedLedgerPayloadProcessor.Processor> outputProcessors;
 
@@ -111,6 +112,11 @@ public class ManagedLedgerInterceptorImpl implements ManagedLedgerInterceptor {
 
     @Override
     public CompletableFuture<Void> onManagedLedgerLastLedgerInitialize(String name, LastEntryHandle lh) {
+        if (appendIndexMetadataInterceptor == null) {
+            // there's no index generator to recover when the AppendIndexMetadataInterceptor isn't configured,
+            // so reading the last entry would be pointless
+            return CompletableFuture.completedFuture(null);
+        }
         return lh.readLastEntryAsync().thenAccept(lastEntryOptional -> {
             if (lastEntryOptional.isPresent()) {
                 Entry lastEntry = lastEntryOptional.get();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/ManagedLedgerInterceptorImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/ManagedLedgerInterceptorImplTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.intercept;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
@@ -28,9 +29,12 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 import lombok.Cleanup;
@@ -42,18 +46,21 @@ import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.Position;
+import org.apache.bookkeeper.mledger.impl.EntryImpl;
 import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.bookkeeper.mledger.intercept.ManagedLedgerInterceptor;
 import org.apache.bookkeeper.test.MockedBookKeeperTestCase;
 import org.apache.pulsar.common.api.proto.BrokerEntryMetadata;
+import org.apache.pulsar.common.intercept.AppendBrokerTimestampMetadataInterceptor;
 import org.apache.pulsar.common.intercept.BrokerEntryMetadataInterceptor;
 import org.apache.pulsar.common.intercept.BrokerEntryMetadataUtils;
 import org.apache.pulsar.common.intercept.ManagedLedgerPayloadProcessor;
 import org.apache.pulsar.common.protocol.Commands;
 import org.jspecify.annotations.Nullable;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 @CustomLog
@@ -245,6 +252,110 @@ public class ManagedLedgerInterceptorImplTest  extends MockedBookKeeperTestCase 
 
         cursor.close();
         ledger.close();
+    }
+
+    @DataProvider(name = "interceptorSetsWithoutIndexInterceptor")
+    public Object[][] interceptorSetsWithoutIndexInterceptor() {
+        return new Object[][]{
+                // brokerEntryMetadataInterceptors holds only the timestamp interceptor
+                {Set.of(new AppendBrokerTimestampMetadataInterceptor())},
+                // brokerEntryMetadataInterceptors is empty: the interceptor is installed because
+                // brokerEntryPayloadProcessors is configured
+                {Collections.<BrokerEntryMetadataInterceptor>emptySet()}
+        };
+    }
+
+    /**
+     * When no AppendIndexMetadataInterceptor is configured there is no index generator to recover into, so
+     * reading the last entry must be skipped altogether. Reading it used to dereference the null
+     * appendIndexMetadataInterceptor whenever the last entry still carried a BrokerEntryMetadata index,
+     * which failed the managed ledger initialization with a ManagedLedgerInterceptException.
+     */
+    @Test(dataProvider = "interceptorSetsWithoutIndexInterceptor", timeOut = 30000)
+    public void testLastLedgerInitializeSkipsIndexRecoveryWithoutIndexInterceptor(
+            Set<BrokerEntryMetadataInterceptor> interceptors) throws Exception {
+        ManagedLedgerInterceptorImpl interceptor = new ManagedLedgerInterceptorImpl(interceptors, null);
+        ByteBuf lastEntryBuffer = lastEntryBufferWithIndex();
+        try {
+            AtomicBoolean lastEntryRead = new AtomicBoolean();
+            interceptor.onManagedLedgerLastLedgerInitialize("my_test_ledger", () -> {
+                lastEntryRead.set(true);
+                return CompletableFuture.completedFuture(
+                        Optional.of(EntryImpl.create(1L, 0L, lastEntryBuffer)));
+            }).get(5, TimeUnit.SECONDS);
+
+            assertThat(lastEntryRead).as("last entry was read").isFalse();
+            assertThat(interceptor.getIndex()).as("recovered index").isEqualTo(-1L);
+        } finally {
+            lastEntryBuffer.release();
+        }
+    }
+
+    @Test(timeOut = 30000)
+    public void testLastLedgerInitializeRecoversIndexWithIndexInterceptor() throws Exception {
+        ManagedLedgerInterceptorImpl interceptor =
+                new ManagedLedgerInterceptorImpl(getBrokerEntryMetadataInterceptors(), null);
+        ByteBuf lastEntryBuffer = lastEntryBufferWithIndex();
+        try {
+            AtomicBoolean lastEntryRead = new AtomicBoolean();
+            interceptor.onManagedLedgerLastLedgerInitialize("my_test_ledger", () -> {
+                lastEntryRead.set(true);
+                return CompletableFuture.completedFuture(
+                        Optional.of(EntryImpl.create(1L, 0L, lastEntryBuffer)));
+            }).get(5, TimeUnit.SECONDS);
+
+            assertThat(lastEntryRead).as("last entry was read").isTrue();
+            assertThat(interceptor.getIndex()).as("recovered index").isEqualTo(99L);
+        } finally {
+            lastEntryBuffer.release();
+        }
+    }
+
+    /**
+     * Reopens a managed ledger whose entries were written while AppendIndexMetadataInterceptor was
+     * configured, with a configuration where it no longer is. This is how the null
+     * appendIndexMetadataInterceptor is reached in production.
+     */
+    @Test(timeOut = 30000)
+    public void testRecoveryIndexAfterIndexInterceptorRemovedFromConfiguration() throws Exception {
+        final int mockBatchSize = 2;
+        final String ledgerName = "my_recovery_index_without_index_interceptor";
+
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        config.setManagedLedgerInterceptor(
+                new ManagedLedgerInterceptorImpl(getBrokerEntryMetadataInterceptors(), null));
+        ManagedLedger ledger = factory.open(ledgerName, config);
+        ledger.addEntry("dummy-entry-1".getBytes(StandardCharsets.UTF_8), mockBatchSize);
+        assertThat(((ManagedLedgerInterceptorImpl) ledger.getManagedLedgerInterceptor()).getIndex())
+                .as("index of the entry written with the index interceptor configured")
+                .isEqualTo(mockBatchSize - 1);
+        ledger.close();
+
+        // reopen with AppendIndexMetadataInterceptor removed from the configuration while the last entry of
+        // the ledger still carries a BrokerEntryMetadata index
+        ManagedLedgerInterceptorImpl interceptorWithoutIndex = new ManagedLedgerInterceptorImpl(
+                Set.of(new AppendBrokerTimestampMetadataInterceptor()), null);
+        ManagedLedgerConfig configWithoutIndex = new ManagedLedgerConfig();
+        configWithoutIndex.setManagedLedgerInterceptor(interceptorWithoutIndex);
+
+        @Cleanup("shutdown")
+        ManagedLedgerFactoryImpl factory2 = new ManagedLedgerFactoryImpl(metadataStore, bkc);
+        ManagedLedger reopenedLedger = factory2.open(ledgerName, configWithoutIndex);
+        assertThat(reopenedLedger.getNumberOfEntries()).as("entries in the reopened ledger").isEqualTo(1L);
+        assertThat(interceptorWithoutIndex.getIndex()).as("recovered index").isEqualTo(-1L);
+        reopenedLedger.close();
+    }
+
+    // builds an entry buffer carrying a BrokerEntryMetadata index, as a broker configured with
+    // AppendIndexMetadataInterceptor would have written it (100 messages in the entry means index 99)
+    private static ByteBuf lastEntryBufferWithIndex() {
+        ByteBuf entryBuffer = Commands.addBrokerEntryMetadata(
+                Unpooled.wrappedBuffer("message".getBytes(StandardCharsets.UTF_8)),
+                getBrokerEntryMetadataInterceptors(), 100);
+        BrokerEntryMetadata metadata = Commands.peekBrokerEntryMetadataIfExist(entryBuffer);
+        assertThat(metadata).as("broker entry metadata of the entry under test").isNotNull();
+        assertThat(metadata.getIndex()).as("index written into the broker entry metadata").isEqualTo(99L);
+        return entryBuffer;
     }
 
     @Test


### PR DESCRIPTION
Fixes #26496

### Motivation

`ManagedLedgerInterceptorImpl.onManagedLedgerLastLedgerInitialize()` dereferences the nullable field `appendIndexMetadataInterceptor` without a null check:

https://github.com/apache/pulsar/blob/4998cd9e4f66ade6a7972da4afcd0f1546ddfc16/pulsar-broker/src/main/java/org/apache/pulsar/broker/intercept/ManagedLedgerInterceptorImpl.java#L113-L128

The field is null whenever the constructor's interceptor set contains no `AppendIndexMetadataInterceptor`. Every other method of the class that touches the field (`getIndex`, `afterFailedAddEntry`, `onManagedLedgerPropertiesInitialize`, `onUpdateManagedLedgerInfo`) null-checks it first; this one does not.

`BrokerService` installs `ManagedLedgerInterceptorImpl` on every persistent topic when `isBrokerEntryMetadataEnabled() || isBrokerPayloadProcessorEnabled()`, and those predicates are just `!brokerEntryMetadataInterceptors.isEmpty()` / `!brokerEntryPayloadProcessors.isEmpty()`. So the field is null while the interceptor is still installed in two supported configurations:

1. `brokerEntryMetadataInterceptors` contains only `AppendBrokerTimestampMetadataInterceptor`.
2. `brokerEntryMetadataInterceptors` is empty and `brokerEntryPayloadProcessors` is configured — the interceptor set passed to the constructor is then empty.

In either configuration, loading a topic whose last ledger's last entry still carries a `BrokerEntryMetadata` with `hasIndex() == true` throws an NPE inside the `thenAccept` callback. `ManagedLedgerImpl.initialize()` wraps it in `ManagedLedgerInterceptException` and calls `callback.initializeFailed(...)`, so the topic fails to load:

```
org.apache.bookkeeper.mledger.ManagedLedgerException$ManagedLedgerInterceptException: java.lang.NullPointerException: Cannot invoke "org.apache.pulsar.common.intercept.AppendIndexMetadataInterceptor.recoveryIndexGenerator(long)" because "this.appendIndexMetadataInterceptor" is null
Caused by: java.lang.NullPointerException: Cannot invoke "org.apache.pulsar.common.intercept.AppendIndexMetadataInterceptor.recoveryIndexGenerator(long)" because "this.appendIndexMetadataInterceptor" is null
	at org.apache.pulsar.broker.intercept.ManagedLedgerInterceptorImpl.lambda$onManagedLedgerLastLedgerInitialize$0(ManagedLedgerInterceptorImpl.java:121)
	at org.apache.pulsar.common.protocol.Commands.peekBrokerEntryMetadataAndConsume(Commands.java:2244)
	at org.apache.pulsar.broker.intercept.ManagedLedgerInterceptorImpl.lambda$onManagedLedgerLastLedgerInitialize$1(ManagedLedgerInterceptorImpl.java:119)
```

The failure is deterministic and self-repeating rather than transient: the topic cannot be loaded, so no broker can write a non-indexed entry to it, and every retry re-reads the same last entry. The topic stays unavailable until the configuration is reverted.

The realistic trigger is a configuration change over time: an operator removes `AppendIndexMetadataInterceptor` from `brokerEntryMetadataInterceptors` (keeping the timestamp interceptor, or having payload processors configured) and restarts. Every topic written under the old configuration then fails to load. The same happens transiently during a rolling restart, or with a heterogeneous `broker.conf` across the broker pool, where brokers still on the old configuration keep writing indexed entries while topics move to brokers on the new configuration.

This is a regression. The guard existed from #10706 and was preserved by #20112 as `boolean hasAppendIndexMetadataInterceptor = appendIndexMetadataInterceptor != null;`. It was dropped by #23311 (commit 9ebd97941d8e), which rewrote the method onto the new `LastEntryHandle.readLastEntryAsync()` API: the `lh.getLastAddConfirmed() >= 0` half of the old condition was relocated into `ManagedLedgerImpl.createLastEntryHandle` (where it is preserved as `Optional.isPresent()`), but the `appendIndexMetadataInterceptor != null` half was relocated nowhere. `git log -S hasAppendIndexMetadataInterceptor` on the file returns exactly two commits: the one that introduced the guard and #23311 which removed it.

Affected branches, verified against the source on GitHub: `master`, `branch-4.2`, `branch-4.1` and `branch-4.0` are unguarded; `branch-3.3` and `branch-3.0` still carry the guard, so no 3.x backport is needed. The first release containing #23311 is 4.0.0.

### Modifications

- `ManagedLedgerInterceptorImpl.onManagedLedgerLastLedgerInitialize` returns a completed future immediately when `appendIndexMetadataInterceptor` is null, restoring the pre-#23311 behaviour. Reading the last entry is skipped entirely rather than guarded inside the callback: with no index generator to recover into, the read has no possible effect, and skipping it also removes a pointless last-entry read from the topic recovery path for every topic on brokers configured that way. The path where the interceptor is present is untouched.
- Annotated the field with JSpecify `@Nullable` to document the invariant that was violated.

The same guard also covers the shadow-topic path: `ShadowManagedLedgerImpl.doInitialize` calls the same method on the source ledger.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

Three tests were added to `ManagedLedgerInterceptorImplTest`:

- `testLastLedgerInitializeSkipsIndexRecoveryWithoutIndexInterceptor` — a `@DataProvider` covers both null-field configurations (timestamp interceptor only, and an empty interceptor set). It stubs `LastEntryHandle` with an entry carrying a `BrokerEntryMetadata` index and asserts that the returned future completes normally and that the last entry was not read at all, which pins the guard's placement before `readLastEntryAsync()` rather than merely the absence of an NPE.
- `testLastLedgerInitializeRecoversIndexWithIndexInterceptor` — the positive control: with `AppendIndexMetadataInterceptor` configured, the last entry is still read and the index is still recovered.
- `testRecoveryIndexAfterIndexInterceptorRemovedFromConfiguration` — reproduces the production scenario end to end through `ManagedLedgerImpl.initialize`: write entries with the index interceptor configured, close, then reopen with it removed.

All three fail on the unpatched code for the real reason. Reverting only the guard makes `testRecoveryIndexAfterIndexInterceptorRemovedFromConfiguration` fail with the `ManagedLedgerInterceptException` shown above, and both data-provider cases of `testLastLedgerInitializeSkipsIndexRecoveryWithoutIndexInterceptor` fail with the NPE.

With the fix, `ManagedLedgerInterceptorImplTest` (12 tests), `MangedLedgerInterceptorImpl2Test` and `BrokerEntryMetadataE2ETest` (15 tests) all pass.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
