### PR TITLE
[improve][doc] Require imports over fully qualified class names

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,8 +56,9 @@ A few rules matter specifically when an AI tool makes the change, on top of the 
   these outward-facing actions — see *Licensing and provenance* above.
 - **A clean local run is weak evidence for concurrency/data race fixes** (timing- and
   platform-dependent). See [`CODING.md`](CODING.md#reproducing-concurrency--memory-visibility-bugs).
-- **Follow Java style guidance.** For Java conventions — including the hard rule that code must use
-  import statements, never fully qualified class names — follow [`CODING.md`](CODING.md#style).
+- **Follow Java style guidance** in [`CODING.md`](CODING.md#style). One hard rule: reference classes
+  by simple name with an `import`, never by fully qualified name inline — unless two classes share a
+  simple name in one file, in which case the less used one stays qualified.
 - **Check before claiming conformance.** Run `./gradlew quickCheck` for a fast source-only pass
   (license headers + checkstyle, no compilation) or `./gradlew sanityCheck` to also
   compile every module's main and test sources; neither builds shadow jars. See

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,8 +56,8 @@ A few rules matter specifically when an AI tool makes the change, on top of the 
   these outward-facing actions — see *Licensing and provenance* above.
 - **A clean local run is weak evidence for concurrency/data race fixes** (timing- and
   platform-dependent). See [`CODING.md`](CODING.md#reproducing-concurrency--memory-visibility-bugs).
-- **Follow Java style guidance.** For Java conventions, including imports over fully qualified class
-  names, follow [`CODING.md`](CODING.md#style).
+- **Follow Java style guidance.** For Java conventions — including the hard rule that code must use
+  import statements, never fully qualified class names — follow [`CODING.md`](CODING.md#style).
 - **Check before claiming conformance.** Run `./gradlew quickCheck` for a fast source-only pass
   (license headers + checkstyle, no compilation) or `./gradlew sanityCheck` to also
   compile every module's main and test sources; neither builds shadow jars. See

--- a/CODING.md
+++ b/CODING.md
@@ -17,8 +17,10 @@ for the agent-specific guardrails on top of it.
   Both run on sources only (no compilation): `./gradlew quickCheck` runs the license-header and
   checkstyle checks across all modules, and `./gradlew sanityCheck` also compiles main + test — see
   [`CONTRIBUTING.md`](CONTRIBUTING.md#building).
-- Prefer imports over fully qualified class names in code. Use a fully qualified class name only when
-  needed to disambiguate a name collision that imports cannot resolve.
+- **Must use imports, not fully qualified class names, in code.** Reference every type through an
+  `import` statement (or the same package); never write a fully qualified class name in a statement or
+  expression. The only exception is a simple-name collision that imports cannot resolve — then fully
+  qualify the conflicting type and note why.
 
 ## Logging
 

--- a/CODING.md
+++ b/CODING.md
@@ -21,6 +21,9 @@ for the agent-specific guardrails on top of it.
   `import` statement (or the same package); never write a fully qualified class name in a statement or
   expression. The only exception is a simple-name collision that imports cannot resolve — then fully
   qualify the conflicting type and note why.
+- Note that Pulsar's code style does **not** put a blank line between static imports and regular
+imports. The Checkstyle config linked in the bullet point above is the authoritative source for the
+exact rules.
 
 ## Logging
 


### PR DESCRIPTION
### Motivation

The previous guidance said "Prefer imports over fully qualified class names", which reads as optional and is easy for AI agents and contributors to ignore. Make it a hard requirement.

### Modifications

- CODING.md: require import statements in code; fully qualified class names are allowed only to disambiguate a simple-name collision that imports cannot resolve.
- AGENTS.md: state the same rule as a hard rule in the agent guardrails.