### PR TITLE
[improve][broker] Use AVL trees for pending acknowledgment entries

### DIFF
--- a/microbench/src/main/java/org/apache/pulsar/broker/service/PendingAckMapCycleBenchmark.java
+++ b/microbench/src/main/java/org/apache/pulsar/broker/service/PendingAckMapCycleBenchmark.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/** Includes the real pending-ACK map's locks, outer ledger lookup and packed value handling, without contention. */
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(2)
+public class PendingAckMapCycleBenchmark {
+    @Param({"1024", "65536"})
+    public int windowSize;
+
+    @Param({"false", "true"})
+    public boolean shuffled;
+
+    private PendingAcksMap pendingAcks;
+    private long[] entryIds;
+    private long nextEntryId;
+    private int cursor;
+
+    @Setup
+    public void setup() {
+        Consumer owner = new Consumer("benchmark-owner", 0);
+        pendingAcks = new PendingAcksMap(owner, () -> null, () -> null);
+        entryIds = new long[windowSize];
+        for (int i = 0; i < windowSize; i++) {
+            entryIds[i] = i;
+            pendingAcks.addPendingAckIfAllowed(1, i, 1, 0);
+        }
+        nextEntryId = windowSize;
+    }
+
+    @Benchmark
+    public int rotateWindow() {
+        int next = cursor++;
+        int index = (shuffled ? next * 4051 : next) & (windowSize - 1);
+        long entryId = entryIds[index];
+        int count = pendingAcks.getRemainingUnacked(1, entryId);
+        pendingAcks.remove(1, entryId);
+        long addedEntryId = nextEntryId++;
+        pendingAcks.addPendingAckIfAllowed(1, addedEntryId, 1, 0);
+        entryIds[index] = addedEntryId;
+        return count;
+    }
+}

--- a/microbench/src/main/java/org/apache/pulsar/broker/service/PendingAckTreeBenchmark.java
+++ b/microbench/src/main/java/org/apache/pulsar/broker/service/PendingAckTreeBenchmark.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import it.unimi.dsi.fastutil.longs.Long2LongAVLTreeMap;
+import it.unimi.dsi.fastutil.longs.Long2LongMap;
+import it.unimi.dsi.fastutil.longs.Long2LongRBTreeMap;
+import it.unimi.dsi.fastutil.longs.Long2LongSortedMap;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/** Compares sorted maps for a moving pending-ACK window; excludes the unchanged outer ledger map and locking. */
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(2)
+public class PendingAckTreeBenchmark {
+    @Param({"RB", "AVL"})
+    public String implementation;
+
+    @Param({"1024", "65536"})
+    public int windowSize;
+
+    @Param({"false", "true"})
+    public boolean shuffled;
+
+    private Long2LongSortedMap map;
+    private long[] entryIds;
+    private long nextEntryId;
+    private int cursor;
+    private long packedValue;
+
+    @Setup
+    public void setup() {
+        map = "AVL".equals(implementation) ? new Long2LongAVLTreeMap() : new Long2LongRBTreeMap();
+        map.defaultReturnValue(PendingAckValues.PACKED_NOT_FOUND);
+        packedValue = PendingAckValues.pack(1, 0);
+        entryIds = new long[windowSize];
+        for (int i = 0; i < windowSize; i++) {
+            entryIds[i] = i;
+            map.put(i, packedValue);
+        }
+        nextEntryId = windowSize;
+    }
+
+    private int nextIndex() {
+        int next = cursor++;
+        // Odd multiplier permutes all indices in these power-of-two windows without an RNG in the hot path.
+        return (shuffled ? next * 4051 : next) & (windowSize - 1);
+    }
+
+    @Benchmark
+    public long lookup() {
+        return map.get(entryIds[nextIndex()]);
+    }
+
+    @Benchmark
+    public long rotateWindow() {
+        int index = nextIndex();
+        long oldEntryId = entryIds[index];
+        long value = map.get(oldEntryId);
+        map.remove(oldEntryId);
+        long newEntryId = nextEntryId++;
+        map.put(newEntryId, packedValue);
+        entryIds[index] = newEntryId;
+        return value;
+    }
+
+    @Benchmark
+    public long scanPrefix() {
+        long sum = 0;
+        for (Long2LongMap.Entry entry : map.headMap(windowSize / 50).long2LongEntrySet()) {
+            sum += entry.getLongKey();
+        }
+        return sum;
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PendingAcksMap.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PendingAcksMap.java
@@ -18,8 +18,8 @@
  */
 package org.apache.pulsar.broker.service;
 
+import it.unimi.dsi.fastutil.longs.Long2LongAVLTreeMap;
 import it.unimi.dsi.fastutil.longs.Long2LongMap;
-import it.unimi.dsi.fastutil.longs.Long2LongRBTreeMap;
 import it.unimi.dsi.fastutil.longs.Long2LongSortedMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectRBTreeMap;
@@ -511,7 +511,7 @@ public class PendingAcksMap {
     }
 
     private static Long2LongSortedMap newLedgerPendingAcks() {
-        Long2LongRBTreeMap ledgerPendingAcks = new Long2LongRBTreeMap();
+        Long2LongAVLTreeMap ledgerPendingAcks = new Long2LongAVLTreeMap();
         ledgerPendingAcks.defaultReturnValue(PendingAckValues.PACKED_NOT_FOUND);
         return ledgerPendingAcks;
     }


### PR DESCRIPTION
### Motivation

Pending acknowledgment windows repeatedly look up, remove and insert entries in a sorted per-ledger map. The AVL implementation reduced the cost of that cycle in focused benchmarks.

### Modifications

Replace the inner fastutil red-black tree with its AVL counterpart. Preserve the sorted interface, outer ledger map, locking, missing-value sentinel and callbacks. Include tree-operation and actual PendingAcksMap cycle benchmarks.

### Verifying this change

Historical JMH measurements of the actual map cycle, including locks and outer ledger lookup but no contention, were 15.7–21.8% faster with unchanged 48 B/cycle allocation. Some isolated small shuffled lookups were about 2.3 ns slower. Full broker CPU/rate were flat; no end-to-end gain is claimed. These are prior experimental results, not new measurements of this extraction.

Local extraction validation passed: `spotlessCheck checkstyleMain checkstyleTest`, benchmark compilation, and 39 scoped tests with no failures or skips: org.apache.pulsar.broker.service.ConsumerTest (2), org.apache.pulsar.broker.service.PendingAcksMapTest (27), org.apache.pulsar.client.api.KeySharedSubscriptionTest (10). Retries were disabled; Gradle ran with `--max-workers=2 --no-parallel`.

- [ ] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
