### PR TITLE
[fix][broker] Prevent automatic TTL expiry from skipping reader messages

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -2410,7 +2410,8 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
     private void checkMessageExpiryWithoutSharedPosition(int messageTtlInSeconds) {
         subscriptions.forEach((__, sub) -> {
-            if (!isCompactionSubscription(sub.getName())
+            // TTL must not advance non-durable reader cursors past unread retained messages.
+            if (sub.getCursor().isDurable() && !isCompactionSubscription(sub.getName())
                     && (additionalSystemCursorNames.isEmpty()
                     || !additionalSystemCursorNames.contains(sub.getName()))) {
                 sub.expireMessagesAsync(messageTtlInSeconds);
@@ -2457,9 +2458,9 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                 // Nothing need to be expired.
                 return;
             }
-            // Expire messages by position, which is more efficient.
+            // Expire durable subscriptions by position. Non-durable readers must retain their read position.
             subscriptions.forEach((__, sub) -> {
-                if (!isCompactionSubscription(sub.getName())
+                if (sub.getCursor().isDurable() && !isCompactionSubscription(sub.getName())
                         && (additionalSystemCursorNames.isEmpty()
                         || !additionalSystemCursorNames.contains(sub.getName()))) {
                     // The variable "position" is to mark delete position.

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/ReaderMessageTTLTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/ReaderMessageTTLTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service.persistent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.AdditionalAnswers.delegatesTo;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import java.util.concurrent.TimeUnit;
+import org.apache.bookkeeper.mledger.ManagedLedger;
+import org.apache.bookkeeper.mledger.Position;
+import org.apache.pulsar.broker.service.SharedPulsarBaseTest;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.Reader;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.common.policies.data.RetentionPolicies;
+import org.awaitility.Awaitility;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+@Test(groups = "broker")
+public class ReaderMessageTTLTest extends SharedPulsarBaseTest {
+
+    @DataProvider
+    public Object[][] expiryPaths() {
+        return new Object[][] {{true}, {false}};
+    }
+
+    @Test(dataProvider = "expiryPaths", timeOut = 60000)
+    public void testReaderRetainsUnreadMessagesDuringExpiry(boolean sharedPosition) throws Exception {
+        String topicName = newTopicName();
+        admin.namespaces().setRetention(getNamespace(), new RetentionPolicies(-1, -1));
+        admin.namespaces().setNamespaceMessageTTL(getNamespace(), 1);
+        admin.topics().createNonPartitionedTopic(topicName);
+        admin.topics().createSubscription(topicName, "durable", MessageId.earliest);
+        int messageCount = 20;
+        try (Producer<String> producer = pulsarClient.newProducer(Schema.STRING).topic(topicName)
+                .enableBatching(false).create()) {
+            for (int i = 0; i < messageCount; i++) {
+                producer.send("message-" + i);
+            }
+        }
+        try (Reader<String> reader = pulsarClient.newReader(Schema.STRING).topic(topicName)
+                .subscriptionName("reader").startMessageId(MessageId.earliest).receiverQueueSize(1).create()) {
+            Message<String> first = reader.readNext(10, TimeUnit.SECONDS);
+            assertThat(first).isNotNull();
+            assertThat(first.getValue()).isEqualTo("message-0");
+            PersistentTopic topic = (PersistentTopic) getTopicReference(topicName).orElseThrow();
+            PersistentSubscription readerSubscription = topic.getSubscription("reader");
+            assertThat(readerSubscription.getCursor().isDurable()).isFalse();
+            Position readPosition = readerSubscription.getCursor().getReadPosition();
+            PersistentSubscription durable = topic.getSubscription("durable");
+
+            // Pause the reader until all published messages are old enough to expire.
+            long expiryTime = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(2);
+            Awaitility.await().until(() -> System.currentTimeMillis() > expiryTime);
+            PersistentTopic expiryTopic = topic;
+            if (!sharedPosition) {
+                expiryTopic = spy(topic);
+                // Exercise the fallback used by custom ManagedLedger implementations.
+                doReturn(mock(ManagedLedger.class, delegatesTo(topic.getManagedLedger())))
+                        .when(expiryTopic).getManagedLedger();
+            }
+            PersistentTopic topicToCheck = expiryTopic;
+            Awaitility.await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
+                topicToCheck.checkMessageExpiry();
+                assertThat(durable.getCursor().getNumberOfEntriesInBacklog(false)).isZero();
+            });
+            assertThat(readerSubscription.getCursor().getMarkDeletedPosition())
+                    .as("TTL must not acknowledge unread reader messages")
+                    .isLessThan(readPosition);
+            for (int i = 1; i < messageCount; i++) {
+                Message<String> message = reader.readNext(10, TimeUnit.SECONDS);
+                assertThat(message).as("retained message %s", i).isNotNull();
+                assertThat(message.getValue()).isEqualTo("message-" + i);
+            }
+            assertThat(reader.hasMessageAvailable()).isFalse();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #26504

### Motivation

A `Reader` attaches to a topic through a **non-durable** subscription, and the cursor of that subscription *is* the reader's scan position — a reader has no backlog and no acknowledgements.

The scheduled TTL task, `PersistentTopic.checkMessageExpiry()`, walks every subscription of the topic and force-acknowledges everything older than the TTL. It excludes the compaction cursor and the configured `additionalSystemCursorNames`, but it does not exclude non-durable cursors, so a reader's cursor gets expired like any consumer backlog.

For a durable subscription that is exactly what TTL is defined to do. For a reader it silently drops data, because `ManagedCursorImpl.setAcknowledgedPosition()` drags the read position along whenever the new mark-delete position reaches or passes it:

```java
if (currentReadPosition.compareTo(markDeletePosition) <= 0) {
    // If the position that is mark-deleted is past the read position, it
    // means that the client has skipped some entries. We need to move
    // read position forward
    Position newReadPosition = ledger.getNextValidPosition(markDeletePosition);
```

A reader that is still scanning messages older than the TTL is therefore teleported past everything the expiry task just acknowledged. It gets no error and no warning — it simply resumes after the gap and returns fewer messages.

That is the behaviour reported in #26504 (from discussion #26501): a reader started at `MessageId.earliest` on a topic with ~10 year retention and a 2 week TTL returned anywhere between 2,647 and 24,756 of the same ~24.7k messages across ten consecutive runs. The outcome depends only on whether the periodic expiry task (`messageExpiryCheckIntervalInMinutes`, 5 minutes by default) fires while the reader is still behind the TTL boundary; raising the TTL past the age of the oldest message made the problem disappear. No message was ever deleted — retention covered them all — the reader was just moved past them.

Retention, not TTL, is what bounds how long a reader may keep reading. When `ManagedLedgerImpl` actually trims ledgers, `advanceCursorsIfNecessary()` force-advances non-durable cursors over the deleted data, so excluding them from TTL expiry cannot let a stale reader pin storage.

### Modifications

`PersistentTopic`: add a `sub.getCursor().isDurable()` condition to the subscription filter in **both** automatic expiry paths — `checkMessageExpiryWithSharedPosition()` (the `ManagedLedgerImpl` path) and `checkMessageExpiryWithoutSharedPosition()` (the fallback for custom `ManagedLedger` implementations).

Durable subscriptions and replicators are unaffected, and only the *automatic* TTL task changes. The administrative expiry endpoints (`pulsar-admin topics expire-messages` and `expire-messages-all-subscriptions`) iterate subscriptions in `PersistentTopicsBase` and still act on reader subscriptions, so an operator can still expire them explicitly.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- New `ReaderMessageTTLTest.testReaderRetainsUnreadMessagesDuringExpiry` publishes 20 messages to a topic with infinite retention and a 1 second TTL, reads the first message, pauses the reader until every message is older than the TTL, then drives `checkMessageExpiry()` until the durable subscription's backlog reaches zero. It asserts that the reader's mark-delete position never passes its read position and that the remaining 19 messages are all still readable, in order.
- The test runs over both expiry paths via a `@DataProvider`: the shared-position path, and — with a `ManagedLedger` mock that delegates to the real one — the per-subscription fallback path.
- Both data provider cases fail on `master` (`AssertionError: [TTL must not acknowledge unread reader messages]`) and pass with the fix.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
