### PR TITLE
[improve][ml] Avoid capturing cache insertion arguments

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeCache.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeCache.java
@@ -72,19 +72,22 @@ class RangeCache {
             if (!value.matchesPosition(key)) {
                 throw new IllegalArgumentException("Value '" + value + "' does not match key '" + key + "'");
             }
-            boolean added = RangeCacheEntryWrapper.withNewInstance(this, key, value, entryLength, newWrapper -> {
-                if (entries.putIfAbsent(key, newWrapper) == null && removalQueue.addEntry(newWrapper)) {
-                    this.size.addAndGet(entryLength);
-                    return true;
-                } else {
-                    // recycle the new wrapper as it was not used
-                    newWrapper.recycle();
-                    return false;
-                }
-            });
-            return added;
+            return RangeCacheEntryWrapper.withNewInstance(this, key, value, entryLength, RangeCache::addEntry);
         } finally {
             value.release();
+        }
+    }
+
+    private static boolean addEntry(RangeCacheEntryWrapper newWrapper) {
+        // withNewInstance holds the wrapper's write lock while these initialized fields are used.
+        RangeCache cache = newWrapper.rangeCache;
+        if (cache.entries.putIfAbsent(newWrapper.key, newWrapper) == null && cache.removalQueue.addEntry(newWrapper)) {
+            cache.size.addAndGet(newWrapper.size);
+            return true;
+        } else {
+            // recycle the new wrapper as it was not used
+            newWrapper.recycle();
+            return false;
         }
     }
 

--- a/microbench/src/main/java/org/apache/bookkeeper/mledger/impl/cache/CacheEvictionCycleBenchmark.java
+++ b/microbench/src/main/java/org/apache/bookkeeper/mledger/impl/cache/CacheEvictionCycleBenchmark.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.mledger.impl.cache;
+
+import java.util.concurrent.TimeUnit;
+import org.apache.bookkeeper.mledger.impl.EntryImpl;
+import org.apache.commons.lang3.tuple.Pair;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+/** Measures a complete insertion/eviction cycle, including allocation, using retained real entries. */
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(2)
+public class CacheEvictionCycleBenchmark {
+    @Param({"100", "1000"})
+    public int batchSize;
+
+    @Param({"false", "true"})
+    public boolean requeue;
+
+    private RangeCacheRemovalQueue queue;
+    private RangeCache cache;
+    private EntryImpl[] entries;
+
+    @Setup
+    public void setup() {
+        queue = new RangeCacheRemovalQueue(1, false);
+        cache = new RangeCache(queue);
+        entries = new EntryImpl[batchSize];
+        for (int i = 0; i < batchSize; i++) {
+            entries[i] = EntryImpl.create(0, i, new byte[1], requeue ? 1 : 0);
+        }
+    }
+
+    @Benchmark
+    public long insertAndEvict() {
+        for (EntryImpl entry : entries) {
+            entry.retain();
+            if (!cache.put(entry.getPosition(), entry)) {
+                entry.release();
+                throw new IllegalStateException("Duplicate cache entry");
+            }
+        }
+        Pair<Integer, Long> removed = queue.evictLeastAccessedEntries(batchSize);
+        if (removed.getLeft() != batchSize || !queue.isEmpty()) {
+            throw new IllegalStateException("Incomplete eviction");
+        }
+        return removed.getRight();
+    }
+
+    @TearDown
+    public void tearDown() {
+        cache.clear();
+        for (EntryImpl entry : entries) {
+            entry.release();
+        }
+    }
+}

--- a/microbench/src/main/java/org/apache/pulsar/client/impl/FastThreadLocalBenchmarkExecutor.java
+++ b/microbench/src/main/java/org/apache/pulsar/client/impl/FastThreadLocalBenchmarkExecutor.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import io.netty.util.concurrent.DefaultThreadFactory;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+/** Optional JMH executor for benchmarks that need Netty's thread-local recycling to be active. */
+public class FastThreadLocalBenchmarkExecutor extends ThreadPoolExecutor {
+    public FastThreadLocalBenchmarkExecutor(int threads, String name) {
+        super(threads, threads, 0, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>(),
+                new DefaultThreadFactory(name));
+    }
+}

--- a/microbench/src/main/java/org/apache/pulsar/client/impl/package-info.java
+++ b/microbench/src/main/java/org/apache/pulsar/client/impl/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/** Microbenchmarks for org.apache.pulsar.client.impl. */
+package org.apache.pulsar.client.impl;


### PR DESCRIPTION
### Motivation

RangeCache.put creates a callback capturing the cache, key and entry size on every insertion, although those values are already initialized on the wrapper.

### Modifications

Replace the capturing callback with a static method reference that reads initialized wrapper fields under the existing wrapper write lock. Preserve map/queue insertion, size accounting, failed-insertion recycling and value release order. Include an insertion/eviction benchmark and a Netty-thread JMH executor.

### Verifying this change

Historical JMH with active Netty recycling saved approximately 32 B per insertion (about 23% allocation in the measured cycles); times improved only 0.9–2.8%. The target allocation disappeared in profiling, but total broker allocation rose 1.4% amid unrelated allocation changes. No aggregate performance gain is claimed. Use -Djmh.executor=CUSTOM -Djmh.executor.class=org.apache.pulsar.client.impl.FastThreadLocalBenchmarkExecutor in benchmark fork JVMs for representative recycling.

Local extraction validation passed: `spotlessCheck checkstyleMain checkstyleTest`, benchmark compilation, and 34 scoped tests with no failures or skips: org.apache.bookkeeper.mledger.impl.cache.RangeCacheRemovalQueueTest (7), org.apache.bookkeeper.mledger.impl.cache.RangeCacheTest (12), org.apache.bookkeeper.mledger.impl.cache.RangeEntryCacheImplTest (15). Retries were disabled; Gradle ran with `--max-workers=2 --no-parallel`.

- [ ] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
