### PR TITLE
[improve][client] Initialize message builder metadata lazily

### DIFF
--- a/microbench/src/main/java/org/apache/pulsar/client/impl/MessageBuilderAllocationBenchmark.java
+++ b/microbench/src/main/java/org/apache/pulsar/client/impl/MessageBuilderAllocationBenchmark.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import java.util.concurrent.TimeUnit;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.common.schema.KeyValue;
+import org.apache.pulsar.common.schema.KeyValueEncodingType;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/** Measures actual typed-builder encoding and message creation without producer/network work. */
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(2)
+public class MessageBuilderAllocationBenchmark {
+    @Param({"BYTES", "INLINE", "SEPARATED"})
+    public String schemaType;
+
+    @Param({"false", "true"})
+    public boolean retainBuilder;
+
+    private Schema<Object> schema;
+    private Object value;
+    private Object retainedBuilder;
+
+    @Setup
+    @SuppressWarnings("unchecked")
+    public void setup() {
+        byte[] payload = new byte[128];
+        if ("BYTES".equals(schemaType)) {
+            schema = (Schema<Object>) (Schema<?>) Schema.BYTES;
+            value = payload;
+        } else {
+            schema = (Schema<Object>) (Schema<?>) Schema.KeyValue(Schema.BYTES, Schema.BYTES,
+                    KeyValueEncodingType.valueOf(schemaType));
+            value = new KeyValue<>(new byte[8], payload);
+        }
+    }
+
+    @Benchmark
+    public void buildMessage(Blackhole blackhole) {
+        TypedMessageBuilderImpl<Object> builder = new TypedMessageBuilderImpl<>(null, schema);
+        builder.value(value);
+        if (retainBuilder) {
+            retainedBuilder = builder;
+        }
+        MessageImpl<Object> message = (MessageImpl<Object>) builder.getMessage();
+        blackhole.consume(message);
+        message.getDataBuffer().release();
+        message.recycle();
+    }
+}

--- a/microbench/src/main/java/org/apache/pulsar/client/impl/package-info.java
+++ b/microbench/src/main/java/org/apache/pulsar/client/impl/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * Benchmarks for client implementation paths.
+ */
+package org.apache.pulsar.client.impl;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
@@ -97,8 +97,12 @@ public class MessageImpl<T> implements TraceableMessage, Message<T> {
             String topic) {
         @SuppressWarnings("unchecked")
         MessageImpl<T> msg = (MessageImpl<T>) RECYCLER.get();
+        // copyFrom copies present fields and appends repeated fields without clearing the destination.
         msg.msgMetadata.clear();
-        msg.msgMetadata.copyFrom(msgMetadata);
+        // A plain typed builder has no metadata until a metadata field is set or accessed.
+        if (msgMetadata != null) {
+            msg.msgMetadata.copyFrom(msgMetadata);
+        }
         msg.messageId = null;
         msg.topic = topic;
         msg.cnx = null;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TypedMessageBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TypedMessageBuilderImpl.java
@@ -51,7 +51,8 @@ public class TypedMessageBuilderImpl<T> implements TypedMessageBuilder<T> {
     private static final ByteBuffer EMPTY_CONTENT = ByteBuffer.allocate(0);
 
     private final transient ProducerBase<?> producer;
-    private final transient MessageMetadata msgMetadata = new MessageMetadata();
+    // Plain payloads need no builder metadata; emitted messages still own their metadata copy.
+    private transient MessageMetadata msgMetadata;
     private final transient Schema<T> schema;
     private transient ByteBuffer content;
     private final transient TransactionImpl txn;
@@ -72,7 +73,7 @@ public class TypedMessageBuilderImpl<T> implements TypedMessageBuilder<T> {
 
     private long beforeSend() {
         if (value == null) {
-            msgMetadata.setNullValue(true);
+            getOrCreateMetadata().setNullValue(true);
         } else {
             AtomicBoolean isKeyValueSchema = new AtomicBoolean(false);
             getKeyValueSchema().map(keyValueSchema -> {
@@ -87,7 +88,8 @@ public class TypedMessageBuilderImpl<T> implements TypedMessageBuilder<T> {
                 EncodeData encodeData = schema.encode(getTopic(), value);
                 content = ByteBuffer.wrap(encodeData.data());
                 if (encodeData.hasSchemaId()) {
-                    msgMetadata.setSchemaId(SchemaIdUtil.addMagicHeader(encodeData.schemaId(), isKeyValueSchema.get()));
+                    getOrCreateMetadata().setSchemaId(
+                            SchemaIdUtil.addMagicHeader(encodeData.schemaId(), isKeyValueSchema.get()));
                 }
                 return this;
             });
@@ -96,8 +98,8 @@ public class TypedMessageBuilderImpl<T> implements TypedMessageBuilder<T> {
         if (txn == null) {
             return -1L;
         }
-        msgMetadata.setTxnidLeastBits(txn.getTxnIdLeastBits());
-        msgMetadata.setTxnidMostBits(txn.getTxnIdMostBits());
+        getOrCreateMetadata().setTxnidLeastBits(txn.getTxnIdLeastBits());
+        getOrCreateMetadata().setTxnidMostBits(txn.getTxnIdMostBits());
         return -1L;
     }
 
@@ -138,11 +140,11 @@ public class TypedMessageBuilderImpl<T> implements TypedMessageBuilder<T> {
                 keyValueSchema.getKeyValueEncodingType() != KeyValueEncodingType.SEPARATED,
                 "This method is not allowed to set keys when in encoding type is SEPARATED"));
         if (key == null) {
-            msgMetadata.setNullPartitionKey(true);
+            getOrCreateMetadata().setNullPartitionKey(true);
             return this;
         }
-        msgMetadata.setPartitionKey(key);
-        msgMetadata.setPartitionKeyB64Encoded(false);
+        getOrCreateMetadata().setPartitionKey(key);
+        getOrCreateMetadata().setPartitionKeyB64Encoded(false);
         return this;
     }
 
@@ -152,17 +154,17 @@ public class TypedMessageBuilderImpl<T> implements TypedMessageBuilder<T> {
                 keyValueSchema.getKeyValueEncodingType() != KeyValueEncodingType.SEPARATED,
                 "This method is not allowed to set keys when in encoding type is SEPARATED"));
         if (key == null) {
-            msgMetadata.setNullPartitionKey(true);
+            getOrCreateMetadata().setNullPartitionKey(true);
             return this;
         }
-        msgMetadata.setPartitionKey(Base64.getEncoder().encodeToString(key));
-        msgMetadata.setPartitionKeyB64Encoded(true);
+        getOrCreateMetadata().setPartitionKey(Base64.getEncoder().encodeToString(key));
+        getOrCreateMetadata().setPartitionKeyB64Encoded(true);
         return this;
     }
 
     @Override
     public TypedMessageBuilder<T> orderingKey(byte[] orderingKey) {
-        msgMetadata.setOrderingKey(orderingKey);
+        getOrCreateMetadata().setOrderingKey(orderingKey);
         return this;
     }
 
@@ -176,7 +178,7 @@ public class TypedMessageBuilderImpl<T> implements TypedMessageBuilder<T> {
     public TypedMessageBuilder<T> property(String name, String value) {
         checkArgument(name != null, "Need Non-Null name");
         checkArgument(value != null, "Need Non-Null value for name: " + name);
-        msgMetadata.addProperty()
+        getOrCreateMetadata().addProperty()
                     .setKey(name)
                     .setValue(value);
         return this;
@@ -187,7 +189,7 @@ public class TypedMessageBuilderImpl<T> implements TypedMessageBuilder<T> {
         for (Map.Entry<String, String> entry : properties.entrySet()) {
             checkArgument(entry.getKey() != null, "Need Non-Null key");
             checkArgument(entry.getValue() != null, "Need Non-Null value for key: " + entry.getKey());
-            msgMetadata.addProperty()
+            getOrCreateMetadata().addProperty()
                     .setKey(entry.getKey())
                     .setValue(entry.getValue());
         }
@@ -197,29 +199,29 @@ public class TypedMessageBuilderImpl<T> implements TypedMessageBuilder<T> {
 
     @Override
     public TypedMessageBuilder<T> eventTime(long timestamp) {
-        msgMetadata.setEventTime(timestamp);
+        getOrCreateMetadata().setEventTime(timestamp);
         return this;
     }
 
     @Override
     public TypedMessageBuilder<T> sequenceId(long sequenceId) {
         checkArgument(sequenceId >= 0);
-        msgMetadata.setSequenceId(sequenceId);
+        getOrCreateMetadata().setSequenceId(sequenceId);
         return this;
     }
 
     @Override
     public TypedMessageBuilder<T> replicationClusters(List<String> clusters) {
         Objects.requireNonNull(clusters);
-        msgMetadata.clearReplicateTo();
-        msgMetadata.addAllReplicateTos(clusters);
+        getOrCreateMetadata().clearReplicateTo();
+        getOrCreateMetadata().addAllReplicateTos(clusters);
         return this;
     }
 
     @Override
     public TypedMessageBuilder<T> disableReplication() {
-        msgMetadata.clearReplicateTo();
-        msgMetadata.addReplicateTo("__local__");
+        getOrCreateMetadata().clearReplicateTo();
+        getOrCreateMetadata().addReplicateTo("__local__");
         return this;
     }
 
@@ -230,7 +232,7 @@ public class TypedMessageBuilderImpl<T> implements TypedMessageBuilder<T> {
 
     @Override
     public TypedMessageBuilder<T> deliverAt(long timestamp) {
-        msgMetadata.setDeliverAtTime(timestamp);
+        getOrCreateMetadata().setDeliverAtTime(timestamp);
         return this;
     }
 
@@ -274,6 +276,13 @@ public class TypedMessageBuilderImpl<T> implements TypedMessageBuilder<T> {
     }
 
     public MessageMetadata getMetadataBuilder() {
+        return getOrCreateMetadata();
+    }
+
+    private MessageMetadata getOrCreateMetadata() {
+        if (msgMetadata == null) {
+            msgMetadata = new MessageMetadata();
+        }
         return msgMetadata;
     }
 
@@ -283,15 +292,15 @@ public class TypedMessageBuilderImpl<T> implements TypedMessageBuilder<T> {
     }
 
     public long getPublishTime() {
-        return msgMetadata.getPublishTime();
+        return getOrCreateMetadata().getPublishTime();
     }
 
     public boolean hasKey() {
-        return msgMetadata.hasPartitionKey();
+        return getOrCreateMetadata().hasPartitionKey();
     }
 
     public String getKey() {
-        return msgMetadata.getPartitionKey();
+        return getOrCreateMetadata().getPartitionKey();
     }
 
     public ByteBuffer getContent() {
@@ -319,10 +328,10 @@ public class TypedMessageBuilderImpl<T> implements TypedMessageBuilder<T> {
         // set key as the message key
         if (keyValue.getKey() != null) {
             keyEncoded = keyValueSchema.getKeySchema().encode(getTopic(), keyValue.getKey());
-            msgMetadata.setPartitionKey(Base64.getEncoder().encodeToString(keyEncoded.data()));
-            msgMetadata.setPartitionKeyB64Encoded(true);
+            getOrCreateMetadata().setPartitionKey(Base64.getEncoder().encodeToString(keyEncoded.data()));
+            getOrCreateMetadata().setPartitionKeyB64Encoded(true);
         } else {
-            msgMetadata.setNullPartitionKey(true);
+            getOrCreateMetadata().setNullPartitionKey(true);
         }
 
         EncodeData valueEncoded = null;
@@ -331,14 +340,14 @@ public class TypedMessageBuilderImpl<T> implements TypedMessageBuilder<T> {
             valueEncoded = keyValueSchema.getValueSchema().encode(getTopic(), keyValue.getValue());
             content = ByteBuffer.wrap(valueEncoded.data());
         } else {
-            msgMetadata.setNullValue(true);
+            getOrCreateMetadata().setNullValue(true);
         }
 
         byte[] schemaId = KeyValue.generateKVSchemaId(
                 keyEncoded != null && keyEncoded.hasSchemaId() ? keyEncoded.schemaId() : null,
                 valueEncoded != null && valueEncoded.hasSchemaId() ? valueEncoded.schemaId() : null);
         if (isValidSchemaId(schemaId)) {
-            msgMetadata.setSchemaId(SchemaIdUtil.addMagicHeader(schemaId, true));
+            getOrCreateMetadata().setSchemaId(SchemaIdUtil.addMagicHeader(schemaId, true));
         }
     }
 

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/TypedMessageBuilderImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/TypedMessageBuilderImplTest.java
@@ -300,4 +300,59 @@ public class TypedMessageBuilderImplTest {
         assertEquals(message.getValue(), data);
     }
 
+    @Test
+    public void testMetadataRemainsIndependentWhenBuilderIsReused() {
+        TypedMessageBuilderImpl<byte[]> builder = new TypedMessageBuilderImpl<>(null, Schema.BYTES);
+        builder.value(new byte[] {1});
+        MessageImpl<byte[]> first = (MessageImpl<byte[]>) builder.getMessage();
+        MessageImpl<byte[]> second = null;
+        MessageImpl<byte[]> third = null;
+        try {
+            // Producer-generated metadata on an emitted message must not become builder state.
+            first.getMessageBuilder().setPublishTime(1234);
+            builder.key("key").property("name", "value").sequenceId(5);
+            second = (MessageImpl<byte[]>) builder.getMessage();
+            assertFalse(first.hasKey());
+            assertTrue(first.getProperties().isEmpty());
+            assertEquals(first.getPublishTime(), 1234L);
+            assertEquals(second.getKey(), "key");
+            assertEquals(second.getProperty("name"), "value");
+            assertEquals(second.getSequenceId(), 5L);
+            assertFalse(second.getMessageBuilder().hasPublishTime());
+
+            // A retained metadata accessor still updates future messages, not already emitted ones.
+            var metadata = builder.getMetadataBuilder();
+            metadata.setPartitionKey("changed");
+            third = (MessageImpl<byte[]>) builder.getMessage();
+            assertEquals(second.getKey(), "key");
+            assertEquals(third.getKey(), "changed");
+            assertFalse(third.getMessageBuilder().hasPublishTime());
+        } finally {
+            first.getDataBuffer().release();
+            first.recycle();
+            if (second != null) {
+                second.getDataBuffer().release();
+                second.recycle();
+            }
+            if (third != null) {
+                third.getDataBuffer().release();
+                third.recycle();
+            }
+        }
+    }
+
+    @Test
+    public void testNullValueMaterializesMetadata() {
+        TypedMessageBuilderImpl<byte[]> builder = new TypedMessageBuilderImpl<>(null, Schema.BYTES);
+        builder.value(null);
+        MessageImpl<byte[]> message = (MessageImpl<byte[]>) builder.getMessage();
+        try {
+            assertTrue(message.getMessageBuilder().isNullValue());
+            assertFalse(message.hasKey());
+        } finally {
+            message.getDataBuffer().release();
+            message.recycle();
+        }
+    }
+
 }


### PR DESCRIPTION
### Motivation

A plain `producer.newMessage().value(payload).sendAsync()` eagerly allocates builder `MessageMetadata` even when no metadata fields are set. The emitted `MessageImpl` owns separate metadata, so this temporary builder object is allocated and copied without contributing fields.

### Modifications

- Create builder metadata on the first setter or accessor that needs it.
- Allow message creation to receive absent builder metadata and skip the empty copy, while keeping each emitted message's metadata independent.
- Preserve metadata materialization for null values, keys, schema IDs and transactions, and preserve the mutable metadata accessor used by reusable builders.
- Add tests for metadata independence across builder reuse and null-value handling, and a focused construction benchmark for bytes and inline/separated key-value schemas.

The destination metadata is still cleared before copying: generated `MessageMetadata.copyFrom()` copies present fields and appends repeated fields without clearing the destination.

### Verifying this change

Prior local experiments measured **328 B less allocation per plain/inline message** and **24–30% less construction time** in the included JMH benchmark. Separated key-value messages still need builder metadata and had unchanged allocation. The benchmark used Linux x86_64, Corretto 25, ZGC with a 1 GiB heap, two forks, three 1-second warmups, five 1-second measurements and the GC profiler. Ordinary JMH threads measured fresh allocation with message recycling inactive; both retained and nonretained builders were covered.

Two prior V4 integration profiles observed **12.2–12.7% lower total producer sampled allocation** for 20M unbatched messages with four consumers on one shared subscription. These measurements came from the experimental branch; they are not new measurements of this extraction. No end-to-end CPU or throughput improvement is claimed.

Local extraction validation passed: required Spotless and main/test Checkstyle checks, both client test classes, transaction produce commit/abort tests, and benchmark compilation.

```shell
./gradlew spotlessCheck checkstyleMain checkstyleTest \
  :pulsar-client-original:test \
  --tests org.apache.pulsar.client.impl.MessageImplTest \
  --tests org.apache.pulsar.client.impl.TypedMessageBuilderImplTest \
  :pulsar-broker:test \
  --tests org.apache.pulsar.broker.transaction.TransactionProduceTest.produceAndCommitTest \
  --tests org.apache.pulsar.broker.transaction.TransactionProduceTest.produceAndAbortTest \
  :microbench:compileJava -PtestRetryCount=0 --max-workers=2 --no-parallel
```

- [ ] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
