### PR TITLE
[fix][ml] Fix active cursor retention and deferred-update synchronization

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ActiveManagedCursorContainerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ActiveManagedCursorContainerImpl.java
@@ -904,10 +904,17 @@ public class ActiveManagedCursorContainerImpl implements ActiveManagedCursorCont
         try {
             processPendingPositions();
             Node current = head;
+            Node previous = null;
             int currentCount = 0;
             Position lastPosition = null;
             List<String> lastPositionCursorNames = new ArrayList<>();
             while (current != null) {
+                if (current.cursor == null) {
+                    throw new IllegalStateException("Released node still linked");
+                }
+                if (current.prev != previous) {
+                    throw new IllegalStateException("Previous node link is inconsistent");
+                }
                 if (current.prev != null && current.position.compareTo(current.prev.position) < 0) {
                     throw new IllegalStateException("Cursors are not ordered: " + current.cursor.getName()
                             + " with position " + current.position + " is after cursor " + current.prev.cursor.getName()
@@ -942,8 +949,15 @@ public class ActiveManagedCursorContainerImpl implements ActiveManagedCursorCont
                 } else {
                     lastPositionCursorNames.add(current.cursor.getName());
                 }
+                previous = current;
                 current = current.next;
-
+            }
+            if (tail != previous) {
+                throw new IllegalStateException("Tail does not match the last linked node");
+            }
+            if (currentCount != trackedNodeCount) {
+                throw new IllegalStateException("Tracked node count does not match the linked list: expected "
+                        + trackedNodeCount + ", but found " + currentCount);
             }
         } finally {
             rwLock.unlockWrite(stamp);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ActiveManagedCursorContainerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ActiveManagedCursorContainerImpl.java
@@ -541,6 +541,12 @@ public class ActiveManagedCursorContainerImpl implements ActiveManagedCursorCont
 
             // update the position
             node.position = newPosition;
+            // A tail that remains in its own position group keeps the same rank and counter.
+            if (node == tail && (node.prev == null
+                    || (node.prev.position.compareTo(oldPosition) != 0
+                    && node.prev.position.compareTo(newPosition) != 0))) {
+                return;
+            }
             // Even the tail must leave or join shared counters when its position group changes.
             if (movingForward) {
                 // first decrement the counter for the old position

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ActiveManagedCursorContainerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ActiveManagedCursorContainerImpl.java
@@ -23,10 +23,13 @@ import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.PriorityQueue;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.locks.StampedLock;
@@ -49,10 +52,14 @@ import org.apache.commons.lang3.tuple.Pair;
  */
 @CustomLog
 public class ActiveManagedCursorContainerImpl implements ActiveManagedCursorContainer {
+    private static final int MIN_REMOVALS_BEFORE_CLEANUP = 64;
+
     private static class Node {
-        final ManagedCursor cursor;
+        // Iterators read this without the lock. Removed nodes must not retain the cursor's object graph.
+        volatile ManagedCursor cursor;
         Position position;
         Position pendingPosition;
+        boolean pendingPositionUpdateQueued;
         boolean pendingRemove = false;
         MutableInt numberOfCursorsAtSamePositionOrBefore;
         Node prev;
@@ -65,6 +72,8 @@ public class ActiveManagedCursorContainerImpl implements ActiveManagedCursorCont
     }
     // number of nodes in the double-linked list
     int trackedNodeCount = 0;
+    // Conservative count: a removed node may have been reused since the last cleanup or position flush.
+    private int removalsSinceLastCleanup;
     private final long continueCachingAddedEntriesAfterLastActiveCursorLeavesMillis;
     private volatile long cursorRemovedTimestampMillis;
     private volatile int cursorCount;
@@ -114,24 +123,21 @@ public class ActiveManagedCursorContainerImpl implements ActiveManagedCursorCont
                     }
                     node.pendingPosition = null;
                 } else {
-                    if (node.pendingPosition == null) {
-                        pendingPositionUpdates.add(node);
-                    }
-                    node.pendingPosition = position;
+                    queuePositionUpdate(node, position);
                 }
             } else {
                 if (position != null) {
                     node = pendingRemovedCursors.remove(cursor.getName());
                     if (node != null) {
                         node.pendingRemove = false;
+                        node.cursor = cursor;
                     }
                 }
                 if (node == null) {
                     node = new Node(cursor, position);
                 }
                 if (position != null) {
-                    node.pendingPosition = position;
-                    pendingPositionUpdates.add(node);
+                    queuePositionUpdate(node, position);
                 }
                 if (cursors.put(cursor.getName(), node) == null) {
                     cursorCount++;
@@ -259,9 +265,16 @@ public class ActiveManagedCursorContainerImpl implements ActiveManagedCursorCont
                     pendingRemovedCursors.put(name, node);
                     node.pendingRemove = true;
                 }
+                node.cursor = null;
                 node.pendingPosition = null;
                 cursorRemovedTimestampMillis = System.currentTimeMillis();
                 cursorCount--;
+                // Keep position updates lazy, but bound retained nodes even if nobody queries their ordering.
+                // Scaling the batch with the live set amortizes scanning it over many removals.
+                if (++removalsSinceLastCleanup >= Math.max(MIN_REMOVALS_BEFORE_CLEANUP, cursorCount)
+                        || cursorCount == 0) {
+                    compactRemovedNodes();
+                }
                 return true;
             } else {
                 return false;
@@ -269,6 +282,46 @@ public class ActiveManagedCursorContainerImpl implements ActiveManagedCursorCont
         } finally {
             rwLock.unlockWrite(stamp);
         }
+    }
+
+    private void compactRemovedNodes() {
+        // Preserve lazy position updates. PriorityQueue.removeIf compacts and heapifies in linear time.
+        pendingPositionUpdates.removeIf(node -> {
+            if (node.cursor == null) {
+                node.pendingPositionUpdateQueued = false;
+                return true;
+            }
+            return false;
+        });
+        if (pendingRemovedCursors.values().removeIf(node -> node.cursor == null)) {
+            Node previous = null;
+            Node current = head;
+            int count = 0;
+            while (current != null) {
+                Node next = current.next;
+                if (current.cursor == null) {
+                    if (previous == null) {
+                        head = next;
+                    } else {
+                        previous.next = next;
+                    }
+                    if (next != null) {
+                        next.prev = previous;
+                    }
+                    current.prev = null;
+                    current.next = null;
+                    trackedNodeCount--;
+                } else {
+                    // Equal-position nodes already share a counter. The last survivor in each group
+                    // sets its final rank, avoiding per-removal counter scans and new allocations.
+                    current.numberOfCursorsAtSamePositionOrBefore.setValue(++count);
+                    previous = current;
+                }
+                current = next;
+            }
+            tail = previous;
+        }
+        removalsSinceLastCleanup = 0;
     }
 
     /**
@@ -334,17 +387,25 @@ public class ActiveManagedCursorContainerImpl implements ActiveManagedCursorCont
                     pendingRemovedCursors.remove(cursor.getName());
                 }
                 // position changed, mark the node as pending
-                if (node.pendingPosition == null) {
-                    pendingPositionUpdates.add(node);
-                }
-                node.pendingPosition = newPosition;
+                queuePositionUpdate(node, newPosition);
             }
         } finally {
             rwLock.unlockWrite(stamp);
         }
     }
 
+    private void queuePositionUpdate(Node node, Position position) {
+        // Clearing pendingPosition cancels an update, but does not remove its heap entry.
+        // In particular, reactivating a node must not enqueue the same node again.
+        if (!node.pendingPositionUpdateQueued) {
+            pendingPositionUpdates.add(node);
+            node.pendingPositionUpdateQueued = true;
+        }
+        node.pendingPosition = position;
+    }
+
     private void processPendingPositions() {
+        removalsSinceLastCleanup = 0;
         if (pendingRemovedCursors.isEmpty() && pendingPositionUpdates.isEmpty()) {
             // No pending changes, nothing to do
             return;
@@ -370,6 +431,7 @@ public class ActiveManagedCursorContainerImpl implements ActiveManagedCursorCont
             if (node == null) {
                 break; // No more pending updates
             }
+            node.pendingPositionUpdateQueued = false;
             if (node.pendingPosition != null) {
                 if (node.position == null) {
                     node.position = node.pendingPosition;
@@ -393,6 +455,7 @@ public class ActiveManagedCursorContainerImpl implements ActiveManagedCursorCont
         // Collect all nodes that should be in the list and update their positions
         List<Node> activeNodes = new ArrayList<>();
         for (Node node : cursors.values()) {
+            node.pendingPositionUpdateQueued = false;
             if (node.pendingPosition != null) {
                 node.position = node.pendingPosition;
                 node.pendingPosition = null;
@@ -684,11 +747,21 @@ public class ActiveManagedCursorContainerImpl implements ActiveManagedCursorCont
 
     @Override
     public Position getSlowestCursorPosition() {
-        long stamp = rwLock.readLock();
+        long stamp = rwLock.tryOptimisticRead();
+        if (stamp != 0 && pendingRemovedCursors.isEmpty() && pendingPositionUpdates.isEmpty()) {
+            // Snapshot scalar fields only; a concurrent writer can invalidate the list before validation.
+            Node first = head;
+            Position position = first != null ? first.position : null;
+            if (rwLock.validate(stamp)) {
+                return position;
+            }
+        }
+        // Flushing pending changes mutates the list and must be exclusive.
+        stamp = rwLock.writeLock();
         try {
             return internalSlowestReaderPosition();
         } finally {
-            rwLock.unlockRead(stamp);
+            rwLock.unlockWrite(stamp);
         }
     }
 
@@ -725,14 +798,24 @@ public class ActiveManagedCursorContainerImpl implements ActiveManagedCursorCont
     public Iterator<ManagedCursor> iterator() {
         final Iterator<Map.Entry<String, Node>> it = cursors.entrySet().iterator();
         return new Iterator<ManagedCursor>() {
+            private ManagedCursor nextCursor;
+
             @Override
             public boolean hasNext() {
-                return it.hasNext();
+                while (nextCursor == null && it.hasNext()) {
+                    nextCursor = it.next().getValue().cursor;
+                }
+                return nextCursor != null;
             }
 
             @Override
             public ManagedCursor next() {
-                return it.next().getValue().cursor;
+                if (!hasNext()) {
+                    throw new NoSuchElementException();
+                }
+                ManagedCursor result = nextCursor;
+                nextCursor = null;
+                return result;
             }
 
             @Override
@@ -754,6 +837,33 @@ public class ActiveManagedCursorContainerImpl implements ActiveManagedCursorCont
             return node.numberOfCursorsAtSamePositionOrBefore.intValue();
         } finally {
             rwLock.unlockWrite(stamp);
+        }
+    }
+
+    @VisibleForTesting
+    int getPendingPositionUpdatesCount() {
+        long stamp = rwLock.readLock();
+        try {
+            return pendingPositionUpdates.size();
+        } finally {
+            rwLock.unlockRead(stamp);
+        }
+    }
+
+    /** Returns one entry per retained node, including null for nodes whose cursor was released. */
+    @VisibleForTesting
+    List<ManagedCursor> getRetainedCursors() {
+        long stamp = rwLock.readLock();
+        try {
+            Set<Node> nodes = new HashSet<>(cursors.values());
+            nodes.addAll(pendingPositionUpdates);
+            nodes.addAll(pendingRemovedCursors.values());
+            for (Node node = head; node != null; node = node.next) {
+                nodes.add(node);
+            }
+            return nodes.stream().map(node -> node.cursor).toList();
+        } finally {
+            rwLock.unlockRead(stamp);
         }
     }
 
@@ -784,7 +894,7 @@ public class ActiveManagedCursorContainerImpl implements ActiveManagedCursorCont
      */
     @VisibleForTesting
     void checkOrderingAndNumberOfCursorsState() {
-        long stamp = rwLock.readLock();
+        long stamp = rwLock.writeLock();
         try {
             processPendingPositions();
             Node current = head;
@@ -830,7 +940,7 @@ public class ActiveManagedCursorContainerImpl implements ActiveManagedCursorCont
 
             }
         } finally {
-            rwLock.unlockRead(stamp);
+            rwLock.unlockWrite(stamp);
         }
     }
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ActiveManagedCursorContainerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ActiveManagedCursorContainerImpl.java
@@ -20,6 +20,7 @@ package org.apache.bookkeeper.mledger.impl;
 
 import static java.util.Objects.requireNonNull;
 import com.google.common.annotations.VisibleForTesting;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -28,7 +29,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.PriorityQueue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -53,6 +53,8 @@ import org.apache.commons.lang3.tuple.Pair;
 @CustomLog
 public class ActiveManagedCursorContainerImpl implements ActiveManagedCursorContainer {
     private static final int MIN_REMOVALS_BEFORE_CLEANUP = 64;
+    // Below this size, the JDK 21 object-array sort does not allocate a temporary merge buffer.
+    private static final int SMALL_POSITION_UPDATE_BATCH = 32;
 
     private static class Node {
         // Iterators read this without the lock. Removed nodes must not retain the cursor's object graph.
@@ -95,18 +97,20 @@ public class ActiveManagedCursorContainerImpl implements ActiveManagedCursorCont
     // Maps a cursor to the node
     private final ConcurrentMap<String, Node> cursors = new ConcurrentHashMap<>();
     private final Map<String, Node> pendingRemovedCursors = new HashMap<>();
-    private final PriorityQueue<Node> pendingPositionUpdates = new PriorityQueue<>(new Comparator<Node>() {
+    // Accumulate without ordering; only incremental flushes benefit from ordering by old position.
+    private final ObjectArrayList<Node> pendingPositionUpdates = new ObjectArrayList<>();
+    private static final Comparator<Node> PENDING_POSITION_COMPARATOR = new Comparator<Node>() {
         @Override
         public int compare(Node o1, Node o2) {
             if (o1.position == null) {
-                return 1; // o1 is null, should be after o2
+                return o2.position == null ? 0 : -1;
             }
             if (o2.position == null) {
-                return -1; // o2 is null, should be after o1
+                return 1;
             }
-            return o2.position.compareTo(o1.position);
+            return o1.position.compareTo(o2.position);
         }
-    });
+    };
 
     private final StampedLock rwLock = new StampedLock();
 
@@ -290,7 +294,7 @@ public class ActiveManagedCursorContainerImpl implements ActiveManagedCursorCont
     }
 
     private void compactRemovedNodes() {
-        // Preserve lazy position updates. PriorityQueue.removeIf compacts and heapifies in linear time.
+        // Preserve lazy position updates while compacting the pending list in linear time.
         pendingPositionUpdates.removeIf(node -> {
             if (node.cursor == null) {
                 node.pendingPositionUpdateQueued = false;
@@ -400,7 +404,7 @@ public class ActiveManagedCursorContainerImpl implements ActiveManagedCursorCont
     }
 
     private void queuePositionUpdate(Node node, Position position) {
-        // Clearing pendingPosition cancels an update, but does not remove its heap entry.
+        // Clearing pendingPosition cancels an update, but does not remove its pending-list entry.
         // In particular, reactivating a node must not enqueue the same node again.
         if (!node.pendingPositionUpdateQueued) {
             pendingPositionUpdates.add(node);
@@ -431,11 +435,23 @@ public class ActiveManagedCursorContainerImpl implements ActiveManagedCursorCont
             }
             pendingRemovedCursors.clear();
         }
-        while (true) {
-            Node node = pendingPositionUpdates.poll();
-            if (node == null) {
-                break; // No more pending updates
+        int pendingCount = pendingPositionUpdates.size();
+        if (pendingCount > 1 && pendingCount < SMALL_POSITION_UPDATE_BATCH) {
+            // Keep the efficient small-array sort without allocating a temporary merge buffer.
+            pendingPositionUpdates.sort(PENDING_POSITION_COMPARATOR);
+        } else if (pendingCount >= SMALL_POSITION_UPDATE_BATCH) {
+            // Ordered batches need no sort. Otherwise use in-place sorting to avoid per-flush buffers.
+            for (int i = 1; i < pendingCount; i++) {
+                if (PENDING_POSITION_COMPARATOR.compare(pendingPositionUpdates.get(i - 1),
+                        pendingPositionUpdates.get(i)) > 0) {
+                    pendingPositionUpdates.unstableSort(PENDING_POSITION_COMPARATOR);
+                    break;
+                }
             }
+        }
+        while (!pendingPositionUpdates.isEmpty()) {
+            // Drain from the end to process descending old positions without shifting array elements.
+            Node node = pendingPositionUpdates.remove(pendingPositionUpdates.size() - 1);
             node.pendingPositionUpdateQueued = false;
             if (node.pendingPosition != null) {
                 if (node.position == null) {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ActiveManagedCursorContainerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ActiveManagedCursorContainerImpl.java
@@ -123,6 +123,11 @@ public class ActiveManagedCursorContainerImpl implements ActiveManagedCursorCont
                     }
                     node.pendingPosition = null;
                 } else {
+                    // Re-adding an existing cursor cancels pending untracking, just like updateCursor.
+                    if (node.pendingRemove) {
+                        node.pendingRemove = false;
+                        pendingRemovedCursors.remove(cursor.getName());
+                    }
                     queuePositionUpdate(node, position);
                 }
             } else {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ActiveManagedCursorContainerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ActiveManagedCursorContainerImpl.java
@@ -536,12 +536,7 @@ public class ActiveManagedCursorContainerImpl implements ActiveManagedCursorCont
 
             // update the position
             node.position = newPosition;
-            if (node == tail) {
-                // Node is at the tail, no need to update counters
-                return;
-            }
-
-            // update the counters
+            // Even the tail must leave or join shared counters when its position group changes.
             if (movingForward) {
                 // first decrement the counter for the old position
                 node.numberOfCursorsAtSamePositionOrBefore.decrement();

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ActiveManagedCursorContainerRetentionTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ActiveManagedCursorContainerRetentionTest.java
@@ -193,6 +193,39 @@ public class ActiveManagedCursorContainerRetentionTest {
         assertThat(container.getNumberOfCursorsAtSamePositionOrBefore(container.get("second"))).isEqualTo(2);
     }
 
+    @DataProvider
+    public Object[][] pendingUntracking() {
+        return new Object[][] {{1, false}, {1, true}, {10, false}, {10, true}};
+    }
+
+    @Test(dataProvider = "pendingUntracking")
+    public void testAddExistingCursorCancelsPendingUntracking(int cursorCount, boolean untrackWithAdd) {
+        ActiveManagedCursorContainerImpl container = new ActiveManagedCursorContainerImpl();
+        for (int i = 0; i < cursorCount; i++) {
+            addCursor(container, "cursor" + i, PositionFactory.create(1, i + 1));
+        }
+        container.getSlowestCursorPosition();
+        int movedIndex = cursorCount / 2;
+        ManagedCursor moved = container.get("cursor" + movedIndex);
+        if (untrackWithAdd) {
+            container.add(moved, null);
+        } else {
+            container.updateCursor(moved, null);
+        }
+        Position later = PositionFactory.create(1, cursorCount + 1);
+        container.add(moved, later);
+        // One pending update rebuilds a singleton container but uses incremental movement with ten cursors.
+        assertThat(container.getSlowestCursorPosition()).isEqualTo(cursorCount == 1 ? later : POSITION);
+        assertThat(container.size()).isEqualTo(cursorCount);
+        for (int i = 0; i < cursorCount; i++) {
+            int expectedRank = i == movedIndex ? cursorCount : (i < movedIndex ? i + 1 : i);
+            assertThat(container.getNumberOfCursorsAtSamePositionOrBefore(container.get("cursor" + i)))
+                    .as("rank of cursor%s after cancelling pending untracking", i)
+                    .isEqualTo(expectedRank);
+        }
+        container.checkOrderingAndNumberOfCursorsState();
+    }
+
     @Test
     public void testReactivatedTailLeavesSharedPositionGroup() {
         ActiveManagedCursorContainerImpl container = new ActiveManagedCursorContainerImpl();

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ActiveManagedCursorContainerRetentionTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ActiveManagedCursorContainerRetentionTest.java
@@ -194,6 +194,71 @@ public class ActiveManagedCursorContainerRetentionTest {
     }
 
     @Test
+    public void testReactivatedTailLeavesSharedPositionGroup() {
+        ActiveManagedCursorContainerImpl container = new ActiveManagedCursorContainerImpl();
+        for (int i = 0; i < 6; i++) {
+            addCursor(container, "cursor" + i, POSITION);
+        }
+        container.getSlowestCursorPosition();
+        // Insert incrementally after the existing group to establish the tail independently of map iteration order.
+        addCursor(container, "tail", POSITION);
+        container.getSlowestCursorPosition();
+        for (int i = 3; i < 6; i++) {
+            container.removeCursor("cursor" + i);
+        }
+        container.getSlowestCursorPosition();
+
+        Position later = PositionFactory.create(1, 2);
+        container.updateCursor(container.get("tail"), later);
+        container.removeCursor("tail");
+        addCursor(container, "tail", later);
+        assertThat(container.getPendingPositionUpdatesCount()).isEqualTo(1);
+        for (int i = 0; i < 3; i++) {
+            assertThat(container.getNumberOfCursorsAtSamePositionOrBefore(container.get("cursor" + i)))
+                    .as("rank of cursor%s after the reactivated tail leaves its group", i)
+                    .isEqualTo(3);
+        }
+        assertThat(container.getNumberOfCursorsAtSamePositionOrBefore(container.get("tail"))).isEqualTo(4);
+        container.checkOrderingAndNumberOfCursorsState();
+    }
+
+    @Test
+    public void testTailPositionGroupsRemainCorrectAfterCompaction() {
+        ActiveManagedCursorContainerImpl container = new ActiveManagedCursorContainerImpl();
+        for (int i = 0; i < 4; i++) {
+            addCursor(container, "cursor" + i, POSITION);
+        }
+        addCursor(container, "tail", PositionFactory.create(1, 3));
+        container.getSlowestCursorPosition();
+        ManagedCursor tailCursor = container.get("tail");
+        // Join and leave the preceding group, and move in both directions within a separate tail group.
+        for (int entryId : new int[] {1, 2, 3, 2, 1, 2}) {
+            container.updateCursor(tailCursor, PositionFactory.create(1, entryId));
+            for (int i = 0; i < 4; i++) {
+                assertThat(container.getNumberOfCursorsAtSamePositionOrBefore(container.get("cursor" + i)))
+                        .as("rank of cursor%s with tail at entry %s", i, entryId)
+                        .isEqualTo(entryId == 1 ? 5 : 4);
+            }
+            assertThat(container.getNumberOfCursorsAtSamePositionOrBefore(tailCursor)).isEqualTo(5);
+            container.checkOrderingAndNumberOfCursorsState();
+        }
+
+        container.removeCursor("cursor0");
+        for (int i = 0; i < 63; i++) {
+            addCursor(container, "temporary" + i, POSITION);
+            container.removeCursor("temporary" + i);
+        }
+        // The removal batch compacts the tracked list without flushing any position updates.
+        assertThat(container.getRetainedCursors()).hasSize(4).doesNotContainNull();
+        for (int i = 1; i < 4; i++) {
+            assertThat(container.getNumberOfCursorsAtSamePositionOrBefore(container.get("cursor" + i)))
+                    .isEqualTo(3);
+        }
+        assertThat(container.getNumberOfCursorsAtSamePositionOrBefore(tailCursor)).isEqualTo(4);
+        container.checkOrderingAndNumberOfCursorsState();
+    }
+
+    @Test
     public void testSlowestPositionReadDoesNotExcludeOtherReaders() throws Exception {
         ActiveManagedCursorContainerImpl container = new ActiveManagedCursorContainerImpl();
         ManagedCursor cursor = mock(ManagedCursor.class);

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ActiveManagedCursorContainerRetentionTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ActiveManagedCursorContainerRetentionTest.java
@@ -27,8 +27,11 @@ import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import io.netty.util.concurrent.DefaultThreadFactory;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -43,6 +46,58 @@ import org.testng.annotations.Test;
 
 public class ActiveManagedCursorContainerRetentionTest {
     private static final Position POSITION = PositionFactory.create(1, 1);
+
+    @DataProvider
+    public Object[][] positionUpdateBatches() {
+        List<Object[]> cases = new ArrayList<>();
+        for (int batchSize : new int[] {1, 31, 32, 33, 80, 100}) {
+            for (boolean reverse : new boolean[] {false, true}) {
+                for (boolean includeNewCursors : new boolean[] {false, true}) {
+                    cases.add(new Object[] {batchSize, reverse, includeNewCursors});
+                }
+            }
+        }
+        return cases.toArray(new Object[0][]);
+    }
+
+    @Test(dataProvider = "positionUpdateBatches")
+    public void testBatchedPositionsMatchCursorRanks(int batchSize, boolean reverse, boolean includeNewCursors) {
+        ActiveManagedCursorContainerImpl container = new ActiveManagedCursorContainerImpl();
+        Map<String, Position> positions = new HashMap<>();
+        for (int i = 0; i < 200; i++) {
+            Position position = PositionFactory.create(1, i / 3);
+            addCursor(container, "cursor" + i, position);
+            positions.put("cursor" + i, position);
+        }
+        container.getSlowestCursorPosition();
+        for (int round = 0; round < 2; round++) {
+            for (int i = 0; i < batchSize; i++) {
+                int index = reverse ? batchSize - i - 1 : i;
+                String name = includeNewCursors && index % 2 == 0 ? "new" + index : "cursor" + index;
+                Position intermediate = PositionFactory.create(1, 1000 + index);
+                if (!positions.containsKey(name)) {
+                    addCursor(container, name, intermediate);
+                } else {
+                    container.updateCursor(container.get(name), intermediate);
+                }
+                // Coalesce repeated updates while moving into shared groups in both directions.
+                Position latest = PositionFactory.create(1, (index + round) % 2 == 0 ? index % 7 : 200 + index % 7);
+                container.updateCursor(container.get(name), latest);
+                positions.put(name, latest);
+            }
+            assertThat(container.getPendingPositionUpdatesCount()).isEqualTo(batchSize);
+            for (Map.Entry<String, Position> entry : positions.entrySet()) {
+                int expectedRank = (int) positions.values().stream()
+                        .filter(position -> position.compareTo(entry.getValue()) <= 0).count();
+                assertThat(container.getNumberOfCursorsAtSamePositionOrBefore(container.get(entry.getKey())))
+                        .as("rank of %s after batch %s", entry.getKey(), round).isEqualTo(expectedRank);
+            }
+            assertThat(container.getSlowestCursorPosition())
+                    .isEqualTo(positions.values().stream().min(Position::compareTo).orElseThrow());
+            assertThat(container.getPendingPositionUpdatesCount()).isZero();
+            container.checkOrderingAndNumberOfCursorsState();
+        }
+    }
 
     @DataProvider
     public Object[][] tracked() {
@@ -186,7 +241,7 @@ public class ActiveManagedCursorContainerRetentionTest {
                 assertThat(container.getPendingPositionUpdatesCount()).isEqualTo(2);
             } else {
                 // Compaction can discard the removed node before reactivation, leaving new orphan
-                // nodes until the next batch. Reused active nodes must not accumulate heap entries.
+                // nodes until the next batch. Reused active nodes must not accumulate pending-list entries.
                 assertThat(container.getPendingPositionUpdatesCount()).isLessThanOrEqualTo(66);
             }
         }

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ActiveManagedCursorContainerRetentionTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ActiveManagedCursorContainerRetentionTest.java
@@ -23,6 +23,7 @@ import static org.apache.bookkeeper.mledger.impl.MockManagedCursor.addCursor;
 import static org.apache.bookkeeper.mledger.impl.MockManagedCursor.createCursor;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import io.netty.util.concurrent.DefaultThreadFactory;
@@ -33,6 +34,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.PositionFactory;
@@ -289,6 +291,75 @@ public class ActiveManagedCursorContainerRetentionTest {
         }
         assertThat(container.getNumberOfCursorsAtSamePositionOrBefore(tailCursor)).isEqualTo(4);
         container.checkOrderingAndNumberOfCursorsState();
+    }
+
+    @Test
+    public void testCompactionRemovesTailBeforeAppending() {
+        ActiveManagedCursorContainerImpl container = new ActiveManagedCursorContainerImpl();
+        for (int i = 1; i <= 5; i++) {
+            addCursor(container, "cursor" + i, PositionFactory.create(1, i));
+        }
+        container.getSlowestCursorPosition();
+        container.removeCursor("cursor5");
+        for (int i = 0; i < 63; i++) {
+            addCursor(container, "temporary" + i, POSITION);
+            container.removeCursor("temporary" + i);
+        }
+        // Verify compaction occurred without a position query repairing the list first.
+        assertThat(container.getRetainedCursors()).hasSize(4).doesNotContainNull();
+        Position appendedPosition = PositionFactory.create(1, 9);
+        addCursor(container, "appended", appendedPosition);
+        ManagedCursor appended = container.get("appended");
+        assertThat(container.getPendingPositionUpdatesCount()).isEqualTo(1);
+        assertThat(container.getNumberOfCursorsAtSamePositionOrBefore(appended)).isEqualTo(5);
+        container.checkOrderingAndNumberOfCursorsState();
+        for (int i = 1; i <= 4; i++) {
+            container.removeCursor("cursor" + i);
+        }
+        assertThat(container.size()).isEqualTo(1);
+        assertThat(container.getSlowestCursorPosition()).isEqualTo(appendedPosition);
+        assertThat(container.getNumberOfCursorsAtSamePositionOrBefore(appended)).isEqualTo(1);
+        container.checkOrderingAndNumberOfCursorsState();
+    }
+
+    @Test
+    public void testSlowestPositionFlushWaitsForReaders() throws Exception {
+        ActiveManagedCursorContainerImpl container = new ActiveManagedCursorContainerImpl();
+        ManagedCursor cursor = mock(ManagedCursor.class);
+        when(cursor.getName()).thenReturn("cursor");
+        container.add(cursor, POSITION);
+        CountDownLatch readLockHeld = new CountDownLatch(1);
+        CountDownLatch releaseReadLock = new CountDownLatch(1);
+        AtomicReference<Thread> flushThread = new AtomicReference<>();
+        assertThat(container.getPendingPositionUpdatesCount()).isEqualTo(1);
+        when(cursor.toString()).thenAnswer(invocation -> {
+            readLockHeld.countDown();
+            assertThat(releaseReadLock.await(30, SECONDS)).isTrue();
+            return "cursor";
+        });
+        ExecutorService executor = Executors.newFixedThreadPool(2,
+                new DefaultThreadFactory("cursor-container-flush-test"));
+        try {
+            Future<String> reader = executor.submit(container::toString);
+            assertThat(readLockHeld.await(10, SECONDS)).isTrue();
+            Future<Position> slowest = executor.submit(() -> {
+                flushThread.set(Thread.currentThread());
+                return container.getSlowestCursorPosition();
+            });
+            // Wait for actual lock contention, rather than assuming the task ran after a fixed delay.
+            // A shared-lock regression completes the task instead and fails the following assertion.
+            await().atMost(10, SECONDS).until(() -> slowest.isDone()
+                    || (flushThread.get() != null && flushThread.get().getState() == Thread.State.WAITING));
+            assertThat(slowest.isDone()).isFalse();
+            releaseReadLock.countDown();
+            assertThat(slowest.get(10, SECONDS)).isEqualTo(POSITION);
+            assertThat(reader.get(10, SECONDS)).isEqualTo("[cursor]");
+            assertThat(container.getPendingPositionUpdatesCount()).isZero();
+        } finally {
+            releaseReadLock.countDown();
+            executor.shutdownNow();
+            assertThat(executor.awaitTermination(10, SECONDS)).isTrue();
+        }
     }
 
     @Test

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ActiveManagedCursorContainerRetentionTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ActiveManagedCursorContainerRetentionTest.java
@@ -1,0 +1,267 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.mledger.impl;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.bookkeeper.mledger.impl.MockManagedCursor.addCursor;
+import static org.apache.bookkeeper.mledger.impl.MockManagedCursor.createCursor;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import io.netty.util.concurrent.DefaultThreadFactory;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import org.apache.bookkeeper.mledger.ManagedCursor;
+import org.apache.bookkeeper.mledger.Position;
+import org.apache.bookkeeper.mledger.PositionFactory;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class ActiveManagedCursorContainerRetentionTest {
+    private static final Position POSITION = PositionFactory.create(1, 1);
+
+    @DataProvider
+    public Object[][] tracked() {
+        return new Object[][] {{false}, {true}};
+    }
+
+    @Test(dataProvider = "tracked")
+    public void testRemovedCursorReleasedBeforeCleanup(boolean tracked) {
+        ActiveManagedCursorContainerImpl container = new ActiveManagedCursorContainerImpl();
+        ManagedCursor survivor = createCursor(container, "survivor", POSITION);
+        container.add(survivor, POSITION);
+        addCursor(container, "removed", POSITION);
+        if (tracked) {
+            container.getSlowestCursorPosition();
+        }
+        container.removeCursor("removed");
+
+        // Inspect retention without triggering a position flush or relying on GC timing.
+        assertThat(container.getRetainedCursors()).containsExactlyInAnyOrder(survivor, null);
+        assertThat(container.getNumberOfCursorsAtSamePositionOrBefore(survivor)).isEqualTo(1);
+        container.checkOrderingAndNumberOfCursorsState();
+    }
+
+    @Test(dataProvider = "tracked")
+    public void testLastRemovalClearsRetainedNodes(boolean tracked) {
+        ActiveManagedCursorContainerImpl container = new ActiveManagedCursorContainerImpl();
+        for (int i = 0; i < 100; i++) {
+            addCursor(container, "cursor", POSITION);
+            if (tracked) {
+                container.getSlowestCursorPosition();
+            }
+            assertThat(container.removeCursor("cursor")).isTrue();
+            assertThat(container.getRetainedCursors()).isEmpty();
+            assertThat(container.size()).isZero();
+        }
+    }
+
+    @Test
+    public void testPendingNodesBoundedWithoutPositionQueries() {
+        ActiveManagedCursorContainerImpl container = new ActiveManagedCursorContainerImpl();
+        ManagedCursor survivor = createCursor(container, "survivor", POSITION);
+        container.add(survivor, POSITION);
+        for (int i = 0; i < 1000; i++) {
+            addCursor(container, "cursor" + i, POSITION);
+            container.removeCursor("cursor" + i);
+            List<ManagedCursor> retained = container.getRetainedCursors();
+            assertThat(retained).hasSizeLessThanOrEqualTo(65);
+            assertThat(retained.stream().filter(cursor -> cursor != null).toList()).containsExactly(survivor);
+        }
+        assertThat(container.getNumberOfCursorsAtSamePositionOrBefore(survivor)).isEqualTo(1);
+        container.checkOrderingAndNumberOfCursorsState();
+    }
+
+    @Test
+    public void testTrackedRemovalsTriggerCleanupWithoutPendingUpdates() {
+        ActiveManagedCursorContainerImpl container = new ActiveManagedCursorContainerImpl();
+        for (int i = 0; i < 1000; i++) {
+            addCursor(container, "cursor" + i, PositionFactory.create(1, i));
+        }
+        container.getSlowestCursorPosition();
+        for (int i = 0; i < 900; i++) {
+            container.removeCursor("cursor" + i);
+            assertThat(container.getRetainedCursors()).hasSizeLessThanOrEqualTo(
+                    container.size() + Math.max(64, container.size()));
+            if (i == 63) {
+                // A large live set should not be rebuilt every fixed-size batch of removals.
+                assertThat(container.getRetainedCursors()).hasSize(1000);
+            }
+        }
+        assertThat(container.getSlowestCursorPosition()).isEqualTo(PositionFactory.create(1, 900));
+        assertThat(container.getNumberOfCursorsAtSamePositionOrBefore(container.get("cursor999"))).isEqualTo(100);
+        container.checkOrderingAndNumberOfCursorsState();
+    }
+
+    @Test
+    public void testCompactionPreservesPendingUpdatesAndSharedCounters() {
+        ActiveManagedCursorContainerImpl container = new ActiveManagedCursorContainerImpl();
+        for (int i = 0; i < 200; i++) {
+            addCursor(container, "cursor" + i, PositionFactory.create(1, i / 10));
+        }
+        container.getSlowestCursorPosition();
+        ManagedCursor moved = container.get("cursor199");
+        container.updateCursor(moved, PositionFactory.create(1, 0));
+        for (int i = 0; i < 200; i += 2) {
+            container.removeCursor("cursor" + i);
+        }
+        assertThat(container.getRetainedCursors()).hasSize(100).doesNotContainNull();
+        assertThat(container.getPendingPositionUpdatesCount()).isEqualTo(1);
+        assertThat(container.getNumberOfCursorsAtSamePositionOrBefore(moved)).isEqualTo(6);
+        for (int i = 1; i < 199; i += 2) {
+            assertThat(container.getNumberOfCursorsAtSamePositionOrBefore(container.get("cursor" + i)))
+                    .as("rank of cursor%s after compaction and the pending move", i)
+                    .isEqualTo(Math.min(100, (i / 10 + 1) * 5 + 1));
+        }
+        container.checkOrderingAndNumberOfCursorsState();
+    }
+
+    @Test
+    public void testPositionQueryResetsCleanupBatch() {
+        ActiveManagedCursorContainerImpl container = new ActiveManagedCursorContainerImpl();
+        addCursor(container, "survivor", POSITION);
+        for (int i = 0; i < 63; i++) {
+            addCursor(container, "cursor" + i, POSITION);
+            container.removeCursor("cursor" + i);
+        }
+        container.getSlowestCursorPosition();
+        addCursor(container, "removed", POSITION);
+        container.removeCursor("removed");
+        // The query already reclaimed the old batch; this removal should remain deferred.
+        assertThat(container.getRetainedCursors()).hasSize(2).containsNull();
+    }
+
+    @Test
+    public void testReusedNodeUsesCurrentCursorInstance() {
+        ActiveManagedCursorContainerImpl container = new ActiveManagedCursorContainerImpl();
+        addCursor(container, "survivor", POSITION);
+        addCursor(container, "recreated", POSITION);
+        container.getSlowestCursorPosition();
+        container.removeCursor("recreated");
+        ManagedCursor replacement = createCursor(container, "recreated", POSITION);
+        container.add(replacement, POSITION);
+
+        assertThat(container.get("recreated")).isSameAs(replacement);
+        assertThat(container.getRetainedCursors()).doesNotContainNull().contains(replacement);
+        assertThat(container.getNumberOfCursorsAtSamePositionOrBefore(replacement)).isEqualTo(2);
+        container.checkOrderingAndNumberOfCursorsState();
+    }
+
+    @Test
+    public void testReactivationDoesNotDuplicatePendingUpdates() {
+        ActiveManagedCursorContainerImpl container = new ActiveManagedCursorContainerImpl();
+        addCursor(container, "first", POSITION);
+        addCursor(container, "second", POSITION);
+        container.getSlowestCursorPosition();
+        for (int i = 0; i < 1000; i++) {
+            container.removeCursor("first");
+            addCursor(container, "first", POSITION);
+            container.removeCursor("second");
+            addCursor(container, "second", POSITION);
+            if (i < 31) {
+                assertThat(container.getPendingPositionUpdatesCount()).isEqualTo(2);
+            } else {
+                // Compaction can discard the removed node before reactivation, leaving new orphan
+                // nodes until the next batch. Reused active nodes must not accumulate heap entries.
+                assertThat(container.getPendingPositionUpdatesCount()).isLessThanOrEqualTo(66);
+            }
+        }
+        container.checkOrderingAndNumberOfCursorsState();
+        assertThat(container.getNumberOfCursorsAtSamePositionOrBefore(container.get("first"))).isEqualTo(2);
+        assertThat(container.getNumberOfCursorsAtSamePositionOrBefore(container.get("second"))).isEqualTo(2);
+    }
+
+    @Test
+    public void testSlowestPositionReadDoesNotExcludeOtherReaders() throws Exception {
+        ActiveManagedCursorContainerImpl container = new ActiveManagedCursorContainerImpl();
+        ManagedCursor cursor = mock(ManagedCursor.class);
+        when(cursor.getName()).thenReturn("cursor");
+        container.add(cursor, POSITION);
+        assertThat(container.getSlowestCursorPosition()).isEqualTo(POSITION);
+
+        CountDownLatch readLockHeld = new CountDownLatch(1);
+        CountDownLatch releaseReadLock = new CountDownLatch(1);
+        when(cursor.toString()).thenAnswer(invocation -> {
+            // toString calls the cursor while holding the container's read lock.
+            readLockHeld.countDown();
+            assertThat(releaseReadLock.await(30, SECONDS)).isTrue();
+            return "cursor";
+        });
+        ExecutorService executor = Executors.newFixedThreadPool(2,
+                new DefaultThreadFactory("cursor-container-read-test"));
+        try {
+            Future<String> reader = executor.submit(container::toString);
+            assertThat(readLockHeld.await(10, SECONDS)).isTrue();
+            Future<Position> slowest = executor.submit(container::getSlowestCursorPosition);
+            assertThat(slowest.get(10, SECONDS)).isEqualTo(POSITION);
+            releaseReadLock.countDown();
+            assertThat(reader.get(10, SECONDS)).isEqualTo("[cursor]");
+        } finally {
+            releaseReadLock.countDown();
+            executor.shutdownNow();
+            assertThat(executor.awaitTermination(10, SECONDS)).isTrue();
+        }
+    }
+
+    @Test
+    public void testSlowestPositionFlushesPendingChanges() {
+        ActiveManagedCursorContainerImpl container = new ActiveManagedCursorContainerImpl();
+        assertThat(container.getSlowestCursorPosition()).isNull();
+        Position later = PositionFactory.create(1, 2);
+        Position latest = PositionFactory.create(1, 3);
+        addCursor(container, "later", later);
+        assertThat(container.getSlowestCursorPosition()).isEqualTo(later);
+        assertThat(container.getSlowestCursorPosition()).isEqualTo(later);
+        addCursor(container, "earlier", POSITION);
+        assertThat(container.getSlowestCursorPosition()).isEqualTo(POSITION);
+        container.updateCursor(container.get("earlier"), latest);
+        assertThat(container.getSlowestCursorPosition()).isEqualTo(later);
+        container.removeCursor("later");
+        assertThat(container.getSlowestCursorPosition()).isEqualTo(latest);
+        assertThat(container.getSlowestCursorPosition()).isEqualTo(latest);
+        container.removeCursor("earlier");
+        assertThat(container.getSlowestCursorPosition()).isNull();
+    }
+
+    @Test
+    public void testIteratorSkipsRemovedNodes() {
+        ActiveManagedCursorContainerImpl container = new ActiveManagedCursorContainerImpl();
+        addCursor(container, "first", POSITION);
+        addCursor(container, "second", POSITION);
+        Iterator<ManagedCursor> iterator = container.iterator();
+        container.removeCursor("first");
+        container.removeCursor("second");
+        assertThat(iterator.hasNext()).isFalse();
+        assertThatThrownBy(iterator::next).isInstanceOf(NoSuchElementException.class);
+
+        addCursor(container, "third", POSITION);
+        Iterator<ManagedCursor> prefetched = container.iterator();
+        assertThat(prefetched.hasNext()).isTrue();
+        assertThat(prefetched.hasNext()).isTrue();
+        container.removeCursor("third");
+        assertThat(prefetched.next().getName()).isEqualTo("third");
+        assertThat(prefetched.hasNext()).isFalse();
+    }
+}

--- a/microbench/src/main/java/org/apache/bookkeeper/mledger/impl/ActiveManagedCursorContainerBenchmark.java
+++ b/microbench/src/main/java/org/apache/bookkeeper/mledger/impl/ActiveManagedCursorContainerBenchmark.java
@@ -135,6 +135,19 @@ public class ActiveManagedCursorContainerBenchmark {
 
     @Threads(1)
     @Benchmark
+    public int tailSeekingForward(ThreadState threadState) {
+        long counter = threadState.nextCounter();
+        ManagedCursor cursor = cursors.get(cursors.size() - 1);
+        // Keep moving the fastest cursor, without joining or leaving a shared position group.
+        cursor.seek(cursor.getReadPosition().getPositionAfterEntries(1));
+        return getNumberOfCursorsAtSamePositionOrBeforeRatio > 0
+                && counter % getNumberOfCursorsAtSamePositionOrBeforeRatio == 0
+                ? container.getNumberOfCursorsAtSamePositionOrBefore(cursor)
+                : (int) cursor.getReadPosition().getEntryId();
+    }
+
+    @Threads(1)
+    @Benchmark
     public Position slowestCursorPosition01() {
         return container.getSlowestCursorPosition();
     }

--- a/microbench/src/main/java/org/apache/bookkeeper/mledger/impl/ActiveManagedCursorContainerBenchmark.java
+++ b/microbench/src/main/java/org/apache/bookkeeper/mledger/impl/ActiveManagedCursorContainerBenchmark.java
@@ -25,6 +25,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
 import org.apache.bookkeeper.mledger.ManagedCursor;
+import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.PositionFactory;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -130,6 +131,34 @@ public class ActiveManagedCursorContainerBenchmark {
     @Benchmark
     public int randomSeekingForward10(ThreadState threadState) {
         return doRandomSeekingForward(threadState);
+    }
+
+    @Threads(1)
+    @Benchmark
+    public Position slowestCursorPosition01() {
+        return container.getSlowestCursorPosition();
+    }
+
+    @Threads(10)
+    @Benchmark
+    public Position slowestCursorPosition10() {
+        return container.getSlowestCursorPosition();
+    }
+
+    @Threads(1)
+    @Benchmark
+    public int cursorChurn(ThreadState threadState) {
+        long counter = threadState.nextCounter();
+        // Keep the other cursors active while repeatedly replacing one subscription.
+        container.removeCursor(cursors.get(0).getName());
+        // Use a new name and instance so that removed nodes cannot simply be reused indefinitely.
+        MockManagedCursor cursor = MockManagedCursor.createCursor(container, "churn" + counter,
+                PositionFactory.create(0, counter));
+        cursors.set(0, cursor);
+        container.add(cursor, cursor.getReadPosition());
+        return getNumberOfCursorsAtSamePositionOrBeforeRatio > 0
+                && counter % getNumberOfCursorsAtSamePositionOrBeforeRatio == 0
+                ? container.getNumberOfCursorsAtSamePositionOrBefore(cursor) : container.size();
     }
 
     private int doRandomSeekingForward(ThreadState threadState) {

--- a/microbench/src/main/java/org/apache/bookkeeper/mledger/impl/ActiveManagedCursorContainerCohortBenchmark.java
+++ b/microbench/src/main/java/org/apache/bookkeeper/mledger/impl/ActiveManagedCursorContainerCohortBenchmark.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.mledger.impl;
+
+import java.util.concurrent.TimeUnit;
+import org.apache.bookkeeper.mledger.PositionFactory;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+public class ActiveManagedCursorContainerCohortBenchmark {
+    @Param({"100", "500"})
+    public int numberOfCursors;
+    private ActiveManagedCursorContainerImpl container;
+    private MockManagedCursor[] cohort;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        container = new ActiveManagedCursorContainerImpl();
+        cohort = new MockManagedCursor[32];
+        for (int i = 0; i < numberOfCursors; i++) {
+            var position = PositionFactory.create(1, i);
+            var cursor = MockManagedCursor.createCursor(container, "cursor" + i, position);
+            container.add(cursor, position);
+            if (i >= numberOfCursors - cohort.length) {
+                cohort[i - (numberOfCursors - cohort.length)] = cursor;
+            }
+        }
+        container.checkOrderingAndNumberOfCursorsState();
+    }
+
+    @Benchmark
+    @Threads(1)
+    @OperationsPerInvocation(32)
+    public int advanceCohort() {
+        // Queue a wave in ascending old-position order. Each cursor advances beyond all old cohort positions.
+        for (var cursor : cohort) {
+            cursor.seek(cursor.getReadPosition().getPositionAfterEntries(cohort.length));
+        }
+        // 32 pending updates stay below trackedNodeCount / 2 for both parameters, forcing incremental processing.
+        return container.getNumberOfCursorsAtSamePositionOrBefore(cohort[cohort.length - 1]);
+    }
+
+    @TearDown(Level.Trial)
+    public void verify() {
+        container.checkOrderingAndNumberOfCursorsState();
+        for (int i = 0; i < cohort.length; i++) {
+            int expected = numberOfCursors - cohort.length + i + 1;
+            if (container.getNumberOfCursorsAtSamePositionOrBefore(cohort[i]) != expected) {
+                throw new AssertionError("Wrong cohort rank at index " + i);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Replacement for #26506.

### Motivation

`ActiveManagedCursorContainerImpl` defers cursor ordering until a position query needs it. With `cacheEvictionByExpectedReadCount` enabled, cursor creation and deletion can continue without such queries. Removed nodes then accumulate in `pendingPositionUpdates` or remain in the ordered list and `pendingRemovedCursors`, retaining their cursor objects and associated object graphs.

This PR replaces the approach in #26506 with immediate cursor-reference release and bounded, batched node compaction. The ten-event flush in #26506 counts cursors removed before their first position flush; already-tracked removals are outside that cleanup trigger. Preserving lazy position updates is important to the efficiency of this data structure.

This also fixes a pre-existing synchronization bug: `getSlowestCursorPosition()` held a **read lock** while calling `processPendingPositions()`, which mutates the pending-update collection, linked list, and counters. Concurrent readers could therefore flush the same state simultaneously. The internal state-checking method had the same locking problem. This is API-correctness hardening: under the current broker configuration paths, this implementation is selected when `cacheEvictionByExpectedReadCount` is enabled, and the broker skips its slowest-position lookup in that mode. The production rank-query path already used the write lock.

### Modifications

- Clear the cursor reference immediately on removal. Make it volatile for the existing lock-free iterator, skip cleared references during iteration, and install the current cursor instance when reusing a node.
- Compact removed nodes after `max(64, live cursor count)` removals, or immediately when the container becomes empty. Prune the pending-update list and unlink removed list nodes in linear time, repairing shared counters in one pass. Compaction preserves pending position updates and does not sort or flush them.
- Track pending-list membership separately from `pendingPosition`, so cancellation and reactivation cannot add the same node repeatedly.
- Replace the pending priority queue with a Fastutil `ObjectArrayList` and sort only before incremental flushes. Process descending old positions to reduce list traversal when cursors advance together. Small batches use the standard sort; larger batches skip sorting when already ordered and otherwise use in-place quicksort to avoid temporary merge buffers. Full rebuilds skip pending-list sorting. Fastutil is already a dependency.
- Make `add()` cancel pending untracking when an existing cursor receives a real position, matching `updateCursor()`. This is a defensive consistency fix: production activation currently guards against adding an already-active cursor.
- Fix a pre-existing, production-reachable tail-counter bug: a tail can leave or join a shared position group without changing list order. Skipping group-counter adjustments produces incorrect ranks even with ordinary position updates on master. Deduplicated reactivation exposes another trigger by avoiding a full rebuild that previously masked the bug. Reuse the existing counter when the tail remains in its own position group, avoiding an allocation without skipping shared-group adjustments.
- Use a validated optimistic read for clean slowest-position lookups. Fall back to the write lock when pending changes need flushing or concurrent mutation invalidates the snapshot. The state-checking method also uses the write lock when flushing.
- Add deterministic retention, compaction, reactivation, iterator, and slowest-position tests. Pin exclusive locking for pending flushes and appending after compaction removes the tail. Strengthen the test-only state checker to validate live cursor references, backward links, the tail, and the tracked node count. Extend `ActiveManagedCursorContainerBenchmark` with cursor-churn, read-only slowest-position, and tail-seek workloads. Add `ActiveManagedCursorContainerCohortBenchmark` for grouped cursor advances.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

Local validation passed:

```shell
./gradlew :managed-ledger:test \
  --tests ActiveManagedCursorContainerTest \
  --tests ActiveManagedCursorContainerRetentionTest \
  -PtestRetryCount=0 -PtestFailFast=false
./gradlew quickCheck
```

The two test classes now run 59 cases. The 11 retention regression cases fail on the unpatched implementation with only read-only testing accessors added. Coverage includes removal before and after position tracking, bounded retention without queries, preserving deferred updates and shared counters during compaction, repeated reactivation, replacement cursor identity, iterator behavior, and cached reads completing while another reader holds the lock. Two additional regression cases fail before the tail-counter fix and cover reactivation after a pending move, joining and leaving position groups, and subsequent compaction. Four further regression cases cover cancelling pending untracking through `add()` on both rebuild and incremental paths; all four fail before the defensive fix. Two further tests protect the pending-flush write lock and compaction tail repair. Both were mutation-tested: replacing the flush write lock with a read lock fails the first test; removing `tail = previous` from compaction fails the second. The additional structural checks run only in the test helper, not on production paths. A further 24 parameterized cases verify batches around the sorting threshold, ascending/reverse arrival order, mixed new and tracked nodes, coalesced repeated updates, shared positions, and a second flush to check pending-state reuse.

#### Performance measurements

The final hybrid implementation at `108223dba7b4` was measured against this PR's previous PriorityQueue implementation at `c80d72a4db89`, plus a fresh churn comparison against #26506. All 18 configurations completed and passed their benchmark state checks. Both sides use the same final benchmark jar and dependencies; only implementation classes are overridden for the comparison variants.

Environment: macOS arm64, Corretto 21.0.11, DEFAULT implementation, 256 MiB heap, GC profiler. Each configuration uses two forks, two 1-second warmup iterations and three 1-second measurement iterations per fork. Variants run sequentially, alternating order between parameter combinations. Tables show millions of updates/operations per second ± JMH-reported 99.9% error; percentages compare means. These are short local measurements, not production performance guarantees. Linux x86_64 validation is still needed.

**Final hybrid versus the previous PriorityQueue implementation**

Query ratio is updates per rank query; zero disables rank queries. `randomSeekingForward01` uses one thread and `randomSeekingForward10` uses ten. `cohort` is the new `ActiveManagedCursorContainerCohortBenchmark.advanceCohort`: it advances the fastest 32 cursors together in ascending old-position order, then queries rank. Both population sizes force incremental processing, and `@OperationsPerInvocation(32)` normalizes throughput and allocation per cursor update. This deliberately ordering-sensitive workload demonstrates the traversal benefit; it is not a measured broker traffic distribution.

| Workload | Cursors | Query ratio | PriorityQueue M ops/s | Final hybrid M ops/s | Mean change | Allocation B/op (before → after) |
|---|---:|---:|---:|---:|---:|---:|
| `randomSeekingForward01` | 100 | 1 | 28.80 ± 0.77 | 33.29 ± 1.07 | +15.6% | 47.83 → 47.83 |
| `randomSeekingForward01` | 100 | 10 | 21.61 ± 0.18 | 24.41 ± 1.84 | +12.9% | 47.14 → 47.14 |
| `randomSeekingForward01` | 100 | 100 | 15.20 ± 0.29 | 18.07 ± 0.31 | +18.9% | 65.35 → 65.35 |
| `randomSeekingForward01` | 500 | 100 | 10.65 ± 0.61 | 10.68 ± 0.52 | +0.2% | 46.37 → 46.37 |
| `randomSeekingForward10` | 500 | 10 | 6.16 ± 0.58 | 6.89 ± 0.96 | +11.8% | 48.37 → 48.33 |
| `cohort` | 100 | 32 | 29.12 ± 0.86 | 51.02 ± 3.14 | +75.2% | 47.50 → 47.50 |
| `cohort` | 500 | 32 | 29.11 ± 0.38 | 43.78 ± 4.41 | +50.4% | 47.50 → 47.50 |
| `cursorChurn` | 500 | 0 | 16.15 ± 0.40 | 16.80 ± 0.33 | +4.0% | 192.16 → 192.00 |

**Cursor churn versus #26506**

At 500 active cursors with no rank queries, `cursorChurn` measures **15.09 ± 0.56 M ops/s for #26506** versus **16.66 ± 0.48 M ops/s for this PR**, a +10.4% change in mean throughput. #26506's implementation is pinned to `bbf855c72c33` and overrides only implementation classes in the same benchmark jar.

**Why this sorting strategy**

FIFO experiments improved several random-seek workloads but lost roughly half their throughput when cursors advanced together. Sorting only during incremental flushes preserved descending-old-position processing, but plain ArrayList.sort introduced temporary-buffer allocations for larger batches. The final hybrid uses the standard small-array sort below 32 entries on JDK 21; for larger batches it skips sorting if already ordered, otherwise uses Fastutil's in-place quicksort. Full rebuilds skip pending-list sorting. Separate paired experiments against plain deferred sorting reduced allocation from 58.37 to 46.37 B/update for large random batches and from 80.00 to 47.50 B/update for the 500-cursor cohort. Fastutil is already a dependency.

The read-only slowest-position benchmarks remain API coverage; this implementation's slowest-position lookup is not on the current broker path.

<details>
<summary>Reproducing the current implementation's workloads</summary>

```shell
./gradlew :microbench:shadowJar

# Repeat with (cursors, query ratio): (100,1), (100,10), (100,100), (500,100).
java -jar microbench/build/libs/microbench-*-benchmarks.jar \
  'ActiveManagedCursorContainerBenchmark.randomSeekingForward01' \
  -p activeManagedCursorContainerImplType=DEFAULT \
  -p numberOfCursors=100 \
  -p getNumberOfCursorsAtSamePositionOrBeforeRatio=10 \
  -f 2 -wi 2 -i 3 -w 1s -r 1s -jvmArgs '-Xms256m -Xmx256m' -prof gc

# Ten-thread comparison: use randomSeekingForward10, 500 cursors, query ratio 10.
# Churn comparison: use cursorChurn, 500 cursors, query ratio 0.

java -jar microbench/build/libs/microbench-*-benchmarks.jar \
  'ActiveManagedCursorContainerCohortBenchmark.advanceCohort' \
  -p numberOfCursors=100,500 \
  -f 2 -wi 2 -i 3 -w 1s -r 1s -jvmArgs '-Xms256m -Xmx256m' -prof gc
```

</details>


### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [x] The threading model — enforce exclusive deferred-state mutation and allow validated optimistic reads when no changes are pending.
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
