### PR TITLE
[improve][client] Avoid eager broker metadata allocation for outgoing messages

### DIFF
--- a/microbench/src/main/java/org/apache/pulsar/client/impl/OutgoingMessageAllocationBenchmark.java
+++ b/microbench/src/main/java/org/apache/pulsar/client/impl/OutgoingMessageAllocationBenchmark.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.TimeUnit;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.common.api.proto.MessageMetadata;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/** Isolates outgoing message construction; excludes builder allocation, serialization and networking. */
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(2)
+public class OutgoingMessageAllocationBenchmark {
+    @Param({"false", "true"})
+    public boolean recycle;
+
+    private final MessageMetadata metadata = new MessageMetadata().setSequenceId(1);
+    private final ByteBuffer payload = ByteBuffer.wrap(new byte[128]);
+
+    @Benchmark
+    public void createMessage(Blackhole blackhole) {
+        MessageImpl<byte[]> message = MessageImpl.create(metadata, payload, Schema.BYTES, "benchmark");
+        blackhole.consume(message);
+        message.getDataBuffer().release();
+        if (recycle) {
+            message.recycle();
+        }
+    }
+}

--- a/microbench/src/main/java/org/apache/pulsar/client/impl/package-info.java
+++ b/microbench/src/main/java/org/apache/pulsar/client/impl/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/** Microbenchmarks for client message construction and processing. */
+package org.apache.pulsar.client.impl;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
@@ -790,7 +790,6 @@ public class MessageImpl<T> implements TraceableMessage, Message<T> {
         this.recyclerHandle = recyclerHandle;
         this.redeliveryCount = 0;
         this.msgMetadata = new MessageMetadata();
-        this.brokerEntryMetadata = new BrokerEntryMetadata();
         this.consumerEpoch = DEFAULT_CONSUMER_EPOCH;
     }
 

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MessageImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MessageImplTest.java
@@ -54,6 +54,36 @@ import org.testng.annotations.Test;
 public class MessageImplTest {
 
     @Test
+    public void testOutgoingBrokerMetadataBeforeAndAfterRecycle() {
+        MessageImpl<byte[]> message = MessageImpl.create(new MessageMetadata(),
+                ByteBuffer.wrap(new byte[1]), Schema.BYTES, "test-topic");
+        try {
+            assertFalse(message.hasBrokerPublishTime());
+            assertFalse(message.hasIndex());
+            assertTrue(message.getBrokerPublishTime().isEmpty());
+            assertTrue(message.getIndex().isEmpty());
+            message.setBrokerEntryMetadata(new BrokerEntryMetadata().setBrokerTimestamp(123).setIndex(456));
+            assertEquals(message.getBrokerPublishTime().orElseThrow().longValue(), 123L);
+            assertEquals(message.getIndex().orElseThrow().longValue(), 456L);
+        } finally {
+            message.getDataBuffer().release();
+            message.recycle();
+        }
+
+        MessageImpl<byte[]> next = MessageImpl.create(new MessageMetadata(),
+                ByteBuffer.wrap(new byte[1]), Schema.BYTES, "test-topic");
+        try {
+            assertFalse(next.hasBrokerPublishTime());
+            assertFalse(next.hasIndex());
+            assertTrue(next.getBrokerPublishTime().isEmpty());
+            assertTrue(next.getIndex().isEmpty());
+        } finally {
+            next.getDataBuffer().release();
+            next.recycle();
+        }
+    }
+
+    @Test
     public void testGetSequenceIdNotAssociated() {
         ByteBuffer payload = ByteBuffer.wrap(new byte[0]);
         MessageImpl<?> msg = MessageImpl.create(new MessageMetadata(), payload, Schema.BYTES, null);


### PR DESCRIPTION
### Motivation

The `MessageImpl` recycler constructor eagerly allocates `BrokerEntryMetadata` for outgoing messages, although those messages do not yet have broker-added timestamp or index information. This creates an unused object whenever a fresh `MessageImpl` is allocated.

### Modifications

Remove that constructor allocation, leaving the field null until metadata is supplied. Existing timestamp/index accessors already handle null, and incoming deserialization supplies parsed metadata. Add coverage for absent metadata, explicitly assigned timestamp/index values, and absence after recycling followed by message creation. Include a focused outgoing-message construction benchmark.

### Verifying this change

Prior Linux x86_64 / Corretto 25 / ZGC JMH measurements showed **608 → 552 B per fresh message**, saving **56 B**, and approximately 8.6% less construction time. The benchmark excludes builder allocation, serialization and networking. Both ordinary-worker modes allocate fresh messages even when `recycle()` is called; already-reused instances do not incur this constructor cost. These are historical experiment results, not new measurements of the extracted branch or a throughput claim.

Local extraction validation passed: all required Spotless and main/test Checkstyle checks, 43 message/builder/broker-metadata test cases with zero failures or skips, and benchmark compilation.

```shell
./gradlew spotlessCheck checkstyleMain checkstyleTest \
  :pulsar-client-original:test \
  --tests org.apache.pulsar.client.impl.MessageImplTest \
  --tests org.apache.pulsar.client.impl.TypedMessageBuilderImplTest \
  :pulsar-broker:test \
  --tests org.apache.pulsar.broker.service.BrokerEntryMetadataE2ETest \
  :microbench:compileJava -PtestRetryCount=0 --max-workers=2 --no-parallel
```

The lifecycle test does not assume that ordinary test threads retrieve the same pooled instance. Existing broker-metadata end-to-end tests cover parsed metadata behavior.

- [ ] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
