### PR TITLE
[improve][client] Dispatch individual acknowledgments without capturing functions

### DIFF
--- a/microbench/src/main/java/org/apache/pulsar/client/impl/AcknowledgmentDispatchBenchmark.java
+++ b/microbench/src/main/java/org/apache/pulsar/client/impl/AcknowledgmentDispatchBenchmark.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
+import org.apache.pulsar.client.util.ExecutorProvider;
+import org.apache.pulsar.common.api.proto.CommandAck.AckType;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/** Exercises the real ACK tracker with a disconnected consumer; excludes network and receipt completion. */
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(2)
+public class AcknowledgmentDispatchBenchmark {
+    @Param({"1", "1000"})
+    public int entries;
+
+    @Param({"insert", "duplicate"})
+    public String pendingIds;
+
+    private PulsarClientImpl client;
+    private ExecutorProvider executorProvider;
+    private BenchmarkConsumer consumer;
+    private PersistentAcknowledgmentsGroupingTracker tracker;
+    private MessageIdImpl[] messageIds;
+
+    @Setup
+    public void setup() throws Exception {
+        client = (PulsarClientImpl) PulsarClient.builder()
+                .serviceUrl("pulsar://localhost:6650")
+                .ioThreads(1).listenerThreads(1).statsInterval(0, TimeUnit.SECONDS).build();
+        executorProvider = new ExecutorProvider(1, "ack-dispatch-benchmark", true);
+        ConsumerConfigurationData<byte[]> conf = new ConsumerConfigurationData<>();
+        conf.setSubscriptionName("benchmark");
+        conf.setAcknowledgementsGroupTimeMicros(TimeUnit.HOURS.toMicros(1));
+        conf.setMaxAcknowledgmentGroupSize(Integer.MAX_VALUE);
+        consumer = new BenchmarkConsumer(client, conf, executorProvider);
+        tracker = new PersistentAcknowledgmentsGroupingTracker(consumer, conf, client.eventLoopGroup());
+        messageIds = new MessageIdImpl[entries];
+        for (int i = 0; i < entries; i++) {
+            messageIds[i] = new MessageIdImpl(1000, i, 0);
+            if ("duplicate".equals(pendingIds)) {
+                tracker.addAcknowledgment(messageIds[i], AckType.Individual, Collections.emptyMap());
+            }
+        }
+    }
+
+    @Benchmark
+    public int acknowledgeGroup(Blackhole blackhole) {
+        for (MessageIdImpl id : messageIds) {
+            blackhole.consume(tracker.addAcknowledgment(id, AckType.Individual, Collections.emptyMap()));
+        }
+        int pending = tracker.getPendingIndividualAcksSize();
+        if (pending != entries) {
+            throw new IllegalStateException("Unexpected pending ACK count: " + pending);
+        }
+        if ("insert".equals(pendingIds)) {
+            // The disconnected flush does not serialize commands; clear bounds the pending set between groups.
+            tracker.flushAndClean();
+        }
+        return pending;
+    }
+
+    @TearDown
+    public void tearDown() throws Exception {
+        try {
+            if (tracker != null) {
+                tracker.close();
+            }
+            if (consumer != null) {
+                consumer.close();
+            }
+        } finally {
+            try {
+                if (client != null) {
+                    client.close();
+                }
+            } finally {
+                if (executorProvider != null) {
+                    executorProvider.shutdownNow();
+                }
+            }
+        }
+    }
+
+    private static final class BenchmarkConsumer extends ConsumerImpl<byte[]> {
+        BenchmarkConsumer(PulsarClientImpl client, ConsumerConfigurationData<byte[]> conf,
+                          ExecutorProvider executorProvider) {
+            super(client, "persistent://public/default/ack-dispatch-benchmark", conf, executorProvider,
+                    0, false, false, new CompletableFuture<>(), null, 0, Schema.BYTES, null, true);
+        }
+
+        @Override
+        void grabCnx() {
+            // Suppress connection startup while retaining the normal consumer/tracker code; no network is needed.
+        }
+    }
+}

--- a/microbench/src/main/java/org/apache/pulsar/client/impl/package-info.java
+++ b/microbench/src/main/java/org/apache/pulsar/client/impl/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/** Microbenchmarks for client message construction and processing. */
+package org.apache.pulsar.client.impl;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java
@@ -39,7 +39,6 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import java.util.function.Function;
 import lombok.CustomLog;
 import lombok.Getter;
 import org.apache.commons.lang3.tuple.Triple;
@@ -179,13 +178,11 @@ public class PersistentAcknowledgmentsGroupingTracker implements Acknowledgments
             if (MessageIdAdvUtils.isBatch(messageIdAdv)) {
                 addIndividualAcknowledgment(MessageIdAdvUtils.discardBatch(messageIdAdv),
                         messageIdAdv,
-                        this::doIndividualAckAsync,
-                        this::doIndividualBatchAckAsync);
+                        null, true);
             } else {
                 addIndividualAcknowledgment(messageIdAdv,
                         null,
-                        this::doIndividualAckAsync,
-                        this::doIndividualBatchAckAsync);
+                        null, true);
             }
         }
     }
@@ -204,8 +201,8 @@ public class PersistentAcknowledgmentsGroupingTracker implements Acknowledgments
     private CompletableFuture<Void> addIndividualAcknowledgment(
             MessageIdAdv msgId,
             @Nullable MessageIdAdv batchMessageId,
-            Function<MessageIdAdv, CompletableFuture<Void>> individualAckFunction,
-            Function<MessageIdAdv, CompletableFuture<Void>> batchAckFunction) {
+            Map<String, Long> properties,
+            boolean groupedByCaller) {
         if (batchMessageId != null) {
             consumer.onAcknowledge(batchMessageId, null);
         } else {
@@ -217,9 +214,11 @@ public class PersistentAcknowledgmentsGroupingTracker implements Acknowledgments
             if (consumer.getPossibleSendToDeadLetterTopicMessages() != null) {
                 consumer.getPossibleSendToDeadLetterTopicMessages().remove(msgId);
             }
-            return individualAckFunction.apply(msgId);
+            // List acknowledgments already hold the grouping lock and flush after processing the list.
+            return groupedByCaller ? doIndividualAckAsync(msgId) : doIndividualAck(msgId, properties);
         } else if (batchIndexAckEnabled) {
-            return batchAckFunction.apply(batchMessageId);
+            return groupedByCaller ? doIndividualBatchAckAsync(batchMessageId)
+                    : doIndividualBatchAck(batchMessageId, properties);
         } else {
             return CompletableFuture.completedFuture(null);
         }
@@ -233,8 +232,7 @@ public class PersistentAcknowledgmentsGroupingTracker implements Acknowledgments
             case Individual:
                 return addIndividualAcknowledgment(msgId,
                         batchMessageId,
-                        __ -> doIndividualAck(__, properties),
-                        __ -> doIndividualBatchAck(__, properties));
+                        properties, false);
             case Cumulative:
                 if (batchMessageId != null) {
                     consumer.onAcknowledgeCumulative(batchMessageId, null);

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/AcknowledgementsGroupingTrackerTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/AcknowledgementsGroupingTrackerTest.java
@@ -39,7 +39,9 @@ import io.netty.util.concurrent.GenericFutureListener;
 import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
@@ -236,6 +238,33 @@ public class AcknowledgementsGroupingTrackerTest {
         // Since we were connected, the ack went out immediately
         assertFalse(tracker.isDuplicate(msg2));
         tracker.close();
+    }
+
+    @Test
+    public void testIndividualAckPropertiesAreCheckedAfterInterceptor() {
+        ConsumerImpl<?> disconnectedConsumer = mock(ConsumerImpl.class);
+        doReturn(new ConsumerStatsRecorderImpl()).when(disconnectedConsumer).getStats();
+        doReturn(UnAckedMessageTracker.UNACKED_MESSAGE_TRACKER_DISABLED)
+                .when(disconnectedConsumer).getUnAckedMessageTracker();
+        ConsumerConfigurationData<?> conf = new ConsumerConfigurationData<>();
+        conf.setAcknowledgementsGroupTimeMicros(TimeUnit.HOURS.toMicros(1));
+        PersistentAcknowledgmentsGroupingTracker tracker =
+                new PersistentAcknowledgmentsGroupingTracker(disconnectedConsumer, conf, eventLoopGroup);
+        MessageIdImpl messageId = new MessageIdImpl(5, 1, 0);
+        Map<String, Long> properties = new HashMap<>();
+        doAnswer(invocation -> {
+            properties.put("interceptor-property", 1L);
+            return null;
+        }).when(disconnectedConsumer).onAcknowledge(messageId, null);
+        try {
+            // Adding properties in the interceptor must force the immediate path. With no connection it fails,
+            // whereas incorrectly checking the initially empty map would queue a successful grouped ACK.
+            CompletableFuture<Void> result = tracker.addAcknowledgment(messageId, AckType.Individual, properties);
+            assertTrue(result.isCompletedExceptionally());
+            assertEquals(tracker.getPendingIndividualAcksSize(), 0);
+        } finally {
+            tracker.close();
+        }
     }
 
     @Test(dataProvider = "isNeedReceipt")


### PR DESCRIPTION
### Motivation

Individual acknowledgment dispatch creates functions capturing properties and the tracker to select between grouped and immediate acknowledgment paths. Profiles observed allocation at these sites.

### Modifications

Replace private Function parameters with direct dispatch using properties and whether the caller already groups acknowledgments. Preserve list locking/final flush, interceptor ordering, property checks, batch and receipt behavior. Add an interceptor/property-order regression test and a real-tracker dispatch benchmark.

### Verifying this change

Historical integration profiling observed 2.6% lower consumer sampled allocation with flat CPU. JMH allocation was unchanged and did not establish a CPU improvement; the larger duplicate case had wide overlapping timing intervals. This is a targeted allocation cleanup, not a throughput claim; no new performance runs were made for extraction.

Local extraction validation passed: `spotlessCheck checkstyleMain checkstyleTest`, benchmark compilation, and 20 scoped tests with no failures or skips: org.apache.pulsar.client.impl.AcknowledgementsGroupingTrackerTest (17), org.apache.pulsar.client.api.InterceptorsTest (3). Retries were disabled; Gradle ran with `--max-workers=2 --no-parallel`.

- [ ] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
