### PR TITLE
[fix][test] Fix flaky V5DagWatchAutoReconnectTest producer test

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/v5/V5DagWatchAutoReconnectTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/v5/V5DagWatchAutoReconnectTest.java
@@ -57,8 +57,9 @@ public class V5DagWatchAutoReconnectTest extends V5ClientBaseTest {
         Producer<String> producer = v5Client.newProducer(Schema.string())
                 .topic(topic)
                 .create();
+        PulsarClient consumerClient = newV5Client();
         @Cleanup
-        QueueConsumer<String> consumer = v5Client.newQueueConsumer(Schema.string())
+        QueueConsumer<String> consumer = consumerClient.newQueueConsumer(Schema.string())
                 .topic(topic)
                 .subscriptionName("dag-reconnect-sub")
                 .subscriptionInitialPosition(SubscriptionInitialPosition.EARLIEST)
@@ -78,9 +79,6 @@ public class V5DagWatchAutoReconnectTest extends V5ClientBaseTest {
         // on the DagWatchClient, which schedules a reconnect.
         forceCloseDagWatchOnProducer(producer);
 
-        // Send a second batch immediately. Existing segments are still reachable
-        // through the per-segment v4 producers (their own connections are unaffected),
-        // so this proves the producer keeps working through the reconnect window.
         int secondN = 10;
         Set<String> secondSent = new HashSet<>();
         for (int i = 0; i < secondN; i++) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/v5/V5DagWatchAutoReconnectTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/v5/V5DagWatchAutoReconnectTest.java
@@ -79,6 +79,9 @@ public class V5DagWatchAutoReconnectTest extends V5ClientBaseTest {
         // on the DagWatchClient, which schedules a reconnect.
         forceCloseDagWatchOnProducer(producer);
 
+        // Send a second batch immediately. The force-close also drops the shared client
+        // connection, so the per-segment v4 producers reconnect; sends issued here are
+        // queued and flushed once the connection is re-established.
         int secondN = 10;
         Set<String> secondSent = new HashSet<>();
         for (int i = 0; i < secondN; i++) {


### PR DESCRIPTION
### Motivation

`testProducerSurvivesDagWatchConnectionDrop` in `V5DagWatchAutoReconnectTest` is flaky: the exact-set assertion intermittently fails with `producer must keep sending after DAG watch reconnect kicks in`.

The test force-closes the producer's DAG-watch channel, but with the default `connectionsPerBroker=1` the v5 client pools a single connection per broker, so that channel is the shared connection for the whole client. The consumer's segment consumers ride the same connection and reconnect alongside the producer; around that window the broker can redeliver first-batch messages (at-least-once semantics), which pollutes the second `drain` and makes the exact-set assertion timing-dependent.

### Modifications

- Create the consumer on its own dedicated client (`newV5Client()`) so the force-close is scoped to the producer's connections only. The producer's segment producers still drop and reconnect (sends issued in the window are queued and flushed once the connection is re-established), but the consumer stays connected — removing the reconnect/redelivery race and making the assertion deterministic.

### Verifying this change

This change updates an existing test and can be verified by running:

```
./gradlew :pulsar-broker:test --tests "org.apache.pulsar.client.api.v5.V5DagWatchAutoReconnectTest"
```

- [x] The change passes the CI checks locally (`BUILD SUCCESSFUL`, `:pulsar-broker:checkstyleTest` clean).

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
- [ ] `doc-not-needed` 
- [ ] `doc` 
- [ ] `doc-omitted`
