### PR TITLE
[improve][test] Split PulsarProfilingTest into v5 and v4 variants

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -207,6 +207,31 @@ container, and runs
 [`PulsarProfilingTest`](tests/integration/src/test/java/org/apache/pulsar/tests/integration/profiling/PulsarProfilingTest.java)
 against it with retries off. That test drives `pulsar-perf` against a single broker.
 
+There are two variants of it, sharing everything but the client generation and the topic domain
+through
+[`AbstractPulsarProfilingTest`](tests/integration/src/test/java/org/apache/pulsar/tests/integration/profiling/AbstractPulsarProfilingTest.java).
+`PulsarProfilingTest` — the one the task runs by default — drives a v5 scalable (`topic://`) topic
+with the `produce` / `consume` commands, and
+[`PulsarProfilingV4Test`](tests/integration/src/test/java/org/apache/pulsar/tests/integration/profiling/PulsarProfilingV4Test.java)
+drives a classic `persistent://` topic with `produce-v4` / `consume-v4`. The pairing is not a free
+choice: the v4 client rejects the `topic://` domain outright, so it is the v4 client that goes with
+the classic topic. To profile that baseline instead:
+
+```bash
+./gradlew :tests:integration:profilingIntegrationTest --tests "*PulsarProfilingV4Test"
+```
+
+Both variants write into `tests/integration/build/pulsar-profiling`. The v4 run's `pulsar-perf`
+output, latency histograms, topic stats and metrics scrapes are suffixed `-v4` so the two runs can be
+told apart; the `.jfr` recordings instead carry the container name, which embeds the test class name.
+The runs are not otherwise like-for-like: scalable topics split their segments under load
+(`scalableTopicAutoScaleEnabled` defaults to true), so the v5 run profiles a topology that reshapes
+itself while the v4 run's stays fixed.
+
+A run sends a fixed 20 million messages, a bit over a minute of load at the throughput the containers
+sustain, and has to be done inside three minutes. Both `pulsar-perf` commands must then have exited
+zero, so a run that stalls or dies fails the test rather than passing as a finished profile.
+
 **Any other integration test can be profiled without being modified**, by pointing the task at it and
 naming the cluster components to attach the profiler to:
 

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/profiling/AbstractPulsarProfilingTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/profiling/AbstractPulsarProfilingTest.java
@@ -1,0 +1,408 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.tests.integration.profiling;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import lombok.CustomLog;
+import org.apache.pulsar.common.naming.TopicDomain;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.util.FutureUtil;
+import org.apache.pulsar.tests.ManualTestUtil;
+import org.apache.pulsar.tests.integration.containers.PulsarContainer;
+import org.apache.pulsar.tests.integration.suites.PulsarTestSuite;
+import org.apache.pulsar.tests.integration.topologies.PulsarClusterSpec;
+import org.apache.pulsar.tests.integration.utils.DockerUtils;
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.containers.GenericContainer;
+
+/**
+ * Base class for the sample tests that profile the broker side with Async Profiler.
+ *
+ * The concrete subclasses only pick which client generation the load is driven with:
+ * {@link PulsarProfilingTest} drives a v5 scalable topic with the v5 pulsar-perf commands and
+ * {@link PulsarProfilingV4Test} drives a classic v4 topic with the {@code -v4} pulsar-perf commands.
+ * Everything else - the cluster spec, the broker and bookie tuning, the pulsar-perf containers and
+ * the profiling wiring - is shared, so the two runs differ only in the client and the topic domain.
+ * They are not like-for-like beyond that: scalable topics auto-split their segments under load
+ * (scalableTopicAutoScaleEnabled defaults to true), so the v5 run profiles a topology that reshapes
+ * itself while the v4 run's stays fixed.
+ *
+ * Example usage (this has been tested on Mac with Orbstack (https://orbstack.dev/) docker):
+ * ./gradlew :tests:integration:profilingIntegrationTest
+ * That single task builds the test image with async-profiler in it, relaxes the kernel perf_event
+ * limits that the cpu sampling engine needs, and runs {@link PulsarProfilingTest} against the
+ * result. Add --tests "*PulsarProfilingV4Test" to profile the v4 variant instead. See
+ * CONTRIBUTING.md for the properties that tune it.
+ * On a Linux host the perf_event limits can also be set persistently with sysctl, in which case
+ * -Pinttest.asyncprofiler.skipPerfEventTuning skips the container that sets them:
+ * kernel.perf_event_paranoid=1
+ * kernel.kptr_restrict=0
+ * kernel.perf_event_max_stack=1024
+ * kernel.perf_event_mlock_kb=2048
+ * Add -Pdocker.wolfi to build the base image from Wolfi, which is what makes the GLIBC_TUNABLES
+ * below take effect.
+ * By default, the .jfr files and logs will go into tests/integration/build/pulsar-profiling
+ * You can use jfrconv from async profiler to convert them into html flamegraphs or use other tools such
+ * as Eclipse Mission Control (https://adoptium.net/jmc) or IntelliJ to open them.
+ */
+@CustomLog
+public abstract class AbstractPulsarProfilingTest extends PulsarTestSuite {
+    // this assumes that Transparent Huge Pages are available on the host machine
+    // Please notice that "madvise" mode is recommended for performance reasons.
+    // For example:
+    // echo madvise | sudo tee /sys/kernel/mm/transparent_hugepage/enabled
+    // echo madvise | sudo tee /sys/kernel/mm/transparent_hugepage/defrag
+    // More info about -XX:+UseTransparentHugePages at
+    // https://shipilev.net/jvm/anatomy-quarks/2-transparent-huge-pages/
+    private static final String DEFAULT_PULSAR_MEM = "-Xmx1g -XX:+UseTransparentHugePages -XX:+AlwaysPreTouch";
+    private static final String PERF_PULSAR_MEM =
+            "-XX:+UseTransparentHugePages -XX:+AlwaysPreTouch -XX:+HeapDumpOnOutOfMemoryError "
+                    + "-XX:HeapDumpPath=/testoutput/%HEAP_DUMP_NAME%";
+    private static final String PRODUCE_MEM_LIMIT = "200M";
+    private static final String CONSUME_MEM_LIMIT = "200M";
+    private static final String BROKER_PULSAR_MEM = "-Xms2g -Xmx2g -XX:+UseTransparentHugePages -XX:+AlwaysPreTouch";
+
+    /**
+     * The topic domain to drive the load against: {@link TopicDomain#topic} for a v5 scalable topic,
+     * {@link TopicDomain#persistent} for a classic v4 topic.
+     */
+    protected abstract TopicDomain getTopicDomain();
+
+    /**
+     * The suffix that selects the pulsar-perf client generation: an empty string runs the v5
+     * {@code produce}/{@code consume} commands, {@code "-v4"} runs {@code produce-v4}/{@code consume-v4}
+     * on the v4 client.
+     *
+     * This is not independent of {@link #getTopicDomain()}: the v4 client refuses scalable topics
+     * outright (PulsarClientImpl rejects the {@code topic://} and {@code segment://} domains with an
+     * InvalidTopicNameException), so {@code "-v4"} only pairs with {@link TopicDomain#persistent}.
+     */
+    protected abstract String getPerfCommandSuffix();
+
+    /**
+     * One admin endpoint the print-stats container polls: the prefix its response is written under in
+     * the test output directory, and the path to GET on the broker.
+     */
+    protected record TopicStatsEndpoint(String fileNamePrefix, String path) {
+    }
+
+    /**
+     * The topic admin endpoints polled once per round, in order. Each topic domain is served by its
+     * own admin resource and they do not expose the same operations, so the concrete test says what
+     * exists for the domain it drives. Returning an empty list collects broker metrics only, which is
+     * the right answer for a domain with no admin stats at all.
+     */
+    protected abstract List<TopicStatsEndpoint> getTopicStatsEndpoints(String topicName);
+
+    /**
+     * Admin path for {@code topicName} under the {@code /admin/v2/<resource>} REST resource. The
+     * resource is not the topic domain: {@code persistent://} topics are served by {@code persistent}
+     * but {@code topic://} (scalable) topics are served by {@code scalable}.
+     */
+    protected static String adminV2Path(String resource, String topicName) {
+        TopicName topic = TopicName.get(topicName);
+        return "/admin/v2/" + resource + "/" + topic.getNamespace() + "/" + topic.getLocalName();
+    }
+
+    // A container that runs pulsar-perf, arguments are currently hard-coded since this is an example
+    static class PulsarPerfContainer extends GenericContainer<PulsarPerfContainer> {
+        private final String brokerHostname;
+        private final String commandSuffix;
+        // Sized to finish well inside the wait in runPulsarPerfBenchmark. The containers sustain
+        // roughly 290k msg/s, so this is a bit over a minute of load - long enough for a profile,
+        // short enough that a run which does not finish is a real stall rather than the normal end.
+        private final long numberOfMessages = 20_000_000;
+
+        public PulsarPerfContainer(File testOutputDir,
+                                   String clusterName,
+                                   String brokerHostname,
+                                   String hostname,
+                                   String memArgs,
+                                   String commandSuffix) {
+            super(PulsarContainer.DEFAULT_IMAGE_NAME);
+            this.brokerHostname = brokerHostname;
+            this.commandSuffix = commandSuffix;
+            withCreateContainerCmdModifier(createContainerCmd -> {
+                createContainerCmd.withHostName(hostname);
+                createContainerCmd.withName(clusterName + "-" + hostname);
+            });
+            String heapDumpName = hostname + "-oom-" + System.currentTimeMillis() + ".hprof";
+            withEnv("PULSAR_MEM", PERF_PULSAR_MEM.replace("%HEAP_DUMP_NAME%", heapDumpName) + " " + memArgs);
+            withEnv("PULSAR_GC", "-XX:+UseZGC");
+            setCommand("sleep 1000000");
+            withFileSystemBind(testOutputDir.getAbsolutePath(), "/testoutput", BindMode.READ_WRITE);
+        }
+
+        public CompletableFuture<Long> consume(String topicName) throws Exception {
+            return DockerUtils.runCommandAsyncWithLogging(getDockerClient(), getContainerId(),
+                    "bash", "-c", "set -o pipefail; echo $$ > /tmp/command.pid; "
+                            + "/pulsar/bin/pulsar-perf consume" + commandSuffix + " " + topicName + " "
+                            + "-u pulsar://" + brokerHostname + ":6650 "
+                            + "-st Shared "
+                            + "-q 50000 "
+                            + "-m " + numberOfMessages + " -ml " + CONSUME_MEM_LIMIT + " "
+                            + "--histogram-file=/testoutput/consume" + commandSuffix
+                            + ".histogram.$(date +%s).hdr "
+                            + "2>&1 | tee /testoutput/consume" + commandSuffix + ".$(date +%s).txt");
+        }
+
+        public CompletableFuture<Long> produce(String topicName) throws Exception {
+            return DockerUtils.runCommandAsyncWithLogging(getDockerClient(), getContainerId(),
+                    "bash", "-c", "set -o pipefail; echo $$ > /tmp/command.pid; "
+                            + "/pulsar/bin/pulsar-perf produce" + commandSuffix + " " + topicName + " "
+                            + "-u pulsar://" + brokerHostname + ":6650 "
+                            + "-au http://" + brokerHostname + ":8080 "
+                            + "-r " + Integer.MAX_VALUE + " "
+                            + "-s 128 -db "
+                            // maxOutstanding only applies to the v4 client; the v5 client accepts
+                            // the flag for back-compat but ignores it
+                            + "-o 20000 "
+                            + "-m " + numberOfMessages + " -ml " + PRODUCE_MEM_LIMIT + " "
+                            + "--histogram-file=/testoutput/produce" + commandSuffix
+                            + ".histogram.$(date +%s).hdr "
+                            + "2>&1 | tee /testoutput/produce" + commandSuffix + ".$(date +%s).txt");
+        }
+
+        /**
+         * Polls the given topic admin endpoints and the broker metrics every 10 seconds. The metrics
+         * are always collected; the topic endpoints may be empty when the domain has no admin stats.
+         */
+        public CompletableFuture<Long> stats(List<TopicStatsEndpoint> endpoints) throws Exception {
+            String brokerUrl = "http://" + brokerHostname + ":8080";
+            StringBuilder script = new StringBuilder("echo $$ > /tmp/command.pid; while [[ 1 ]]; do ");
+            boolean firstEndpoint = true;
+            for (TopicStatsEndpoint endpoint : endpoints) {
+                if (!firstEndpoint) {
+                    script.append("sleep 1; ");
+                }
+                firstEndpoint = false;
+                script.append("curl -s ").append(brokerUrl).append(endpoint.path())
+                        .append(" | jq | tee /testoutput/").append(endpoint.fileNamePrefix())
+                        .append(commandSuffix).append(".$(date +%s).txt; ");
+            }
+            script.append("curl -s ").append(brokerUrl).append("/metrics/ > /testoutput/metrics")
+                    .append(commandSuffix).append(".$(date +%s).txt; sleep 10; done");
+            return DockerUtils.runCommandAsyncWithLogging(getDockerClient(), getContainerId(),
+                    "bash", "-c", script.toString());
+        }
+
+        public void triggerShutdown() {
+            if (isRunning()) {
+                // attempt to stop containers gracefully
+                DockerUtils.runCommandAsyncWithLogging(getDockerClient(), getContainerId(),
+                                "bash", "-c", "pkill java; while pgrep -c java; do "
+                                        + "echo Waiting for java processes to stop.; sleep 1; done; "
+                                        + "kill $(cat /tmp/command.pid)")
+                        .orTimeout(10, TimeUnit.SECONDS)
+                        .exceptionally(t -> null)
+                        .join();
+            }
+        }
+
+        public void stop() {
+            if (isRunning()) {
+                // attempt to stop containers gracefully
+                dockerClient.stopContainerCmd(getContainerId())
+                        .withTimeout(15)
+                        .exec();
+            }
+            super.stop();
+        }
+    }
+
+    private PulsarPerfContainer perfConsume;
+    private PulsarPerfContainer perfProduce;
+    private PulsarPerfContainer printStats;
+    private File testOutputDir;
+
+    @Override
+    public void setupCluster() throws Exception {
+        ManualTestUtil.skipManualTestIfNotEnabled();
+        createTestOutputDir();
+        super.setupCluster();
+    }
+
+    private void createTestOutputDir() {
+        testOutputDir = new File("build/pulsar-profiling");
+        if (!testOutputDir.exists()) {
+            if (!testOutputDir.mkdirs()) {
+                throw new IllegalArgumentException("Test output directory + '" + testOutputDir.getAbsolutePath()
+                        + "' doesn't exist and cannot be created.");
+            }
+        }
+        if (!testOutputDir.isDirectory()) {
+            throw new IllegalArgumentException(
+                    "Test output directory '" + testOutputDir.getAbsolutePath() + "' isn't a directory.");
+        }
+        // change access to testOutputDir to allow all access so the the container user can write to it
+        // This matters only on Linux
+        try {
+            Files.setPosixFilePermissions(testOutputDir.toPath(), PosixFilePermissions.fromString("rwxrwxrwx"));
+        } catch (IOException e) {
+            throw new UncheckedIOException("Cannot change access to test output directory", e);
+        }
+    }
+
+    @Override
+    public void tearDownCluster() throws Exception {
+        if (printStats != null) {
+            printStats.triggerShutdown();
+        }
+        if (perfProduce != null) {
+            perfProduce.triggerShutdown();
+        }
+        if (perfConsume != null) {
+            perfConsume.triggerShutdown();
+        }
+        if (printStats != null) {
+            printStats.stop();
+            printStats = null;
+        }
+        if (perfProduce != null) {
+            perfProduce.stop();
+            perfProduce = null;
+        }
+        if (perfConsume != null) {
+            perfConsume.stop();
+            perfConsume = null;
+        }
+        super.tearDownCluster();
+    }
+
+    @Override
+    protected void beforeStartCluster() throws Exception {
+        super.beforeStartCluster();
+        pulsarCluster.forEachContainer(
+                // This is effective only when -Pdocker.wolfi has been passed when building java-test-image
+                // setting mmap_threshold explicitly will avoid it's dynamic increase
+                // https://sourceware.org/glibc/manual/latest/html_node/Memory-Allocation-Tunables.html
+                c -> c.withEnv("GLIBC_TUNABLES",
+                        "glibc.malloc.hugetlb=1:glibc.malloc.mmap_threshold=131072:glibc.malloc.arena_max=4"));
+    }
+
+    @Override
+    protected PulsarClusterSpec.PulsarClusterSpecBuilder beforeSetupCluster(String clusterName,
+        PulsarClusterSpec.PulsarClusterSpecBuilder specBuilder) {
+
+        // Enable profiling on the broker
+        specBuilder.profileBroker(true);
+        specBuilder.profileDirectory(testOutputDir.getAbsolutePath());
+
+        // Only run one broker so that all load goes to a single broker
+        specBuilder.numBrokers(1);
+        // Have 3 bookies to reduce bottleneck on bookie
+        specBuilder.numBookies(3);
+        // no need for proxy
+        specBuilder.numProxies(0);
+
+        // Increase memory for brokers and configure more aggressive rollover
+        Map<String, String> brokerEnvs = new HashMap<>();
+        brokerEnvs.put("PULSAR_MEM", BROKER_PULSAR_MEM);
+        brokerEnvs.put("managedLedgerMinLedgerRolloverTimeMinutes", "1");
+        brokerEnvs.put("managedLedgerMaxLedgerRolloverTimeMinutes", "5");
+        brokerEnvs.put("managedLedgerMaxSizePerLedgerMbytes", "512");
+        brokerEnvs.put("managedLedgerDefaultEnsembleSize", "1");
+        brokerEnvs.put("managedLedgerDefaultWriteQuorum", "1");
+        brokerEnvs.put("managedLedgerDefaultAckQuorum", "1");
+        //brokerEnvs.put("maxPendingPublishRequestsPerConnection", "1000");
+        brokerEnvs.put("dispatcherRetryBackoffInitialTimeInMs", "0");
+        brokerEnvs.put("dispatcherRetryBackoffMaxTimeInMs", "0");
+        brokerEnvs.put("preciseDispatcherFlowControl", "true");
+        //brokerEnvs.put("PULSAR_PREFIX_subscriptionKeySharedUseClassicPersistentImplementation", "true");
+        //brokerEnvs.put("PULSAR_PREFIX_subscriptionSharedUseClassicPersistentImplementation", "true");
+        brokerEnvs.put("dispatcherMaxReadBatchSize", "1000");
+        //brokerEnvs.put("dispatcherMaxReadSizeBytes", "10000000");
+        //brokerEnvs.put("dispatcherDispatchMessagesInSubscriptionThread", "false");
+        //brokerEnvs.put("dispatcherMaxRoundRobinBatchSize", "1000");
+        specBuilder.brokerEnvs(brokerEnvs);
+
+        // Increase memory for bookkeepers and make compaction run more often
+        Map<String, String> bkEnv = new HashMap<>();
+        bkEnv.put("PULSAR_MEM", DEFAULT_PULSAR_MEM);
+        bkEnv.put("dbStorage_writeCacheMaxSizeMb", "64");
+        bkEnv.put("dbStorage_readAheadCacheMaxSizeMb", "96");
+        bkEnv.put("journalMaxSizeMB", "256");
+        bkEnv.put("journalSyncData", "false");
+        bkEnv.put("majorCompactionInterval", "300");
+        bkEnv.put("minorCompactionInterval", "30");
+        bkEnv.put("compactionRateByEntries", "20000");
+        bkEnv.put("gcWaitTime", "30000");
+        bkEnv.put("isForceGCAllowWhenNoSpace", "true");
+        bkEnv.put("diskUsageLwmThreshold", "0.75");
+        bkEnv.put("diskCheckInterval", "60");
+        specBuilder.bookkeeperEnvs(bkEnv);
+
+        // Create pulsar-perf containers
+        String brokerHostname = clusterName + "-pulsar-broker-0";
+        String commandSuffix = getPerfCommandSuffix();
+        perfProduce = new PulsarPerfContainer(testOutputDir, clusterName, brokerHostname, "perf-produce", "-Xmx2g",
+                commandSuffix);
+        perfConsume = new PulsarPerfContainer(testOutputDir, clusterName, brokerHostname, "perf-consume", "-Xmx1g",
+                commandSuffix);
+        printStats = new PulsarPerfContainer(testOutputDir, clusterName, brokerHostname, "print-stats", "-Xmx1g",
+                commandSuffix);
+        specBuilder.externalServices(Map.of(
+                "pulsar-produce", perfProduce,
+                "pulsar-consume", perfConsume,
+                "print-stats", printStats
+        ));
+
+        return specBuilder;
+    }
+
+    /**
+     * Drives pulsar-perf against a freshly generated topic and waits for both sides to finish.
+     *
+     * The concrete subclasses wrap this in the actual {@code @Test} method: Gradle's TestNG detector
+     * never scans method annotations on an abstract class, so an {@code @Test} that lived only here
+     * would leave both subclasses looking like non-test classes and neither would be handed to
+     * TestNG. (The detector does follow the superclass chain, so a subclass of a *concrete* base does
+     * inherit its test methods - it is abstractness, not inheritance, that stops it.)
+     */
+    protected void runPulsarPerfBenchmark() throws Exception {
+        String topicName = generateTopicName("profiletest", getTopicDomain());
+        CompletableFuture<Long> consumeFuture = perfConsume.consume(topicName);
+        Thread.sleep(1000);
+        CompletableFuture<Long> produceFuture = perfProduce.produce(topicName);
+        Thread.sleep(4000);
+        printStats.stats(getTopicStatsEndpoints(topicName));
+        // pulsar-perf is sized to finish inside this window, so running out of it is a failure.
+        FutureUtil.waitForAll(List.of(consumeFuture, produceFuture))
+                .orTimeout(3, TimeUnit.MINUTES)
+                .exceptionally(t -> {
+                    log.error().exception(t).log("Failed to run pulsar-perf");
+                    throw FutureUtil.wrapToCompletionException(t);
+                })
+                .get();
+        assertSoftly(softly -> {
+            softly.assertThat(consumeFuture).as("consume should have completed successfully").isCompletedWithValue(0L);
+            softly.assertThat(produceFuture).as("produce should have completed successfully").isCompletedWithValue(0L);
+        });
+    }
+}

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/profiling/PulsarProfilingV4Test.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/profiling/PulsarProfilingV4Test.java
@@ -23,31 +23,31 @@ import org.apache.pulsar.common.naming.TopicDomain;
 import org.testng.annotations.Test;
 
 /**
- * Profiles the broker while pulsar-perf drives a v5 scalable topic with the v5 client.
+ * Profiles the broker while pulsar-perf drives a classic v4 topic with the v4 client.
  *
- * This is the variant that {@code ./gradlew :tests:integration:profilingIntegrationTest} runs by
- * default. See {@link AbstractPulsarProfilingTest} for how to run it and where the recordings land,
- * and {@link PulsarProfilingV4Test} for the v4 counterpart.
+ * Run it with {@code ./gradlew :tests:integration:profilingIntegrationTest --tests
+ * "*PulsarProfilingV4Test"}. It is the pre-v5 baseline for {@link PulsarProfilingTest}: same
+ * cluster, same load parameters, only the client generation and the topic domain differ. See
+ * {@link AbstractPulsarProfilingTest} for the rest.
  */
-public class PulsarProfilingTest extends AbstractPulsarProfilingTest {
+public class PulsarProfilingV4Test extends AbstractPulsarProfilingTest {
 
     @Override
     protected TopicDomain getTopicDomain() {
-        return TopicDomain.topic;
+        return TopicDomain.persistent;
     }
 
     @Override
     protected String getPerfCommandSuffix() {
-        return "";
+        return "-v4";
     }
 
     @Override
     protected List<TopicStatsEndpoint> getTopicStatsEndpoints(String topicName) {
-        // Scalable topics have their own admin resource: aggregated stats (including per-segment and
-        // per-subscription counts) are under /admin/v2/scalable, not /admin/v2/topic, and there is no
-        // internalStats equivalent, so the managed-ledger internals of the backing segments are not
-        // collected. Broker metrics are collected either way.
-        return List.of(new TopicStatsEndpoint("stats", adminV2Path("scalable", topicName) + "/stats"));
+        String basePath = adminV2Path("persistent", topicName);
+        return List.of(
+                new TopicStatsEndpoint("stats", basePath + "/stats"),
+                new TopicStatsEndpoint("internal_stats", basePath + "/internalStats"));
     }
 
     @Test(timeOut = 600_000)


### PR DESCRIPTION
### Motivation

The profiling sample test could only benchmark one client generation at a time. Switching between the
v5 scalable topic path and the classic v4 path meant editing the topic domain and the `pulsar-perf`
subcommands in place, so comparing the two required a working-tree change between runs and the two
configurations kept overwriting each other.

The two are not independent axes. The v4 client rejects the `topic://` and `segment://` domains
outright — `PulsarClientImpl.isScalableDomain` fails producer, consumer and reader creation with an
`InvalidTopicNameException` — so a scalable topic can only be driven by the v5 client. "v5 topic" and
"v4 topic" are therefore one choice, worth naming once per test class.

Two further problems surfaced while splitting it, both of which made the existing test misreport:

- The print-stats container built its admin URL as `/admin/v2/` plus the topic name with `://`
  replaced by `/`. That works for `persistent://`, but no JAX-RS resource is registered at
  `/admin/v2/topic`: scalable topics are served by `ScalableTopics`, `@Path("/scalable")`. Since the
  test drove a `topic://` topic, its whole topic stats loop was writing 404 bodies into
  `stats.<ts>.txt` and `internal_stats.<ts>.txt`.
- The run asked for 100,000,000 messages, which takes about 350 seconds (~290k msg/s across produce
  and consume), against a three-minute wait. The run could never finish inside its window, so the
  wait always ended in the `TimeoutException` branch that logs and swallows it — and the exit-code
  assertions that follow then ran against futures that were still incomplete, failing every ordinary
  profiling run. Because the still-running consume future was asserted first, a produce that really
  had died even reported "consume should have completed successfully" and named the wrong command.

### Modifications

- Rename `PulsarProfilingTest` to `AbstractPulsarProfilingTest` and keep everything shared there: the
  cluster spec, the broker and bookie tuning, the `pulsar-perf` containers and the profiling wiring.
- Add three hooks for the variation. `getTopicDomain()` and `getPerfCommandSuffix()` pick the topic
  domain and the client generation; the suffix is threaded into `PulsarPerfContainer`, which builds
  `pulsar-perf produce<suffix>` / `consume<suffix>`. `getTopicStatsEndpoints(topicName)` returns the
  admin endpoints to poll as (output file prefix, path) pairs, since each domain is served by a
  different resource and they do not expose the same operations. Returning an empty list collects
  broker metrics only; the metrics scrape is unconditional in every case.
- `PulsarProfilingTest` drives a v5 scalable (`topic://`) topic with `produce`/`consume` and polls
  `/admin/v2/scalable/<ns>/<topic>/stats`, whose `ScalableTopicStats` already carries the per-segment
  and per-subscription breakdown. There is no `internalStats` counterpart for scalable topics, so the
  managed-ledger internals of the backing segments are not collected.
- `PulsarProfilingV4Test` drives a classic `persistent://` topic with `produce-v4`/`consume-v4` and
  keeps both `/stats` and `/internalStats` under `/admin/v2/persistent`, exactly as before.
- Each concrete class declares its own `@Test` delegating to the base's `runPulsarPerfBenchmark()`.
  Gradle's TestNG detector never scans method annotations on an abstract class, so an `@Test` left on
  the base makes both subclasses look like non-test classes and the run fails with "No tests found
  for given includes". (The detector does walk the superclass chain; it is abstractness, not
  inheritance, that stops it.) This matches the existing convention for abstract bases in
  `tests/integration`, such as `TcMetadataDiscoveryTestBase`.
- Drop the message count to 20,000,000 — a bit over a minute of load at the throughput the containers
  sustain, which leaves ample headroom in the three-minute wait — and remove the `TimeoutException`
  special case, so a run that does not finish now fails. Both commands are complete when the wait
  returns, so the exit-code assertions are unconditional again. A non-zero exit completes the future
  normally with the exit code as its value (`DockerUtils.runCommandAsyncWithLogging`), so those
  assertions remain the only thing that catches a `pulsar-perf` that died early.
- Both variants write into `build/pulsar-profiling`, so the v4 run's `pulsar-perf` output, histograms,
  topic stats and metrics scrapes are tagged with the same `-v4` suffix. The v5 run keeps the existing
  file names.
- Update `CONTRIBUTING.md`'s profiling section, which described a single profiling test: document both
  variants and how to run the v4 one, why the client generation and the topic domain are not
  independent, where each run's artifacts land, and that the runs are not like-for-like because
  scalable topics auto-split under load (`scalableTopicAutoScaleEnabled` defaults to true), so the v5
  run profiles a topology that reshapes itself while the v4 run's stays fixed.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a modification to a manual profiling test, which is skipped unless
`pulsar.test.enableManualTest` is set, so CI does not exercise it. It was verified locally:

- `./gradlew :tests:integration:integrationTest --tests "*PulsarProfilingTest*" --tests "*PulsarProfilingV4Test*"`
  discovers and runs both concrete classes (both skip on the manual-test guard) and does not pick up
  the abstract base.
- `./gradlew :tests:integration:profilingIntegrationTest` still resolves its hardcoded filter to
  `PulsarProfilingTest` alone; the v4 variant runs with `--tests "*PulsarProfilingV4Test"`.
- The generated stats scripts were rendered for both variants and for the metrics-only case and
  checked with `bash -n`; the v4 script is unchanged from the previous behaviour.
- The exit-code assertions were exercised against all six outcomes: both commands running, one
  running, both exited 0, produce exited non-zero with and without consume still running, and a
  docker-layer failure.
- `./gradlew spotlessCheck checkstyleMain checkstyleTest` and `./gradlew quickCheck` pass.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
