### PR TITLE
[fix][ml] OOM caused by orphan items in ActiveManagedCursorContainerImpl.pendingPositionUpdates

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ActiveManagedCursorContainerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ActiveManagedCursorContainerImpl.java
@@ -65,6 +65,7 @@ public class ActiveManagedCursorContainerImpl implements ActiveManagedCursorCont
     }
     // number of nodes in the double-linked list
     int trackedNodeCount = 0;
+    private int meaninglessPendingUpdateCount = 0;
     private final long continueCachingAddedEntriesAfterLastActiveCursorLeavesMillis;
     private volatile long cursorRemovedTimestampMillis;
     private volatile int cursorCount;
@@ -258,10 +259,19 @@ public class ActiveManagedCursorContainerImpl implements ActiveManagedCursorCont
                 if (node.position != null) {
                     pendingRemovedCursors.put(name, node);
                     node.pendingRemove = true;
+                } else {
+                    // The cursor was triggered an inactivation before the pending updates are flushed, then the pending
+                    // update item is meaningless.
+                    meaninglessPendingUpdateCount++;
                 }
                 node.pendingPosition = null;
                 cursorRemovedTimestampMillis = System.currentTimeMillis();
                 cursorCount--;
+                // Clear meaningless pending update, which avoids OOM.
+                if (meaninglessPendingUpdateCount >= 10) {
+                    processPendingPositions();
+                    meaninglessPendingUpdateCount = 0;
+                }
                 return true;
             } else {
                 return false;
@@ -754,6 +764,16 @@ public class ActiveManagedCursorContainerImpl implements ActiveManagedCursorCont
             return node.numberOfCursorsAtSamePositionOrBefore.intValue();
         } finally {
             rwLock.unlockWrite(stamp);
+        }
+    }
+
+    @VisibleForTesting
+    int getPendingPositionUpdatesCount() {
+        long stamp = rwLock.readLock();
+        try {
+            return pendingPositionUpdates.size();
+        } finally {
+            rwLock.unlockRead(stamp);
         }
     }
 

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -168,6 +168,24 @@ import org.testng.annotations.Test;
 public class ManagedLedgerTest extends MockedBookKeeperTestCase {
     private static final Charset Encoding = StandardCharsets.UTF_8;
 
+    @Test
+    public void testRemovedCursorsAwaitingFirstPositionUpdateRemainInPendingQueue() throws Exception {
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        initManagedLedgerConfig(config);
+        config.setCacheEvictionByExpectedReadCount(true);
+        ManagedLedgerImpl ledger = (ManagedLedgerImpl) factory.open("pending-position-updates", config);
+
+        for (int index = 0; index < 50; index++) {
+            String cursorName = "cursor" + index;
+            ManagedCursor cursor = ledger.openCursor(cursorName);
+            ledger.deleteCursor(cursorName);
+        }
+
+        ActiveManagedCursorContainerImpl activeCursors =
+                (ActiveManagedCursorContainerImpl) ledger.getActiveCursors();
+        assertTrue(activeCursors.getPendingPositionUpdatesCount() < 10);
+    }
+
     @DataProvider(name = "checkOwnershipFlag")
     public Object[][] checkOwnershipFlagProvider() {
         return new Object[][] { { Boolean.TRUE }, { Boolean.FALSE } };


### PR DESCRIPTION
### Motivation

The issue was introduced by https://github.com/apache/pulsar/pull/24623, only affects the version newer than `4.1.0`

**Background**

- `ActiveManagedCursorContainerImpl` traces the slowest position of cursors. 
- To delay the calculation of the slowest position,  `ActiveManagedCursorContainerImpl` maintains two collections: `pendingRemovedCursors` and `pendingPositionUpdates`.
- `pendingRemovedCursors` caches the events that cursors are inactive, and `pendingPositionUpdates` caches the events that cursors are active.
- When getting the slowest position, it flushes `pendingRemovedCursors` and `pendingPositionUpdates`.
  - **(Highlight)** If no such call was made, it never flushes

**Issue**

With `cacheEvictionByExpectedReadCount` enabled, a cursor can be removed before its read any messages. The removed cursor is no longer tracked in the Managed ledger, but its node remains in `ActiveManagedCursorContainerImpl.pendingPositionUpdates` until a future pending-position flush. If no such flush is triggered, repeated cursor creation and removal can accumulate stale nodes and retain their associated cursor objects, increasing memory usage and potentially causing OOM.

**It can be reproduced with the following steps**. See also the new test.
- create a topic
- create subscription 1
- delete the subscription
  - an orphan item is left in  `ActiveManagedCursorContainerImpl.pendingPositionUpdates`.
- create subscription 2
- delete the subscription 
  - the second orphan item is left in  `ActiveManagedCursorContainerImpl.pendingPositionUpdates`.
- ...

### Modifications

Count orphan items in `ActiveManagedCursorContainerImpl.pendingPositionUpdates`,  flush pending cursor updates, and reset the counter when the count of orphan items is 10.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment