### PR TITLE
[improve][test] Reduce perf-producer traversal and completion overhead

### DIFF
--- a/microbench/build.gradle.kts
+++ b/microbench/build.gradle.kts
@@ -27,6 +27,7 @@ plugins {
 dependencies {
     api(project(":managed-ledger"))
     implementation(project(":pulsar-common"))
+    implementation(project(":pulsar-testclient"))
     api(project(":pulsar-broker"))
     implementation(libs.bookkeeper.server)
     implementation(libs.fastutil)

--- a/microbench/src/main/java/org/apache/pulsar/client/impl/ProducerRoundRobinBenchmark.java
+++ b/microbench/src/main/java/org/apache/pulsar/client/impl/ProducerRoundRobinBenchmark.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/** Isolates round-robin list traversal; real perf-producer payload, metrics and asynchronous sends are omitted. */
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(2)
+public class ProducerRoundRobinBenchmark {
+    @Param({"1", "8", "64"})
+    public int producerCount;
+
+    @Param({"false", "true"})
+    public boolean indexed;
+
+    private List<ProducerSlot> producers;
+
+    @Setup
+    public void setup() {
+        producers = new ArrayList<>(producerCount);
+        for (int i = 0; i < producerCount; i++) {
+            producers.add(new ProducerSlot());
+        }
+    }
+
+    @Benchmark
+    public long visitProducers() {
+        long sent = 0;
+        if (indexed) {
+            for (int i = 0; i < producers.size(); i++) {
+                sent += producers.get(i).send();
+            }
+        } else {
+            for (ProducerSlot producer : producers) {
+                sent += producer.send();
+            }
+        }
+        return sent;
+    }
+
+    private static final class ProducerSlot {
+        private long completed;
+
+        long send() {
+            return ++completed;
+        }
+    }
+}

--- a/microbench/src/main/java/org/apache/pulsar/client/impl/package-info.java
+++ b/microbench/src/main/java/org/apache/pulsar/client/impl/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/** Microbenchmarks for org.apache.pulsar.client.impl. */
+package org.apache.pulsar.client.impl;

--- a/microbench/src/main/java/org/apache/pulsar/testclient/PerfSendCompletionBenchmark.java
+++ b/microbench/src/main/java/org/apache/pulsar/testclient/PerfSendCompletionBenchmark.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.testclient;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/** Measures actual perf-producer accounting and future completion, without SDK/network work. */
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(2)
+public class PerfSendCompletionBenchmark {
+    @Param({"false", "true"})
+    public boolean completed;
+
+    @Param({"false", "true"})
+    public boolean recordLatency;
+
+    private PerformanceProducerV4 producer;
+    private AtomicLong totalSent;
+    private byte[] payload;
+    private long warmupEndTime;
+
+    @Setup
+    public void setup() {
+        producer = new PerformanceProducerV4();
+        totalSent = new AtomicLong();
+        payload = new byte[128];
+        warmupEndTime = recordLatency ? 0 : Long.MAX_VALUE;
+    }
+
+    @Benchmark
+    public CompletableFuture<Void> sendCompletion() {
+        CompletableFuture<Object> send = new CompletableFuture<>();
+        long sendTime = System.nanoTime();
+        if (completed) {
+            send.complete(null);
+        }
+        CompletableFuture<Void> result =
+                producer.trackSendCompletion(send, payload, totalSent, sendTime, warmupEndTime);
+        if (!completed) {
+            send.complete(null);
+        }
+        return result;
+    }
+}

--- a/microbench/src/main/java/org/apache/pulsar/testclient/package-info.java
+++ b/microbench/src/main/java/org/apache/pulsar/testclient/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/** Microbenchmarks for performance-tool overhead. */
+package org.apache.pulsar.testclient;

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducerBase.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducerBase.java
@@ -27,6 +27,7 @@ import static org.apache.pulsar.client.impl.conf.ProducerConfigurationData.DEFAU
 import static org.apache.pulsar.testclient.PerfClientUtils.LATENCY_HISTOGRAM_SIGNIFICANT_DIGITS;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Range;
 import com.google.common.util.concurrent.RateLimiter;
 import io.github.merlimat.slog.Logger;
@@ -42,6 +43,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -527,6 +529,63 @@ public abstract class PerformanceProducerBase<ClientT, ProducerT, TxnT> extends 
         }
     }
 
+    // The returned stage is only awaited for transactions; it must not be cancelled before accounting runs.
+    CompletableFuture<Void> trackSendCompletion(CompletableFuture<?> sendFuture, byte[] payloadData,
+                                                AtomicLong totalSent, long sendTime, long warmupEndTime) {
+        return sendFuture.handle((messageId, sendError) -> {
+            if (sendError != null) {
+                recordSendFailure(sendError);
+            } else {
+                try {
+                    recordSendSuccess(payloadData, totalSent, sendTime, warmupEndTime);
+                } catch (Throwable accountingError) {
+                    // The former thenRun/exceptionally chain also handled failures from accounting.
+                    recordSendFailure(accountingError);
+                }
+            }
+            return null;
+        });
+    }
+
+    private void recordSendSuccess(byte[] payloadData, AtomicLong totalSent, long sendTime, long warmupEndTime) {
+        bytesSent.add(payloadData.length);
+        messagesSent.increment();
+        totalSent.incrementAndGet();
+        totalMessagesSent.increment();
+        totalBytesSent.add(payloadData.length);
+
+        long now = System.nanoTime();
+        if (now > warmupEndTime) {
+            long latencyMicros = Math.min(NANOSECONDS.toMicros(now - sendTime), MAX_LATENCY_MICROS);
+            recorder.recordValue(latencyMicros);
+            cumulativeRecorder.recordValue(latencyMicros);
+        }
+    }
+
+    private void recordSendFailure(Throwable error) {
+        // Preserve the exception shape formerly relayed through thenRun to exceptionally.
+        Throwable ex = error instanceof CompletionException ? error : new CompletionException(error);
+        Throwable cause = FutureUtil.unwrapCompletionException(ex);
+        // Ignore the exception when the producer is closed
+        if (isAlreadyClosedException(cause)) {
+            return;
+        }
+        if (PerfClientUtils.hasInterruptedException(ex)) {
+            Thread.currentThread().interrupt();
+            return;
+        }
+        log.warn().exception(ex).log("Write message error with exception");
+        messagesFailed.increment();
+        if (this.exitOnFailure) {
+            PerfClientUtils.exit(1);
+        }
+    }
+
+    @VisibleForTesting
+    long getMessagesFailed() {
+        return messagesFailed.sum();
+    }
+
     private void runProducer(int producerId,
                              long numMessages,
                              int msgRate,
@@ -589,7 +648,8 @@ public abstract class PerformanceProducerBase<ClientT, ProducerT, TxnT> extends 
                 if (produceEnough) {
                     break;
                 }
-                for (ProducerT producer : producers) {
+                for (int producerIndex = 0; producerIndex < producers.size(); producerIndex++) {
+                    ProducerT producer = producers.get(producerIndex);
                     if (this.testTime > 0) {
                         if (System.nanoTime() > testEndTime) {
                             log.info()
@@ -646,39 +706,9 @@ public abstract class PerformanceProducerBase<ClientT, ProducerT, TxnT> extends 
                     } else if (msgKeyMode == MessageKeyGenerationMode.autoIncrement) {
                         messageKey = String.valueOf(totalSent.get());
                     }
-                    CompletableFuture<?> sendFuture =
-                            sendMessage(producer, payloadData, transaction, messageKey, deliverAfterSeconds)
-                            .thenRun(() -> {
-                                bytesSent.add(payloadData.length);
-                                messagesSent.increment();
-                                totalSent.incrementAndGet();
-                                totalMessagesSent.increment();
-                                totalBytesSent.add(payloadData.length);
-
-                                long now = System.nanoTime();
-                                if (now > warmupEndTime) {
-                                    long latencyMicros =
-                                            Math.min(NANOSECONDS.toMicros(now - sendTime), MAX_LATENCY_MICROS);
-                                    recorder.recordValue(latencyMicros);
-                                    cumulativeRecorder.recordValue(latencyMicros);
-                                }
-                            }).exceptionally(ex -> {
-                                Throwable cause = FutureUtil.unwrapCompletionException(ex);
-                                // Ignore the exception when the producer is closed
-                                if (isAlreadyClosedException(cause)) {
-                                    return null;
-                                }
-                                if (PerfClientUtils.hasInterruptedException(ex)) {
-                                    Thread.currentThread().interrupt();
-                                    return null;
-                                }
-                                log.warn().exception(ex).log("Write message error with exception");
-                                messagesFailed.increment();
-                                if (this.exitOnFailure) {
-                                    PerfClientUtils.exit(1);
-                                }
-                                return null;
-                            });
+                    CompletableFuture<?> sendFuture = trackSendCompletion(
+                            sendMessage(producer, payloadData, transaction, messageKey, deliverAfterSeconds),
+                            payloadData, totalSent, sendTime, warmupEndTime);
                     if (this.isEnableTransaction) {
                         pendingTxnSends.add(sendFuture);
                     }

--- a/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerformanceProducerCompletionTest.java
+++ b/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerformanceProducerCompletionTest.java
@@ -1,0 +1,201 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.testclient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mockStatic;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.mockito.MockedStatic;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class PerformanceProducerCompletionTest {
+    @DataProvider
+    public Object[][] completionTiming() {
+        return new Object[][] {{false}, {true}};
+    }
+
+    @Test(dataProvider = "completionTiming")
+    public void successUpdatesCountsBeforeCompleting(boolean completed) {
+        RecordingProducer producer = new RecordingProducer();
+        AtomicLong totalSent = new AtomicLong();
+        CompletableFuture<Object> send = new CompletableFuture<>();
+        if (completed) {
+            send.complete(new Object());
+        }
+        CompletableFuture<Void> tracked =
+                producer.trackSendCompletion(send, new byte[128], totalSent, System.nanoTime(), 0);
+        if (!completed) {
+            assertThat(tracked).isNotDone();
+            assertThat(totalSent.get()).isZero();
+            send.complete(new Object());
+        }
+        assertThat(tracked.join()).isNull();
+        assertThat(totalSent.get()).isEqualTo(1);
+        assertThat(producer.getMessagesFailed()).isZero();
+        assertThat(producer.observedCause).isNull();
+    }
+
+    @DataProvider
+    public Object[][] sendFailures() {
+        return new Object[][] {
+            {false, "ordinary"}, {true, "ordinary"},
+            {false, "wrapped"}, {true, "wrapped"},
+            {false, "cancelled"}, {true, "cancelled"},
+            {false, "closed"}, {true, "closed"},
+            {false, "interrupted"}, {true, "interrupted"}
+        };
+    }
+
+    @Test(dataProvider = "sendFailures")
+    public void failuresAreHandledBeforeCompleting(boolean completed, String failureKind) {
+        RecordingProducer producer = new RecordingProducer();
+        AtomicLong totalSent = new AtomicLong();
+        Throwable cause = switch (failureKind) {
+            case "closed" -> new PulsarClientException.AlreadyClosedException("closed");
+            case "interrupted" -> new InterruptedException("interrupted");
+            case "cancelled" -> new CancellationException("cancelled");
+            default -> new IllegalStateException("send failed");
+        };
+        Throwable failure = failureKind.equals("wrapped") ? new CompletionException(cause) : cause;
+        CompletableFuture<Object> send = new CompletableFuture<>();
+        try {
+            if (completed) {
+                send.completeExceptionally(failure);
+            }
+            CompletableFuture<Void> tracked =
+                    producer.trackSendCompletion(send, new byte[128], totalSent, System.nanoTime(), 0);
+            if (!completed) {
+                assertThat(tracked).isNotDone();
+                send.completeExceptionally(failure);
+            }
+            // Transaction send lists depend on failures being consumed by this stage.
+            assertThat(CompletableFuture.allOf(tracked).join()).isNull();
+            assertThat(producer.observedCause).isSameAs(cause);
+            assertThat(totalSent.get()).isZero();
+            boolean ignored = failureKind.equals("closed") || failureKind.equals("interrupted");
+            assertThat(producer.getMessagesFailed()).isEqualTo(ignored ? 0 : 1);
+            assertThat(Thread.currentThread().isInterrupted()).isEqualTo(failureKind.equals("interrupted"));
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    @Test(dataProvider = "completionTiming")
+    public void metricFailuresUseTheSendFailureHandler(boolean completed) {
+        RecordingProducer producer = new RecordingProducer();
+        AtomicLong totalSent = new AtomicLong();
+        CompletableFuture<Object> send = new CompletableFuture<>();
+        if (completed) {
+            send.complete(null);
+        }
+        // A future send timestamp produces a negative latency, rejected by HdrHistogram.
+        CompletableFuture<Void> tracked =
+                producer.trackSendCompletion(send, new byte[128], totalSent, Long.MAX_VALUE, 0);
+        if (!completed) {
+            send.complete(null);
+        }
+        assertThat(tracked.join()).isNull();
+        assertThat(totalSent.get()).isEqualTo(1);
+        assertThat(producer.getMessagesFailed()).isEqualTo(1);
+        assertThat(producer.observedCause).isInstanceOf(RuntimeException.class);
+    }
+
+    @DataProvider
+    public Object[][] failureOrigins() {
+        return new Object[][] {{false}, {true}};
+    }
+
+    @Test(dataProvider = "failureOrigins")
+    public void errorHandlerFailureRemainsExceptional(boolean accountingFailure) {
+        IllegalArgumentException handlerFailure = new IllegalArgumentException("classification failed");
+        PerformanceProducerV4 producer = new PerformanceProducerV4() {
+            @Override
+            protected boolean isAlreadyClosedException(Throwable cause) {
+                throw handlerFailure;
+            }
+        };
+        CompletableFuture<?> send = accountingFailure ? CompletableFuture.completedFuture(null)
+                : CompletableFuture.failedFuture(new IllegalStateException("send failed"));
+        CompletableFuture<Void> tracked = producer.trackSendCompletion(send,
+                new byte[128], new AtomicLong(), accountingFailure ? Long.MAX_VALUE : System.nanoTime(), 0);
+        assertThatThrownBy(tracked::join).isInstanceOf(CompletionException.class).hasCause(handlerFailure);
+    }
+
+    @Test
+    public void interruptionIsRestoredOnTheCompletingThread() throws Exception {
+        RecordingProducer producer = new RecordingProducer();
+        CompletableFuture<Object> send = new CompletableFuture<>();
+        CompletableFuture<Void> tracked = producer.trackSendCompletion(
+                send, new byte[128], new AtomicLong(), System.nanoTime(), 0);
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            boolean interrupted = executor.submit(() -> {
+                try {
+                    send.completeExceptionally(new InterruptedException("send interrupted"));
+                    return Thread.currentThread().isInterrupted();
+                } finally {
+                    Thread.interrupted();
+                }
+            }).get(10, TimeUnit.SECONDS);
+            assertThat(interrupted).isTrue();
+            assertThat(tracked.join()).isNull();
+            assertThat(Thread.currentThread().isInterrupted()).isFalse();
+            assertThat(producer.getMessagesFailed()).isZero();
+        } finally {
+            executor.shutdownNow();
+            assertThat(executor.awaitTermination(10, TimeUnit.SECONDS)).isTrue();
+        }
+    }
+
+    @Test
+    public void exitOnFailureRunsAfterFailureAccounting() {
+        PerformanceProducerV4 producer = new PerformanceProducerV4();
+        producer.exitOnFailure = true;
+        try (MockedStatic<PerfClientUtils> utils = mockStatic(PerfClientUtils.class)) {
+            utils.when(() -> PerfClientUtils.exit(1)).thenAnswer(invocation -> {
+                assertThat(producer.getMessagesFailed()).isEqualTo(1);
+                return null;
+            });
+            CompletableFuture<Void> tracked = producer.trackSendCompletion(
+                    CompletableFuture.failedFuture(new IllegalStateException("send failed")),
+                    new byte[128], new AtomicLong(), System.nanoTime(), 0);
+            assertThat(tracked.join()).isNull();
+            utils.verify(() -> PerfClientUtils.exit(1));
+        }
+    }
+
+    private static final class RecordingProducer extends PerformanceProducerV4 {
+        private Throwable observedCause;
+
+        @Override
+        protected boolean isAlreadyClosedException(Throwable cause) {
+            observedCause = cause;
+            return super.isAlreadyClosedException(cause);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

The perf producer allocates an iterator during round-robin traversal and two completion stages per deferred send for success accounting and failure handling. This driver overhead contributes to producer profiling costs.

### Modifications

Use indexed traversal over the fixed local producer ArrayList and a single handle stage with separate success/failure helpers. Preserve failure swallowing, exception wrapping, interruption, exit policy, accounting-error handling and transaction completion ordering. Add focused completion tests and traversal/completion benchmarks. The returned completion stage is internal and never cancelled by the send loop; it is awaited for transactions. Add a microbench project dependency on pulsar-testclient to benchmark the actual helper.

### Verifying this change

Historical deferred-completion JMH improved from 205.880 to 160.447 ns and 304 to 184 B. E038 incremental producer allocation fell 11.5% and matched-window CPU samples per million sends fell about 7.2%. E037 independently removed iterator allocation (about 2.1% of producer allocation) with CPU flat; these percentages are not additive. This optimizes the perf driver, not SDK/broker internals. No new performance experiments were run for extraction.

Local extraction validation passed: `spotlessCheck checkstyleMain checkstyleTest`, benchmark compilation, and 33 scoped tests with no failures or skips: org.apache.pulsar.testclient.PerformanceProducerCompletionTest (18), org.apache.pulsar.testclient.PerformanceProducerTest (6), org.apache.pulsar.testclient.PerformanceV4CommandsTest (9). Retries were disabled; Gradle ran with `--max-workers=2 --no-parallel`.

- [ ] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

- [x] Dependencies (add or upgrade a dependency) — microbench gains a project dependency on pulsar-testclient for the benchmark; no runtime dependency version changes.
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
