### PR TITLE
[fix][ml] Preserve ledger properties when recovering the last ledger on open

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -470,10 +470,16 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                                 if (State.Terminated.equals(state)) {
                                     currentLedger = lh;
                                 }
-                                LedgerInfo info = new LedgerInfo().setLedgerId(id)
-                                        .setEntries(lh.getLastAddConfirmed() + 1).setSize(lh.getLength())
-                                        .setTimestamp(clock.millis());
-                                ledgers.put(id, info);
+                                ledgers.compute(id, (ledgerId, oldInfo) -> {
+                                    LedgerInfo info = new LedgerInfo();
+                                    if (oldInfo != null) {
+                                        info.copyFrom(oldInfo);
+                                    } else {
+                                        info.setLedgerId(ledgerId);
+                                    }
+                                    return info.setEntries(lh.getLastAddConfirmed() + 1)
+                                            .setSize(lh.getLength()).setTimestamp(clock.millis());
+                                });
                                 if (managedLedgerInterceptor != null) {
                                     managedLedgerInterceptor
                                             .onManagedLedgerLastLedgerInitialize(name, createLastEntryHandle(lh))

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -5008,6 +5008,83 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
     }
 
     /**
+     * Reopening a managed ledger rebuilds the last ledger's LedgerInfo from BookKeeper
+     * (the znode stat is stale while the ledger is the current writing ledger). The rebuild
+     * must only refresh entries/size/timestamp and preserve the fields already persisted in
+     * the znode -- per-ledger properties and the offload context.
+     *
+     * <p>Before the fix, the rebuild created the LedgerInfo from scratch, dropping properties
+     * and offloadContext; the loss was then persisted by the ledger-ids rewrite in
+     * initializeBookKeeper.
+     */
+    @Test(timeOut = 20000)
+    public void testLedgerPropertiesAndOffloadContextPreservedAfterReopen() throws Exception {
+        String name = "testLedgerPropertiesAndOffloadContextPreservedAfterReopen";
+        ManagedLedgerImpl ml = (ManagedLedgerImpl) factory.open(name);
+
+        // One entry before tagging the ledger, so BK is already ahead of the znode stat.
+        ml.addEntry("entry-1".getBytes(Encoding));
+        long lastLedger = ml.ledgers.lastKey();
+
+        // Simulate a ledger that has been offloaded: inject the offload context into the
+        // in-memory info, then persist it together with a ledger property.
+        LedgerInfo infoWithOffload = new LedgerInfo().setLedgerId(lastLedger);
+        infoWithOffload.setOffloadContext().setUidMsb(11L).setUidLsb(22L).setComplete(true);
+        ml.ledgers.put(lastLedger, infoWithOffload);
+        ml.asyncAddLedgerProperty(lastLedger, "key1", "value1").join();
+
+        // Write more entries after the property write: BK entries/size now lead the znode stat.
+        ml.addEntry("entry-2".getBytes(Encoding));
+        ml.addEntry("entry-3".getBytes(Encoding));
+        ml.close();
+
+        // Reopen: initialize() refreshes the last ledger's stats from BookKeeper.
+        ManagedLedgerImpl mlReopened = (ManagedLedgerImpl) factory.open(name);
+        LedgerInfo info = mlReopened.ledgers.get(lastLedger);
+        Assert.assertNotNull(info);
+
+        // entries/size reflect all the writes recorded by BookKeeper
+        Assert.assertEquals(info.getEntries(), 3L);
+        Assert.assertEquals(info.getSize(),
+                (long) "entry-1".getBytes(Encoding).length + "entry-2".getBytes(Encoding).length
+                        + "entry-3".getBytes(Encoding).length);
+
+        // properties are preserved
+        Assert.assertEquals(info.getPropertiesCount(), 1);
+        Assert.assertEquals(mlReopened.asyncGetLedgerProperty(lastLedger, "key1").join(), "value1");
+
+        // offload context is preserved
+        Assert.assertTrue(info.hasOffloadContext());
+        Assert.assertEquals(info.getOffloadContext().getUidMsb(), 11L);
+        Assert.assertEquals(info.getOffloadContext().getUidLsb(), 22L);
+        Assert.assertTrue(info.getOffloadContext().isComplete());
+        mlReopened.close();
+    }
+
+    /**
+     * Regression: reopening a managed ledger whose last ledger has no properties behaves as
+     * before -- stats are refreshed from BookKeeper and no properties/offload context appear.
+     */
+    @Test(timeOut = 20000)
+    public void testLastLedgerStatsRefreshedAfterReopenWithoutProperties() throws Exception {
+        String name = "testLastLedgerStatsRefreshedAfterReopenWithoutProperties";
+        ManagedLedgerImpl ml = (ManagedLedgerImpl) factory.open(name);
+        ml.addEntry("entry-1".getBytes(Encoding));
+        ml.addEntry("entry-2".getBytes(Encoding));
+        long lastLedger = ml.ledgers.lastKey();
+        ml.close();
+
+        ManagedLedgerImpl mlReopened = (ManagedLedgerImpl) factory.open(name);
+        LedgerInfo info = mlReopened.ledgers.get(lastLedger);
+        Assert.assertNotNull(info);
+        Assert.assertEquals(info.getEntries(), 2L);
+        Assert.assertEquals(info.getSize(), (long) "entry-1".getBytes(Encoding).length * 2);
+        Assert.assertEquals(info.getPropertiesCount(), 0);
+        Assert.assertFalse(info.hasOffloadContext());
+        mlReopened.close();
+    }
+
+    /**
      * Verifies that a ledger-property write whose metadata-store callback completes AFTER the ledger
      * has been closed does not regress the closed ledger's entries.
      *


### PR DESCRIPTION


### Motivation

`ManagedLedgerImpl#initialize()` unconditionally re-opens the last ledger on every
managed-ledger open to refresh its stats from BookKeeper, because the znode stat of the
ledger that was the current writing ledger is stale (it is only persisted on ledger
rollover). However, the rebuild constructed the `LedgerInfo` from scratch:

```java
LedgerInfo info = new LedgerInfo().setLedgerId(id)
        .setEntries(lh.getLastAddConfirmed() + 1).setSize(lh.getLength())
        .setTimestamp(clock.millis());
ledgers.put(id, info);
```
dropping every other field already persisted in the metadata store — per-ledger properties and the offload context. The loss is then made durable by the full ledger-ids rewrite in initializeBookKeeper() ("Save it back to ensure all nodes exist"), silently, with no error log.

This breaks the persistence contract of asyncAddLedgerProperty / asyncRemoveLedgerProperty: a ledger property only survives until the managed ledger is next opened (topic load, unload/reload, broker restart), then disappears, while the APIs report success all along. It also wipes the offload context of the last ledger, so an already-offloaded ledger looks like it was never offloaded after a reopen, which allows redundant offloads and skips the bookkeeper-deletion bookkeeping during trimming.

The same merge pattern (keep the persisted fields, refresh only entries/size/timestamp) is already used by `ledgerClosed()` on the rollover path; the recovery path in initialize() is the only remaining place that rebuilds a LedgerInfo of an existing ledger from scratch.

### Modifications

In ManagedLedgerImpl#initialize(), replace the from-scratch LedgerInfo rebuild of the last ledger with the same merge already used by ledgerClosed(): the new info is copyFrom(oldInfo), keeping every persisted field (properties, offload context, ...), and only entries / size / timestamp are overridden with the authoritative BookKeeper values. The Terminated, no-such-ledger and empty-ledger cleanup paths are unchanged.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment