### PR TITLE
[improve][client] Avoid unused send-stat snapshots for default callbacks

### DIFF
--- a/microbench/src/main/java/org/apache/pulsar/client/impl/SendCompletionStatsBenchmark.java
+++ b/microbench/src/main/java/org/apache/pulsar/client/impl/SendCompletionStatsBenchmark.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.impl.metrics.LatencyHistogram;
+import org.apache.pulsar.common.api.proto.MessageMetadata;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+/** Measures actual OpSendMsg completion for custom callbacks; guards the snapshot-preserving fallback. */
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(2)
+public class SendCompletionStatsBenchmark {
+    @Param({"false", "true"})
+    public boolean retainStats;
+
+    private MessageImpl<byte[]> message;
+    private ProducerImpl.OpSendMsg operation;
+    private StatsCallback callback;
+
+    @Setup
+    public void setup() {
+        message = MessageImpl.create(new MessageMetadata(), ByteBuffer.wrap(new byte[128]), Schema.BYTES, "benchmark");
+        callback = new StatsCallback();
+        operation = ProducerImpl.OpSendMsg.create(LatencyHistogram.NOOP, message, null, 123, callback);
+        operation.updateSentTimestamp();
+    }
+
+    @Benchmark
+    public long complete() {
+        operation.sendComplete(null);
+        return callback.observed;
+    }
+
+    @TearDown
+    public void tearDown() {
+        operation.recycle();
+        message.getDataBuffer().release();
+        message.recycle();
+    }
+
+    private class StatsCallback implements SendCallback {
+        private long observed;
+        private OpSendMsgStats retained;
+
+        @Override
+        public void sendComplete(Throwable error, OpSendMsgStats stats) {
+            observed = stats.getSequenceId() + stats.getUncompressedSize() + stats.getRetryCount();
+            if (retainStats) {
+                retained = stats;
+            }
+        }
+
+        @Override
+        public void addCallback(MessageImpl<?> message, SendCallback callback) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public SendCallback getNextSendCallback() {
+            return null;
+        }
+
+        @Override
+        public MessageImpl<?> getNextMessage() {
+            return null;
+        }
+
+        @Override
+        public CompletableFuture<MessageId> getFuture() {
+            return null;
+        }
+    }
+}

--- a/microbench/src/main/java/org/apache/pulsar/client/impl/package-info.java
+++ b/microbench/src/main/java/org/apache/pulsar/client/impl/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/** Microbenchmarks for client message construction and processing. */
+package org.apache.pulsar.client.impl;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -462,6 +462,10 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
 
         @Override
         public void sendComplete(Throwable e, OpSendMsgStats opSendMsgStats) {
+            sendComplete(e);
+        }
+
+        private void sendComplete(Throwable e) {
             SendCallback loopingCallback = this;
             MessageImpl<?> loopingMsg = currentMsg;
             while (loopingCallback != null) {
@@ -1743,17 +1747,22 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                     rpcLatencyHistogram.recordFailure(now - this.lastSentAt);
                 }
 
-                OpSendMsgStats opSendMsgStats = OpSendMsgStatsImpl.builder()
-                        .uncompressedSize(uncompressedSize)
-                        .sequenceId(sequenceId)
-                        .retryCount(retryCount)
-                        .batchSizeByte(batchSizeByte)
-                        .numMessagesInBatch(numMessagesInBatch)
-                        .highestSequenceId(highestSequenceId)
-                        .totalChunks(totalChunks)
-                        .chunkId(chunkId)
-                        .build();
-                callback.sendComplete(finalEx, opSendMsgStats);
+                if (callback instanceof ProducerImpl<?>.DefaultSendMessageCallback defaultCallback) {
+                    // The client's default callback does not use the per-operation snapshot.
+                    defaultCallback.sendComplete(finalEx);
+                } else {
+                    OpSendMsgStats opSendMsgStats = OpSendMsgStatsImpl.builder()
+                            .uncompressedSize(uncompressedSize)
+                            .sequenceId(sequenceId)
+                            .retryCount(retryCount)
+                            .batchSizeByte(batchSizeByte)
+                            .numMessagesInBatch(numMessagesInBatch)
+                            .highestSequenceId(highestSequenceId)
+                            .totalChunks(totalChunks)
+                            .chunkId(chunkId)
+                            .build();
+                    callback.sendComplete(finalEx, opSendMsgStats);
+                }
             }
         }
 

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ProducerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ProducerImplTest.java
@@ -34,10 +34,62 @@ import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.impl.metrics.LatencyHistogram;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
 import org.apache.pulsar.common.protocol.ByteBufPair;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 public class ProducerImplTest {
+    @DataProvider
+    public Object[][] completionErrors() {
+        return new Object[][] {{null}, {new PulsarClientException.TimeoutException("send timed out", 41)}};
+    }
+
+    @Test(dataProvider = "completionErrors")
+    public void testCustomCompletionStatsSurviveOperationRecycle(Exception error) {
+        MessageImpl<byte[]> message = MessageImpl.create(new MessageMetadata(),
+                ByteBuffer.wrap(new byte[128]), Schema.BYTES, "test-topic");
+        SendCallback callback = mock(SendCallback.class);
+        ProducerImpl.OpSendMsg operation = ProducerImpl.OpSendMsg.create(
+                LatencyHistogram.NOOP, message, null, 41, callback);
+        OpSendMsgStats snapshot;
+        Throwable completionError;
+        try {
+            operation.updateSentTimestamp();
+            operation.retryCount = 2;
+            operation.batchSizeByte = 1024;
+            operation.numMessagesInBatch = 5;
+            operation.highestSequenceId = 45;
+            operation.totalChunks = 2;
+            operation.chunkId = 1;
+            operation.sendComplete(error);
+            ArgumentCaptor<OpSendMsgStats> statsCaptor = ArgumentCaptor.forClass(OpSendMsgStats.class);
+            ArgumentCaptor<Throwable> errorCaptor = ArgumentCaptor.forClass(Throwable.class);
+            verify(callback).sendComplete(errorCaptor.capture(), statsCaptor.capture());
+            snapshot = statsCaptor.getValue();
+            completionError = errorCaptor.getValue();
+        } finally {
+            operation.recycle();
+            message.getDataBuffer().release();
+            message.recycle();
+        }
+        assertEquals(snapshot.getUncompressedSize(), 128L);
+        assertEquals(snapshot.getSequenceId(), 41L);
+        assertEquals(snapshot.getRetryCount(), 2);
+        assertEquals(snapshot.getBatchSizeByte(), 1024L);
+        assertEquals(snapshot.getNumMessagesInBatch(), 5);
+        assertEquals(snapshot.getHighestSequenceId(), 45L);
+        assertEquals(snapshot.getTotalChunks(), 2);
+        assertEquals(snapshot.getChunkId(), 1);
+        if (error == null) {
+            assertNull(completionError);
+        } else {
+            assertTrue(completionError instanceof PulsarClientException.TimeoutException);
+            assertEquals(((PulsarClientException.TimeoutException) completionError).getSequenceId(), 41L);
+            assertTrue(completionError.getMessage().contains("retryCount 2"));
+        }
+    }
+
     @Test
     public void testChunkedMessageCtxDeallocate() {
         int totalChunks = 3;


### PR DESCRIPTION
### Motivation

`ProducerImpl.OpSendMsg.sendComplete()` constructs an immutable `OpSendMsgStatsImpl` snapshot for every completion, but the private `DefaultSendMessageCallback` ignores it. This adds a 64-byte allocation on the normal producer completion path.

### Modifications

- Move the default callback's existing completion loop into a private overload that takes only the error.
- Call that overload directly for the private default callback, skipping snapshot construction.
- Preserve the existing immutable snapshot for all other callbacks, including callers that retain it after the send operation is recycled.
- Add success/timeout coverage for retained custom snapshots and a focused benchmark for the custom-callback fallback.

Callback chaining, interceptor invocation, future completion, payload release, timeout diagnostics and metrics recording keep their existing behavior. The `SendCallback` interface is unchanged.

### Verifying this change

Prior matched V4 integration profiles (20M unbatched 128-byte messages, four consumers sharing a subscription) showed producer sampled allocation falling **31.105 → 29.694 GB (4.5%)**, with the 1.311 GB snapshot allocation site absent from the optimized recording. CPU samples were effectively flat. These are historical experimental-branch results, not new measurements of this extraction; no throughput or latency improvement is claimed.

The included JMH benchmark exercises custom callbacks through the actual send-completion method. Retained snapshots remained **64 B/op** before and after; a callback consuming only fields had approximately zero allocation after JIT optimization. Retaining-callback time was 18.885 → 19.540 ns in that comparison. This benchmark guards the fallback and does not measure the private default callback's CPU benefit.

Local extraction validation passed: all required Spotless and main/test Checkstyle tasks, 16 scoped test cases (custom snapshots, async sends/ACKs, batching, timeouts and interceptors), and benchmark compilation. No tests failed or were skipped.

```shell
./gradlew spotlessCheck checkstyleMain checkstyleTest \
  :pulsar-client-original:test \
  --tests org.apache.pulsar.client.impl.ProducerImplTest \
  :pulsar-broker:test \
  --tests org.apache.pulsar.client.api.SimpleProducerConsumerTest.testAsyncProducerAndAsyncAck \
  --tests org.apache.pulsar.client.api.SimpleProducerConsumerTest.testSendTimeout \
  --tests org.apache.pulsar.client.api.InterceptorsTest.testProducerInterceptor \
  --tests org.apache.pulsar.client.api.InterceptorsTest.testProducerInterceptorsWithExceptions \
  --tests org.apache.pulsar.client.api.InterceptorsTest.testProducerInterceptorsWithErrors \
  --tests org.apache.pulsar.client.api.InterceptorsTest.testProducerInterceptorAccessMessageData \
  :microbench:compileJava -PtestRetryCount=0 --max-workers=2 --no-parallel
```

- [ ] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
