### PR TITLE
[improve][ml] Share read-permit release callbacks within a batch

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImpl.java
@@ -372,12 +372,13 @@ public class RangeEntryCacheImpl implements EntryCache {
                 if (!entries.isEmpty()) {
                     // release permits only when entries have been handled
                     AtomicInteger remainingCount = new AtomicInteger(entries.size());
+                    Runnable releasePermits = () -> {
+                        if (remainingCount.decrementAndGet() <= 0) {
+                            pendingReadsLimiter.release(handle);
+                        }
+                    };
                     for (Entry entry : entries) {
-                        ((EntryImpl) entry).onDeallocate(() -> {
-                            if (remainingCount.decrementAndGet() <= 0) {
-                                pendingReadsLimiter.release(handle);
-                            }
-                        });
+                        ((EntryImpl) entry).onDeallocate(releasePermits);
                     }
                 } else {
                     pendingReadsLimiter.release(handle);

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImplTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImplTest.java
@@ -107,6 +107,45 @@ public class RangeEntryCacheImplTest {
         expectedReadCount = () -> 1;
     }
 
+    @Test
+    public void testReadPermitsReleasedOnlyAfterLastEntryReference() {
+        InflightReadsLimiter limiter = mockEntryCacheManager.getInflightReadsLimiter();
+        InflightReadsLimiter.Handle handle = new InflightReadsLimiter.Handle(300, 0, true);
+        CompletableFuture<List<Entry>> result = new CompletableFuture<>();
+        rangeEntryCache.doAsyncReadEntriesWithAcquiredPermits(lh,
+                PositionFactory.create(1, 0), PositionFactory.create(1, 2), 3, expectedReadCount,
+                new AsyncCallbacks.ReadEntriesCallback() {
+                    @Override
+                    public void readEntriesComplete(List<Entry> entries, Object ctx) {
+                        result.complete(entries);
+                    }
+
+                    @Override
+                    public void readEntriesFailed(ManagedLedgerException exception, Object ctx) {
+                        result.completeExceptionally(exception);
+                    }
+                }, null, handle, 300);
+        assertThat(result).isCompleted();
+        List<Entry> entries = result.getNow(null);
+        try {
+            assertThat(entries).hasSize(3);
+            ((ReferenceCountedEntry) entries.get(0)).retain();
+            entries.get(2).release();
+            entries.get(0).release();
+            entries.get(1).release();
+            verify(limiter, never()).release(any());
+            entries.get(0).release();
+            verify(limiter, times(1)).release(handle);
+        } finally {
+            for (Entry entry : entries) {
+                ReferenceCountedEntry referenceCountedEntry = (ReferenceCountedEntry) entry;
+                if (referenceCountedEntry.refCnt() > 0) {
+                    referenceCountedEntry.release(referenceCountedEntry.refCnt());
+                }
+            }
+        }
+    }
+
     private RangeEntryCacheImpl createRangeEntryCache(boolean copyEntries) {
         return new RangeEntryCacheImpl(mockEntryCacheManager, mockManagedLedger, copyEntries,
                 mockRangeCacheRemovalQueue, EntryLengthFunction.DEFAULT, pendingReadsManager);

--- a/microbench/src/main/java/org/apache/bookkeeper/mledger/impl/cache/ReadBatchCallbackBenchmark.java
+++ b/microbench/src/main/java/org/apache/bookkeeper/mledger/impl/cache/ReadBatchCallbackBenchmark.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.mledger.impl.cache;
+
+import io.opentelemetry.api.OpenTelemetry;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.bookkeeper.mledger.impl.EntryImpl;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+/** Measures real entry-copy/release and read-permit accounting with per-entry or per-batch callbacks. */
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(2)
+public class ReadBatchCallbackBenchmark {
+    private static final long LIMIT_BYTES = 16 * 1024 * 1024;
+
+    @Param({"1", "100", "1000"})
+    public int batchSize;
+
+    @Param({"false", "true"})
+    public boolean sharedCallback;
+
+    private EntryImpl[] cachedEntries;
+    private EntryImpl[] readEntries;
+    private InflightReadsLimiter limiter;
+    private ScheduledExecutorService executor;
+
+    @Setup
+    public void setup() {
+        executor = Executors.newSingleThreadScheduledExecutor();
+        limiter = new InflightReadsLimiter(LIMIT_BYTES, 1, 0, executor, OpenTelemetry.noop());
+        cachedEntries = new EntryImpl[batchSize];
+        readEntries = new EntryImpl[batchSize];
+        for (int i = 0; i < batchSize; i++) {
+            cachedEntries[i] = EntryImpl.create(1, i, new byte[128]);
+            cachedEntries[i].getPosition();
+        }
+    }
+
+    @Benchmark
+    public long readAndReleaseBatch() {
+        InflightReadsLimiter batchLimiter = limiter;
+        InflightReadsLimiter.Handle handle = batchLimiter.acquire(batchSize * 128L, null).orElseThrow();
+        AtomicInteger remainingCount = new AtomicInteger(batchSize);
+        Runnable shared = sharedCallback ? releaseCallback(remainingCount, batchLimiter, handle) : null;
+        for (int i = 0; i < batchSize; i++) {
+            EntryImpl entry = EntryImpl.create(cachedEntries[i]);
+            entry.onDeallocate(sharedCallback ? shared : releaseCallback(remainingCount, batchLimiter, handle));
+            readEntries[i] = entry;
+        }
+        for (int i = batchSize - 1; i >= 0; i--) {
+            readEntries[i].release();
+            readEntries[i] = null;
+        }
+        return batchLimiter.getRemainingBytes();
+    }
+
+    private static Runnable releaseCallback(AtomicInteger remainingCount, InflightReadsLimiter limiter,
+                                            InflightReadsLimiter.Handle handle) {
+        return () -> {
+            if (remainingCount.decrementAndGet() <= 0) {
+                limiter.release(handle);
+            }
+        };
+    }
+
+    @TearDown
+    public void tearDown() {
+        try {
+            if (limiter.getRemainingBytes() != LIMIT_BYTES) {
+                throw new IllegalStateException("Read permits were not released exactly once per batch");
+            }
+        } finally {
+            for (EntryImpl entry : cachedEntries) {
+                entry.release();
+            }
+            limiter.close();
+            executor.shutdownNow();
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

A cached read batch currently creates an equivalent release callback for every entry, although all callbacks share the same remaining-entry counter and permit handle.

### Modifications

Create one callback per read batch and attach it to every entry. Keep atomic remaining-entry accounting and release permits only after the final entry is deallocated. Add a test retaining one entry reference while the other entries are released and a focused callback-allocation benchmark.

### Verifying this change

Historical JMH removed approximately 40 B per entry in large batches; a long fanout profile reduced broker sampled allocation by 2.3%, with CPU/rate flat. These are prior experimental results, not new measurements of this extraction.

Local extraction validation passed: `spotlessCheck checkstyleMain checkstyleTest`, benchmark compilation, and 30 scoped tests with no failures or skips: org.apache.bookkeeper.mledger.impl.InflightReadsLimiterIntegrationTest (14), org.apache.bookkeeper.mledger.impl.cache.RangeEntryCacheImplTest (16). Retries were disabled; Gradle ran with `--max-workers=2 --no-parallel`.

- [ ] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
