### PR TITLE
[improve][ml] Back LongBitmap with the on-heap RoaringBitmap to fix ack allocation hotspot

### DIFF
--- a/microbench/src/main/java/org/apache/bookkeeper/mledger/impl/PositionRangeSetBenchmark.java
+++ b/microbench/src/main/java/org/apache/bookkeeper/mledger/impl/PositionRangeSetBenchmark.java
@@ -47,6 +47,11 @@ import org.openjdk.jmh.infra.Blackhole;
  * <pre>{@code
  * ./gradlew :microbench:shadowJar
  * java -jar microbench/build/libs/microbench-*-benchmarks.jar PositionRangeSetBenchmark
+ *
+ * # Allocation profile of the individual-ack path (addOpenClosedSameLedger issues a
+ * # one-wide range add per ack, the shape that dominates cursor allocation):
+ * java -jar microbench/build/libs/microbench-*-benchmarks.jar \
+ *     PositionRangeSetBenchmark.addOpenClosedSameLedger -prof gc
  * }</pre>
  */
 @BenchmarkMode(Mode.Throughput)

--- a/microbench/src/main/java/org/apache/pulsar/common/util/collections/LongBitmapBenchmark.java
+++ b/microbench/src/main/java/org/apache/pulsar/common/util/collections/LongBitmapBenchmark.java
@@ -91,6 +91,17 @@ public class LongBitmapBenchmark {
 
     @Benchmark
     @Threads(1)
+    public void longBitmapAddSingleValueRangeSingleThread() {
+        // The shape PositionRangeSet.addOpenClosed issues for an individually acked message:
+        // a one-wide range, not a point add. Every other benchmark here uses checkedAdd, which
+        // was already on the amortized growth path, so none of them could observe the
+        // container-growth regression this benchmark exists to guard.
+        long v = nextValue.getAndIncrement();
+        longBitmap.add(v, v + 1);
+    }
+
+    @Benchmark
+    @Threads(1)
     public boolean roaringBitmapAddSingleThread() {
         long v = nextValue.getAndIncrement();
         return roaringBitmap.checkedAdd((int) v);

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentRoaringBitmap.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentRoaringBitmap.java
@@ -27,25 +27,45 @@ import java.util.function.LongConsumer;
 import org.roaringbitmap.BitSetUtil;
 import org.roaringbitmap.PeekableIntIterator;
 import org.roaringbitmap.RoaringBitmap;
-import org.roaringbitmap.buffer.MutableRoaringBitmap;
 
 /**
- * {@link LongBitmap} implementation backed by {@link MutableRoaringBitmap} and guarded
- * by a {@link StampedLock}.
+ * {@link LongBitmap} implementation backed by {@link RoaringBitmap} and guarded by a
+ * {@link StampedLock}.
+ *
+ * <p><b>Why the on-heap variant.</b> {@link RoaringBitmap} stores each container in a plain
+ * {@code char[]}/{@code long[]}. Its {@code org.roaringbitmap.buffer.MutableRoaringBitmap}
+ * counterpart stores them in NIO buffers, which exists so that a bitmap can be read straight out
+ * of a memory-mapped {@link ByteBuffer}. Pulsar never memory-maps a bitmap and never hands one out
+ * as a zero-copy read-only view, so it paid the indirection for nothing: the buffer variant's
+ * {@code MappeableArrayContainer.iadd} reallocates its container to exactly the new cardinality
+ * with no growth headroom, so appending one value at a time through {@link #add(long, long)} — the
+ * shape an individual message acknowledgement produces — reallocated on every single call, while
+ * {@code ArrayContainer.iadd} grows geometrically. Both variants share the portable serialization
+ * format, so persisted cursor state and delayed-delivery snapshots round-trip across this choice in
+ * both directions.
  *
  * <p><b>Thread-safety basis.</b> RoaringBitmap is not thread-safe by default
- * (see <a href="https://github.com/apache/pulsar/issues/25991">pulsar#25991</a>). This
- * wrapper relies on the documented contract that {@link MutableRoaringBitmap}'s read
- * methods — the {@code ImmutableBitmapDataProvider} surface inherited from
- * {@code ImmutableRoaringBitmap} — do not mutate internal state, while methods added by
- * {@code BitmapDataProvider} and other {@code MutableRoaringBitmap} mutators
- * ({@code andNot}, {@code or}, {@code checkedRemove}, {@code runOptimize}, {@code clone},
- * ...) do. Read methods run under the read lock; mutators under the write lock.
- * {@code clone()} is used under the read lock in {@link #forEachLong} and {@link #serialize};
- * its source has been audited to be read-only on the live bitmap. <b>Before upgrading
- * the RoaringBitmap dependency or changing the lock split</b>, re-audit these methods
- * and run the concurrency regression tests ({@code testConcurrentForEachLongAndMutate},
- * {@code testOrDoesNotMutateInput}).
+ * (see <a href="https://github.com/apache/pulsar/issues/25991">pulsar#25991</a>).
+ * {@link RoaringBitmap} is a single class implementing both {@code ImmutableBitmapDataProvider} and
+ * {@code BitmapDataProvider}, so the type system does not separate readers from mutators here — the
+ * split below is maintained by audit rather than by the compiler. Under the READ lock this class
+ * calls only {@code contains(int)}, {@code contains(long, long)}, {@code getLongCardinality()},
+ * {@code isEmpty()}, {@code rank(int)}, {@code nextValue(int)}, {@code previousValue(int)},
+ * {@code nextAbsentValue(int)}, {@code previousAbsentValue(int)}, {@code serializedSizeInBytes()},
+ * {@code clone()} and {@link BitSetUtil#toLongArray(RoaringBitmap)}; each was verified to read
+ * {@code highLowContainer} and its containers without writing to either. Everything that mutates —
+ * {@code add}, {@code checkedAdd}, {@code checkedRemove}, {@code remove}, {@code clear},
+ * {@code or}, {@code andNot}, {@code runOptimize}, {@code trim}, {@code getIntIterator} (used by
+ * {@link #drainTo} alongside the removal it feeds) and {@code deserialize} — runs under the WRITE
+ * lock. {@code clone()} is used under the read lock in {@link #forEachLong} and {@link #serialize};
+ * {@code runOptimize()} and {@code serialize(ByteBuffer)} then run on that clone with no lock held.
+ * <b>Before upgrading the RoaringBitmap dependency or changing the lock split</b>, re-audit that
+ * list and run the concurrency regression tests ({@code testConcurrentForEachLongAndMutate},
+ * {@code testOrDoesNotMutateInput}, {@code testConcurrentSerializeToLongArray}).
+ *
+ * <p>The instance must be a plain {@link RoaringBitmap}, never {@code FastRankRoaringBitmap}: the
+ * latter memoizes cardinalities inside {@code rank}/{@code select}, which would turn a read-lock
+ * call into a data race.
  *
  * <p><b>Critical sections.</b> Single-value reads take the read lock; mutations take the
  * write lock. Bulk mutations that touch two bitmaps ({@link #or}) acquire this bitmap's
@@ -54,9 +74,9 @@ import org.roaringbitmap.buffer.MutableRoaringBitmap;
  * ({@link #serialize}, {@link #forEachLong}) clones under a brief read lock and finishes
  * without holding it, so optimize/iterate/runOptimize don't block writers.
  *
- * <p><b>Memory.</b> {@link MutableRoaringBitmap#trim()} fires when removals since the
- * last trim reach {@link #TRIM_AFTER_REMOVES}, or whenever the bitmap becomes empty.
- * {@link #serialize} runs {@code runOptimize()} on the clone so persisted bytes are compact.
+ * <p><b>Memory.</b> {@link RoaringBitmap#trim()} fires when removals since the last trim reach
+ * {@link #TRIM_AFTER_REMOVES}, or whenever the bitmap becomes empty. {@link #serialize} runs
+ * {@code runOptimize()} on the clone so persisted bytes are compact.
  */
 class ConcurrentRoaringBitmap implements LongBitmap {
 
@@ -64,18 +84,34 @@ class ConcurrentRoaringBitmap implements LongBitmap {
     private static final long UINT32_SIZE = 1L << 32;
     private static final long MAX_UINT32 = UINT32_SIZE - 1;
 
-    private final MutableRoaringBitmap bitmap;
+    private final RoaringBitmap bitmap;
     private final StampedLock lock;
     private long removesSinceTrim;
 
     ConcurrentRoaringBitmap() {
-        this.bitmap = new MutableRoaringBitmap();
+        this(new RoaringBitmap());
+    }
+
+    private ConcurrentRoaringBitmap(RoaringBitmap bitmap) {
+        this.bitmap = bitmap;
         this.lock = new StampedLock();
     }
 
-    private ConcurrentRoaringBitmap(MutableRoaringBitmap bitmap) {
-        this.bitmap = bitmap;
-        this.lock = new StampedLock();
+    /**
+     * Creates a bitmap holding the values encoded in {@code data}, in the
+     * {@link java.util.BitSet#toLongArray()} format produced by {@link #serializeToLongArray()}.
+     *
+     * <p>{@link BitSetUtil#bitmapOf(long[])} already builds every container at its exact block
+     * cardinality, so adopting its result avoids the empty-bitmap plus {@code clear()} plus
+     * {@code or()} round trip that the instance method {@link #deserializeFromLongArray(long[])}
+     * cannot avoid — {@link #bitmap} is {@code final}, because {@link #or} reads its identity
+     * without holding a lock to order the two locks it acquires.
+     *
+     * @param data long array in BitSet format
+     * @return a new bitmap containing exactly the values encoded in {@code data}
+     */
+    static ConcurrentRoaringBitmap fromLongArray(long[] data) {
+        return new ConcurrentRoaringBitmap(BitSetUtil.bitmapOf(data));
     }
 
     @Override
@@ -109,7 +145,19 @@ class ConcurrentRoaringBitmap implements LongBitmap {
         validateRange(to - 1);
         long stamp = lock.writeLock();
         try {
-            bitmap.add(from, to);
+            if (to - from == 1) {
+                // Single-value ranges dominate the acknowledgement path: PositionRangeSet
+                // .addOpenClosed issues add(entryId, entryId + 1) for every individually acked
+                // message. add(int) seeds a brand-new container at ArrayContainer's default
+                // capacity, while add(long, long) seeds it through Container.rangeOfOnes at
+                // exactly 1 and then has to grow on the next value. The two are equivalent for a
+                // one-wide range: rangeOfOnes returns an ArrayContainer for cardinality <= 2, the
+                // same class add(int) creates, and both convert to a bitmap container at
+                // cardinality 4096. Must stay inside the lock and after both validateRange calls.
+                bitmap.add((int) from);
+            } else {
+                bitmap.add(from, to);
+            }
         } finally {
             lock.unlockWrite(stamp);
         }
@@ -339,13 +387,18 @@ class ConcurrentRoaringBitmap implements LongBitmap {
 
     @Override
     public void forEachLong(LongConsumer action) {
-        MutableRoaringBitmap snapshot;
+        RoaringBitmap snapshot;
         long stamp = lock.readLock();
         try {
+            if (bitmap.isEmpty()) {
+                return;
+            }
             snapshot = bitmap.clone();
         } finally {
             lock.unlockRead(stamp);
         }
+        // The cast is load-bearing: RoaringBitmap also implements Iterable<Integer>, so an
+        // uncast lambda binds to Iterable.forEach(Consumer<? super Integer>) and boxes every value.
         snapshot.forEach((org.roaringbitmap.IntConsumer) v ->
                 action.accept(Integer.toUnsignedLong(v)));
     }
@@ -355,7 +408,7 @@ class ConcurrentRoaringBitmap implements LongBitmap {
         if (limit <= 0) {
             return 0;
         }
-        MutableRoaringBitmap toRemove = new MutableRoaringBitmap();
+        RoaringBitmap toRemove = new RoaringBitmap();
         long collected;
         long writeStamp = lock.writeLock();
         try {
@@ -392,7 +445,7 @@ class ConcurrentRoaringBitmap implements LongBitmap {
 
     @Override
     public byte[] serialize() {
-        MutableRoaringBitmap copy;
+        RoaringBitmap copy;
         long stamp = lock.readLock();
         try {
             copy = bitmap.clone();
@@ -409,8 +462,12 @@ class ConcurrentRoaringBitmap implements LongBitmap {
     public long[] serializeToLongArray() {
         long stamp = lock.readLock();
         try {
-            RoaringBitmap immutable = bitmap.toRoaringBitmap();
-            return BitSetUtil.toLongArray(immutable);
+            // BitSetUtil.toLongArray only reads the bitmap (isEmpty / last / getContainerPointer /
+            // Container.copyBitmapTo, all of which write solely into the returned array), so it is
+            // correct against the live instance under the read lock. Do not reintroduce a
+            // defensive copy: MutableRoaringBitmap.toRoaringBitmap(), which this replaced,
+            // advanced the live containers' buffer positions and so mutated under the read lock.
+            return BitSetUtil.toLongArray(bitmap);
         } finally {
             lock.unlockRead(stamp);
         }
@@ -418,11 +475,13 @@ class ConcurrentRoaringBitmap implements LongBitmap {
 
     @Override
     public void deserializeFromLongArray(long[] data) {
+        // Built outside the lock: BitSetUtil.bitmapOf reads only the caller-owned long[] and the
+        // result is thread-confined until it is merged in below.
+        RoaringBitmap replacement = BitSetUtil.bitmapOf(data);
         long stamp = lock.writeLock();
         try {
             bitmap.clear();
-            RoaringBitmap rb = BitSetUtil.bitmapOf(data);
-            bitmap.or(rb.toMutableRoaringBitmap());
+            bitmap.or(replacement);
             removesSinceTrim = 0;
         } finally {
             lock.unlockWrite(stamp);
@@ -433,7 +492,10 @@ class ConcurrentRoaringBitmap implements LongBitmap {
         try {
             ByteBuffer nioBuffer = buf.nioBuffer(buf.readerIndex(), buf.readableBytes());
             int startPosition = nioBuffer.position();
-            MutableRoaringBitmap bitmap = new MutableRoaringBitmap();
+            RoaringBitmap bitmap = new RoaringBitmap();
+            // Deliberately the DataInput overload: RoaringBitmap.deserialize(ByteBuffer) slices its
+            // argument and leaves the caller's position untouched, which would break the
+            // skipBytes accounting below.
             bitmap.deserialize(new ByteBufferDataInput(nioBuffer));
             buf.skipBytes(nioBuffer.position() - startPosition);
             return new ConcurrentRoaringBitmap(bitmap);

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/LongBitmaps.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/LongBitmaps.java
@@ -70,8 +70,6 @@ public final class LongBitmaps {
      * @return a new LongBitmap containing the deserialized values
      */
     public static LongBitmap deserializeFromLongArray(long[] data) {
-        LongBitmap bitmap = create();
-        bitmap.deserializeFromLongArray(data);
-        return bitmap;
+        return ConcurrentRoaringBitmap.fromLongArray(data);
     }
 }

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/LongBitmapCompatibilityTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/LongBitmapCompatibilityTest.java
@@ -85,6 +85,72 @@ public class LongBitmapCompatibilityTest {
     }
 
     /**
+     * Golden on-disk bytes, captured from the implementation before it moved to the on-heap
+     * {@code org.roaringbitmap.RoaringBitmap}. {@link #testLongBitmapBufferEqualsStandardRoaringBitmap}
+     * compares {@link LongBitmap} against {@code org.roaringbitmap.RoaringBitmap}, so once
+     * {@code ConcurrentRoaringBitmap} is itself backed by that class the comparison no longer pins
+     * the format against an independent reference. These literals do, and they must not change:
+     * the cursor's individually-deleted ranges and the delayed-delivery bucket snapshots are
+     * persisted in exactly this format.
+     */
+    private static final byte[] GOLDEN_POINTS = {
+            (byte) 0x3A, (byte) 0x30, (byte) 0x00, (byte) 0x00, (byte) 0x03, (byte) 0x00,
+            (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x01, (byte) 0x00,
+            (byte) 0x10, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0xFF, (byte) 0xFF,
+            (byte) 0x00, (byte) 0x00, (byte) 0x20, (byte) 0x00, (byte) 0x00, (byte) 0x00,
+            (byte) 0x24, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x26, (byte) 0x00,
+            (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x64, (byte) 0x00,
+            (byte) 0x00, (byte) 0x00, (byte) 0xFF, (byte) 0xFF,
+    };
+
+    private static final byte[] GOLDEN_RUN = {
+            (byte) 0x3B, (byte) 0x30, (byte) 0x00, (byte) 0x00, (byte) 0x01, (byte) 0x00,
+            (byte) 0x00, (byte) 0x87, (byte) 0x13, (byte) 0x01, (byte) 0x00, (byte) 0x00,
+            (byte) 0x00, (byte) 0x87, (byte) 0x13,
+    };
+
+    /**
+     * Pins the persisted format against literals rather than against another RoaringBitmap
+     * instance, so it keeps its meaning across a change of backing implementation.
+     */
+    @Test
+    public void testSerializedFormatMatchesGoldenBytes() {
+        LongBitmap points = LongBitmaps.create();
+        points.add(0);
+        points.add(100);
+        points.add(1L << 20);
+        points.add(0xFFFFFFFFL);
+        assertEquals(points.serialize(), GOLDEN_POINTS,
+                "persisted format changed for sparse points");
+
+        // A contiguous run exercises runOptimize(), which serialize() applies to its clone —
+        // the one place a container-representation change would surface in persisted bytes.
+        LongBitmap run = LongBitmaps.create();
+        for (int i = 0; i < 5000; i++) {
+            run.add(i);
+        }
+        assertEquals(run.serialize(), GOLDEN_RUN, "persisted format changed for a contiguous run");
+    }
+
+    /**
+     * The golden bytes must also read back. Guards the deserialize side of the format, including
+     * that {@code readerIndex} advances by exactly the payload length.
+     */
+    @Test
+    public void testGoldenBytesRoundTrip() {
+        for (byte[] golden : new byte[][]{GOLDEN_POINTS, GOLDEN_RUN}) {
+            ByteBuf buf = Unpooled.wrappedBuffer(golden);
+            try {
+                LongBitmap restored = LongBitmaps.deserialize(buf);
+                assertEquals(restored.serialize(), golden);
+                assertEquals(buf.readableBytes(), 0, "readerIndex must advance by the payload");
+            } finally {
+                buf.release();
+            }
+        }
+    }
+
+    /**
      * Round-trip: 32-bit RoaringBitmap buffer -> LongBitmap. Confirms that
      * persisted data written by the old code path can be read by LongBitmap.
      */
@@ -140,7 +206,7 @@ public class LongBitmapCompatibilityTest {
     /**
      * Roaring64Bitmap buffer cannot be deserialized as a LongBitmap.
      * Roaring64Bitmap's serialized format starts with a bucket count, not the
-     * 32-bit cookie (12346), so {@code MutableRoaringBitmap.deserialize} throws.
+     * 32-bit cookie (12346), so {@code RoaringBitmap.deserialize} throws.
      */
     @Test
     public void testRoaring64BufferNotReadableAsLongBitmap() throws Exception {
@@ -153,7 +219,7 @@ public class LongBitmapCompatibilityTest {
 
         ByteBuf buf = Unpooled.wrappedBuffer(roaring64Bytes);
         try {
-            // MutableRoaringBitmap wraps IOException as RuntimeException.
+            // RoaringBitmap wraps IOException as RuntimeException.
             assertThrows(Exception.class, () -> LongBitmaps.deserialize(buf));
         } finally {
             buf.release();

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/LongBitmapTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/LongBitmapTest.java
@@ -25,6 +25,7 @@ import static org.testng.Assert.assertTrue;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -488,21 +489,141 @@ public class LongBitmapTest {
 
     @Test
     public void testRangeVsSingleValueEquivalence() {
-        // For any v, add(v, v+1) / contains(v, v+1) / remove(v, v+1) ≡ add(v) / contains(v) / remove(v).
+        // For any v, add(v, v+1) / remove(v, v+1) is equivalent to add(v) / remove(v).
         long[] values = {0, 1, 100, 65535, 65536, 1L << 30, 0xFFFFFFFFL};
         for (long v : values) {
-            LongBitmap bitmap = LongBitmaps.create();
-            bitmap.add(v);
-            assertTrue(bitmap.contains(v));
-            assertEquals(bitmap.cardinality(), 1);
+            LongBitmap viaRange = LongBitmaps.create();
+            LongBitmap viaPoint = LongBitmaps.create();
 
-            bitmap.add(v);  // idempotent
-            assertEquals(bitmap.cardinality(), 1);
+            viaRange.add(v, v + 1);
+            viaPoint.add(v);
+            assertTrue(viaRange.contains(v));
+            assertEquals(viaRange.cardinality(), 1);
+            assertEquals(viaRange.serialize(), viaPoint.serialize());
 
-            bitmap.remove(v);
-            assertFalse(bitmap.contains(v));
-            assertEquals(bitmap.cardinality(), 0);
+            viaRange.add(v, v + 1);  // idempotent
+            viaPoint.add(v);
+            assertEquals(viaRange.cardinality(), 1);
+            assertEquals(viaPoint.cardinality(), 1);
+
+            assertTrue(viaRange.remove(v, v + 1));
+            assertTrue(viaPoint.remove(v));
+            assertFalse(viaRange.contains(v));
+            assertEquals(viaRange.cardinality(), 0);
+            assertEquals(viaRange.serialize(), viaPoint.serialize());
         }
+        // Note: contains(v, v + 1) is deliberately not asserted here — see
+        // testUint32BoundaryRange for the documented false-negative at the uint32 boundary.
+    }
+
+    @Test
+    public void testSingleValueRangeAddMatchesPointAdd() {
+        // add(v, v + 1) must be indistinguishable from add(v) through the whole LongBitmap
+        // surface, including persisted bytes. Each seed crosses the 4096 array-to-bitmap
+        // container conversion, and the last one reaches the uint32 boundary where
+        // (int) from == -1.
+        long[] seeds = {0, 1, 4090, 65530, 1L << 20, 0x7FFFF000L, 0xFFFFFFFFL - 8200};
+        for (long seed : seeds) {
+            LongBitmap viaRange = LongBitmaps.create();
+            LongBitmap viaPoint = LongBitmaps.create();
+            for (int i = 0; i < 8300; i++) {
+                long v = seed + i;
+                if (v > 0xFFFFFFFFL) {
+                    break;
+                }
+                viaRange.add(v, v + 1);
+                viaPoint.add(v);
+                assertEquals(viaRange.cardinality(), viaPoint.cardinality(),
+                        "seed " + seed + " i " + i);
+            }
+            assertEquals(viaRange.serialize(), viaPoint.serialize(), "seed " + seed);
+            assertEquals(viaRange.serializedSize(), viaPoint.serializedSize());
+            assertEquals(viaRange.lastPresentValue(), viaPoint.lastPresentValue());
+            for (int i = 0; i < 8300; i += 97) {
+                long v = seed + i;
+                if (v > 0xFFFFFFFFL) {
+                    break;
+                }
+                assertEquals(viaRange.rank(v + 1), viaPoint.rank(v + 1));
+                assertEquals(viaRange.nextAbsentValue(v), viaPoint.nextAbsentValue(v));
+                assertEquals(viaRange.nextPresentValue(v), viaPoint.nextPresentValue(v));
+            }
+        }
+    }
+
+    @Test
+    public void testCapacitySlackIsNotObservable() {
+        // The backing container is grown geometrically and shrunk on removal, so its capacity
+        // can exceed its cardinality. Nothing observable through LongBitmap may depend on that:
+        // serialization writes exactly `cardinality` values.
+        LongBitmap withSlack = LongBitmaps.create();
+        for (int i = 0; i < 3000; i++) {
+            withSlack.add(i * 2L);
+        }
+        for (int i = 0; i < 1500; i++) {
+            withSlack.remove(i * 2L);
+        }
+        LongBitmap fresh = LongBitmaps.create();
+        for (int i = 1500; i < 3000; i++) {
+            fresh.add(i * 2L);
+        }
+        assertEquals(withSlack.cardinality(), fresh.cardinality());
+        assertEquals(withSlack.serializedSize(), fresh.serializedSize());
+        assertEquals(withSlack.serialize(), fresh.serialize());
+        assertEquals(withSlack.serializeToLongArray(), fresh.serializeToLongArray());
+
+        LongBitmap grown = LongBitmaps.create();
+        for (int i = 0; i < 5000; i++) {
+            grown.add(i, i + 1L);
+        }
+        LongBitmap pointBuilt = LongBitmaps.create();
+        for (int i = 0; i < 5000; i++) {
+            pointBuilt.add(i);
+        }
+        assertEquals(grown.serialize(), pointBuilt.serialize());
+        assertEquals(grown.serializeToLongArray(), pointBuilt.serializeToLongArray());
+    }
+
+    @Test
+    public void testConcurrentSerializeToLongArray() throws Exception {
+        // serializeToLongArray() runs under the READ lock, so concurrent callers must not
+        // interfere. This fails if the implementation ever reintroduces a conversion that
+        // mutates the live bitmap (the previous MutableRoaringBitmap.toRoaringBitmap() advanced
+        // each container's NIO buffer position and produced BufferUnderflowException here).
+        LongBitmap bitmap = LongBitmaps.create();
+        for (int i = 0; i < 60000; i += 2) {
+            bitmap.add(i);
+        }
+        long[] expected = bitmap.serializeToLongArray();
+
+        int threads = 8;
+        int iterations = 4000;
+        ExecutorService executor = Executors.newFixedThreadPool(threads);
+        AtomicInteger errors = new AtomicInteger();
+        AtomicInteger mismatches = new AtomicInteger();
+        CountDownLatch latch = new CountDownLatch(threads);
+        try {
+            for (int t = 0; t < threads; t++) {
+                executor.submit(() -> {
+                    try {
+                        for (int i = 0; i < iterations; i++) {
+                            if (!Arrays.equals(bitmap.serializeToLongArray(), expected)) {
+                                mismatches.incrementAndGet();
+                            }
+                        }
+                    } catch (Throwable e) {
+                        errors.incrementAndGet();
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+            assertTrue(latch.await(60, TimeUnit.SECONDS));
+        } finally {
+            executor.shutdownNow();
+        }
+        assertEquals(errors.get(), 0, "serializeToLongArray threw under concurrent readers");
+        assertEquals(mismatches.get(), 0, "serializeToLongArray returned a corrupt array");
     }
 
     @Test
@@ -698,7 +819,7 @@ public class LongBitmapTest {
     public void testUint32BoundaryRange() {
         // Verify range APIs handle the uint32 upper boundary correctly.
         // add(MAX_UINT32, MAX_UINT32+1) should add exactly one value: MAX_UINT32.
-        // Note: MutableRoaringBitmap.contains(long, long) has a known issue at this
+        // Note: RoaringBitmap.contains(long, long) has a known issue at this
         // boundary where it returns false even when the value is present, so we only
         // test contains(long) single-value form and cardinality.
         LongBitmap bitmap = LongBitmaps.create();


### PR DESCRIPTION
### Motivation

Allocation profiling of a busy broker attributed **74.8% of sampled allocations** to a single frame under the message-acknowledgement path:

```
java.nio.HeapCharBuffer.<init>
java.nio.CharBuffer.allocate(int)
org.roaringbitmap.buffer.MappeableArrayContainer.iadd(int, int)
org.roaringbitmap.buffer.MutableRoaringBitmap.add(long, long)
org.apache.pulsar.common.util.collections.ConcurrentRoaringBitmap.add(long, long)
org.apache.bookkeeper.mledger.impl.PositionRangeSet.addOpenClosed(long, long, long, long)
org.apache.bookkeeper.mledger.impl.ManagedCursorImpl.asyncDelete(...)
org.apache.pulsar.broker.service.PersistentSubscription.acknowledgeMessageAsync(...)
org.apache.pulsar.broker.service.Consumer.individualAck(...)
org.apache.pulsar.broker.service.ServerCnx.handleAck(CommandAck)
```

The cause is not a missing capacity hint — it is a missing growth factor in one method of RoaringBitmap's `buffer` package. `MappeableArrayContainer.iadd` reallocates its content buffer to *exactly* the new cardinality, with no headroom:

```java
// org.roaringbitmap.buffer.MappeableArrayContainer#iadd
CharBuffer destination = CharBuffer.allocate(newcardinality);
```

while the on-heap twin grows geometrically:

```java
// org.roaringbitmap.ArrayContainer#iadd
char[] destination = new char[calculateCapacity(newcardinality)];
```

`MappeableArrayContainer` defines its own `calculateCapacity(int min)` and calls it from `increaseCapacity`, but not from `iadd`. Since `PositionRangeSet.addOpenClosed` issues `add(entryId, entryId + 1)` — a one-wide range — for every individually acknowledged message, each ack reallocated the container's whole backing buffer, giving O(n) allocations and O(n²) copying while an array container fills.

The `buffer` package exists so a bitmap can be read straight out of a memory-mapped `ByteBuffer`. Pulsar never memory-maps a bitmap and never hands one out as a zero-copy read-only view, so it was paying for the indirection and getting the pathological growth in return.

### Modifications

- Retype `ConcurrentRoaringBitmap`'s backing bitmap from `org.roaringbitmap.buffer.MutableRoaringBitmap` to `org.roaringbitmap.RoaringBitmap`, and rewrite the class javadoc's thread-safety section for the new class. `RoaringBitmap` implements both `ImmutableBitmapDataProvider` and `BitmapDataProvider`, so the reader/mutator split is no longer expressed in the type system; the javadoc now enumerates exactly which methods run under which lock, and records that the instance must never be a `FastRankRoaringBitmap` (it memoizes inside `rank`/`select`).
- Route one-wide ranges in `add(long, long)` to `add(int)`, which seeds a new container at `ArrayContainer`'s default capacity rather than at exactly 1 via `Container.rangeOfOnes`.
- Drop two whole-bitmap container copies the migration makes unnecessary: `toRoaringBitmap()` in `serializeToLongArray()` and `toMutableRoaringBitmap()` in `deserializeFromLongArray()`.
- Route `LongBitmaps.deserializeFromLongArray` through a new package-private `ConcurrentRoaringBitmap.fromLongArray`, which adopts the exactly-sized containers `BitSetUtil.bitmapOf` already builds instead of going through an empty bitmap plus `clear()` plus `or()`.

**This also removes a read-lock violation that exists on master today.** `serializeToLongArray()` ran `toRoaringBitmap()` under the *read* lock. That reaches `MappeableArrayContainer.toShortArray()`, which does `content.rewind()` followed by `content.get(...)` — advancing the live container's buffer position while other readers hold the same lock. Reproduced standalone: **7 `BufferUnderflowException` across 8 threads × 4000 iterations before this change, 0 after.** `clone()` was never affected; it calls `duplicate()` first, with the comment *"for thread-safety"*.

The portable serialized format is identical between the two packages, so persisted cursor state and delayed-delivery bucket snapshots round-trip in both directions across this change — including during a rolling upgrade or downgrade.

Measured with `ThreadMXBean.getCurrentThreadAllocatedBytes`, filling one container with sequential single-value range adds:

| values | before | after | factor |
|---|---|---|---|
| 1,000 | 1,076,120 B | 6,752 B | 159× |
| 4,096 | 17,088,632 B | 37,464 B | 456× |
| 10,000 | 17,096,920 B | 45,696 B | 374× |
| 200,000 | 63,054,032 B | 174,248 B | 362× |

The plateau at ~17.1 MB is `ArrayContainer.DEFAULT_MAX_SIZE = 4096`: past that the container becomes a bitmap container and stops reallocating, so the win scales with how many 16-bit blocks churn through the 0..4096 band — and it restarts on every drain/refill cycle, which is why this is a steady-state cost rather than a startup one.

#### On adding a size parameter to `LongBitmaps.create` / `deserialize`

Considered and deliberately not done — no public API is added:

- A construction-time hint can only size the container *directory* (`char[] keys` + `Container[] values`, ~6 bytes per container), never the content buffer that was actually hot. Measured: 50,000 acks cost 17,096,920 B at the default capacity 4, 17,097,416 B presized to 64, and 17,103,040 B presized to 1024.
- After this change there is no public constructor hook at all: `RoaringArray(int)`, `RoaringBitmap(int)` and `RoaringBitmap(RoaringArray)` are all package-private. The only public route, `RoaringBitmapWriter.writer().initialCapacity(n)`, calls `sanityCheck` which **throws** `IllegalArgumentException` for `n >= 0xFFFF`. Since the parameter's real unit is "distinct high-16-bit prefixes", the natural reading — `create(50000)` for a 50,000-entry ledger — would throw.
- A hint on `deserialize` is a no-op by construction: `RoaringArray.deserialize(DataInput)` opens with `clear()` (which nulls `keys`/`values`) and then sizes both arrays exactly from the serialized cookie's container count.
- `RoaringBitmapWriter` measured **3.5× worse** than plain `add()` for a dense ascending build at n=5000, and its ascending-order contract is violated by the ack path by construction.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

```shell
./gradlew quickCheck
./gradlew spotlessCheck checkstyleMain checkstyleTest
./gradlew :pulsar-common:test --tests 'org.apache.pulsar.common.util.collections.LongBitmapTest'
./gradlew :pulsar-common:test --tests 'org.apache.pulsar.common.util.collections.LongBitmapCompatibilityTest'
./gradlew :managed-ledger:test --tests 'org.apache.bookkeeper.mledger.impl.PositionRangeSetTest'
./gradlew :managed-ledger:test --tests 'org.apache.bookkeeper.mledger.impl.PositionRangeSetCompatibilityTest'
./gradlew :managed-ledger:test --tests 'org.apache.bookkeeper.mledger.impl.ManagedCursorTest'
./gradlew :pulsar-broker:test --tests 'org.apache.pulsar.broker.delayed.bucket.BucketDelayedDeliveryTrackerTest'
./gradlew :pulsar-broker:test --tests 'org.apache.pulsar.broker.delayed.bucket.BucketDelayedMessageIndexTest'
./gradlew :pulsar-broker:test --tests 'org.apache.pulsar.broker.delayed.InMemoryDeliveryTrackerTest'
./gradlew :pulsar-broker:test --tests 'org.apache.pulsar.broker.service.DrainingHashesTrackerTest'
./gradlew :pulsar-broker:test --tests 'org.apache.pulsar.broker.service.ConsumerNameIndexTrackerTest'
```

364 tests, 0 failures locally.

New tests:

- `LongBitmapTest.testConcurrentSerializeToLongArray` — **fails on master, passes with this change**; it is the regression gate for the read-lock violation described above.
- `LongBitmapTest.testSingleValueRangeAddMatchesPointAdd` — `add(v, v+1)` must be indistinguishable from `add(v)` across the whole `LongBitmap` surface including persisted bytes, over 7 seeds × 8,300 values that cross the 4096 array→bitmap container conversion and reach the uint32 boundary where `(int) from == -1`.
- `LongBitmapTest.testCapacitySlackIsNotObservable` — geometric growth means capacity can exceed cardinality; nothing observable may depend on that.
- `LongBitmapCompatibilityTest.testSerializedFormatMatchesGoldenBytes` / `testGoldenBytesRoundTrip` — the pre-existing `testLongBitmapBufferEqualsStandardRoaringBitmap` compares `LongBitmap` against `org.roaringbitmap.RoaringBitmap`, so once `ConcurrentRoaringBitmap` *is* that class the comparison stops pinning anything against an independent reference. These fixtures were captured from the **pre-migration** implementation and pin the format against literals instead.

`LongBitmapTest.testRangeVsSingleValueEquivalence` is repaired rather than added: its comment promised `add(v, v+1)` / `remove(v, v+1)` equivalence, but its body only ever exercised `add(v)` / `remove(v)`, so it pinned nothing on the API this change touches.

`BucketDelayedDeliveryTrackerTest` is the one worth watching — it is the only remaining `org.roaringbitmap.buffer` reference in the repository, reading `LongBitmap` output back through `ImmutableRoaringBitmap`, and it passes unchanged. That is independent confirmation that the on-disk format did not move.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

Nothing is checked, with two notes for reviewers:

- **Dependencies** — RoaringBitmap was already a dependency at the same version; only which of its two packages is used has changed. No version or coordinate moves.
- **Threading model** — the `StampedLock` split is unchanged in shape, but the audit behind it was redone against `RoaringBitmap` and one violating call was removed, so the class javadoc changed accordingly. Per `CODING.md`, a clean local run is weak evidence for concurrency changes; the substantive argument is the mechanical audit recorded in the javadoc, plus the removal of the `toRoaringBitmap()` call that was demonstrably mutating under the read lock.
