### PR TITLE
[improve][ml] Share immutable publish positions with cached entries

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
@@ -266,6 +266,7 @@ public class OpAddEntry implements AddCallback, CloseCallback, Runnable, Managed
 
         // ctx will contain a Position instance only in the case of ShadowManagedLedgerImpl
         long ledgerId = ledger != null ? ledger.getId() : ((Position) ctx).getLedgerId();
+        Position lastEntry = PositionFactory.create(ledgerId, entryId);
 
         // Handle caching for tailing reads
         if (ml.shouldCacheAddedEntry()) {
@@ -275,7 +276,7 @@ public class OpAddEntry implements AddCallback, CloseCallback, Runnable, Managed
                 // use the number of active cursors as the expected read count
                 expectedReadCount = ml.getActiveCursors().size();
             }
-            EntryImpl entry = EntryImpl.create(ledgerId, entryId, data, expectedReadCount);
+            EntryImpl entry = EntryImpl.create(lastEntry, data, expectedReadCount);
             entry.setDecreaseReadCountOnRelease(false);
             // EntryCache.insert: duplicates entry by allocating new entry and data. so, recycle entry after calling
             // insert
@@ -283,7 +284,6 @@ public class OpAddEntry implements AddCallback, CloseCallback, Runnable, Managed
             entry.release();
         }
 
-        Position lastEntry = PositionFactory.create(ledgerId, entryId);
         ManagedLedgerImpl.ENTRIES_ADDED_COUNTER_UPDATER.incrementAndGet(ml);
         ml.lastConfirmedEntry = lastEntry;
 

--- a/microbench/src/main/java/org/apache/bookkeeper/mledger/impl/PublishPositionSharingBenchmark.java
+++ b/microbench/src/main/java/org/apache/bookkeeper/mledger/impl/PublishPositionSharingBenchmark.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.mledger.impl;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.util.concurrent.FastThreadLocalThread;
+import java.util.concurrent.TimeUnit;
+import org.apache.bookkeeper.mledger.Position;
+import org.apache.bookkeeper.mledger.PositionFactory;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+/** Isolates position construction with real pooled entry copies; does not model persistence or cache maps. */
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(2)
+public class PublishPositionSharingBenchmark {
+    @Param({"false", "true"})
+    public boolean sharePosition;
+
+    @Param({"false", "true"})
+    public boolean cacheEntry;
+
+    private ByteBuf data;
+    private long nextEntryId;
+    private volatile Position cachedPosition;
+    private volatile Position confirmedPosition;
+
+    @Setup
+    public void setup() {
+        if (!FastThreadLocalThread.currentThreadWillCleanupFastThreadLocals()) {
+            throw new IllegalStateException("Run with FastThreadLocalBenchmarkExecutor in the fork JVM");
+        }
+        data = PooledByteBufAllocator.DEFAULT.directBuffer(128).writeZero(128);
+    }
+
+    @Benchmark
+    public long completePublish() {
+        long entryId = nextEntryId++;
+        Position lastEntry = sharePosition ? PositionFactory.create(1, entryId) : null;
+        if (cacheEntry) {
+            EntryImpl entry = sharePosition ? EntryImpl.create(lastEntry, data, 0)
+                    : EntryImpl.create(1, entryId, data, 0);
+            try {
+                EntryImpl copy = EntryImpl.createWithRetainedDuplicate(entry.getPosition(), entry.getDataBuffer(), 0);
+                try {
+                    cachedPosition = copy.getPosition();
+                } finally {
+                    copy.release();
+                }
+            } finally {
+                entry.release();
+            }
+        }
+        if (!sharePosition) {
+            lastEntry = PositionFactory.create(1, entryId);
+        }
+        confirmedPosition = lastEntry;
+        return lastEntry.getEntryId();
+    }
+
+    @TearDown
+    public void tearDown() {
+        cachedPosition = null;
+        confirmedPosition = null;
+        data.release();
+    }
+}

--- a/microbench/src/main/java/org/apache/pulsar/client/impl/FastThreadLocalBenchmarkExecutor.java
+++ b/microbench/src/main/java/org/apache/pulsar/client/impl/FastThreadLocalBenchmarkExecutor.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import io.netty.util.concurrent.DefaultThreadFactory;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+/** Optional JMH executor for benchmarks that need Netty's thread-local recycling to be active. */
+public class FastThreadLocalBenchmarkExecutor extends ThreadPoolExecutor {
+    public FastThreadLocalBenchmarkExecutor(int threads, String name) {
+        super(threads, threads, 0, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>(),
+                new DefaultThreadFactory(name));
+    }
+}

--- a/microbench/src/main/java/org/apache/pulsar/client/impl/package-info.java
+++ b/microbench/src/main/java/org/apache/pulsar/client/impl/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/** Microbenchmarks for org.apache.pulsar.client.impl. */
+package org.apache.pulsar.client.impl;


### PR DESCRIPTION
### Motivation

Cached publish completion creates a position for the cache entry and then another identical immutable position for the last-confirmed state and add callback.

### Modifications

Create the completion position before cache insertion and pass it to the existing EntryImpl.create overload taking Position. Reuse the immutable instance for the cache and completion state; preserve uncached, shadow-ledger and rollover paths. Include a pooled-entry position-sharing benchmark and Netty-thread executor.

### Verifying this change

Historical pooled-entry JMH reduced cached-path allocation from 64 to 32 B, with CPU effectively flat; uncached allocation remained 32 B. The targeted position allocation disappeared in the full profile, but aggregate broker allocation/CPU were flat. No aggregate gain is claimed. Run the benchmark fork with -Djmh.executor=CUSTOM -Djmh.executor.class=org.apache.pulsar.client.impl.FastThreadLocalBenchmarkExecutor; its runtime guard verifies appropriate threads. No new performance experiments were run for extraction.

Local extraction validation passed: `spotlessCheck checkstyleMain checkstyleTest`, benchmark compilation, and 19 scoped tests with no failures or skips: org.apache.bookkeeper.mledger.impl.EntryImplTest (10), org.apache.bookkeeper.mledger.impl.ManagedLedgerTest (8), org.apache.bookkeeper.mledger.impl.ShadowManagedLedgerImplTest (1). Retries were disabled; Gradle ran with `--max-workers=2 --no-parallel`.

- [ ] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
