### PR TITLE
[improve][broker] Avoid lookup positions when batch-index state is empty

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedCursor.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedCursor.java
@@ -912,6 +912,14 @@ public interface ManagedCursor {
     long[] getDeletedBatchIndexesAsLongArray(Position position);
 
     /**
+     * Get deleted batch indexes using ledger and entry IDs. Implementations may avoid creating a position when
+     * no batch-index acknowledgements are recorded. The default preserves existing cursor implementations.
+     */
+    default long[] getDeletedBatchIndexesAsLongArray(long ledgerId, long entryId) {
+        return getDeletedBatchIndexesAsLongArray(PositionFactory.create(ledgerId, entryId));
+    }
+
+    /**
      * @return the managed cursor stats MBean
      */
     ManagedCursorMXBean getStats();

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -4069,6 +4069,16 @@ public class ManagedCursorImpl implements ManagedCursor {
     }
 
     @Override
+    public long[] getDeletedBatchIndexesAsLongArray(long ledgerId, long entryId) {
+        // Subclasses may override the position-based lookup, so preserve their virtual dispatch.
+        if (getClass() == ManagedCursorImpl.class
+                && (batchDeletedIndexes == null || batchDeletedIndexes.isEmpty())) {
+            return null;
+        }
+        return getDeletedBatchIndexesAsLongArray(PositionFactory.create(ledgerId, entryId));
+    }
+
+    @Override
     public ManagedCursorMXBean getStats() {
         return this.mbean;
     }

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -4640,6 +4640,53 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
     }
 
     @Test
+    public void testBatchIndexLookupByIdsPreservesSubclassOverride() {
+        ManagedLedgerImpl ledger = mock(ManagedLedgerImpl.class);
+        when(ledger.getConfig()).thenReturn(new ManagedLedgerConfig());
+        when(ledger.getLogger()).thenReturn(log);
+        long[] expected = {7};
+        ManagedCursorImpl cursor = new ManagedCursorImpl(mock(BookKeeper.class), ledger, "c1") {
+            @Override
+            public long[] getDeletedBatchIndexesAsLongArray(Position position) {
+                assertEquals(position.getLedgerId(), 12L);
+                assertEquals(position.getEntryId(), 34L);
+                return expected;
+            }
+        };
+        assertEquals(cursor.getDeletedBatchIndexesAsLongArray(12, 34), expected);
+    }
+
+    @Test
+    public void testBatchIndexLookupByIdsDefaultImplementation() {
+        ManagedCursor cursor = mock(ManagedCursor.class, Mockito.CALLS_REAL_METHODS);
+        Position position = PositionFactory.create(12, 34);
+        long[] expected = {7};
+        when(cursor.getDeletedBatchIndexesAsLongArray(position)).thenReturn(expected);
+        assertEquals(cursor.getDeletedBatchIndexesAsLongArray(12, 34), expected);
+        verify(cursor).getDeletedBatchIndexesAsLongArray(position);
+    }
+
+    @Test
+    public void testBatchIndexLookupByLedgerAndEntryIds() throws Exception {
+        ManagedLedger ledger = factory.open("batch_index_lookup_ids");
+        ManagedCursor cursor = ledger.openCursor("c1");
+        Position position = ledger.addEntry("entry".getBytes(Encoding));
+        long ledgerId = position.getLedgerId();
+        long entryId = position.getEntryId();
+        assertNull(cursor.getDeletedBatchIndexesAsLongArray(ledgerId, entryId));
+
+        deleteBatchIndex(cursor, position, 10, Lists.newArrayList(new IntRange().setStart(2).setEnd(4)));
+        long[] snapshot = cursor.getDeletedBatchIndexesAsLongArray(ledgerId, entryId);
+        assertEquals(snapshot, cursor.getDeletedBatchIndexesAsLongArray(position));
+        assertNull(cursor.getDeletedBatchIndexesAsLongArray(ledgerId, entryId + 1));
+        snapshot[0] = 0;
+        assertNotEquals(cursor.getDeletedBatchIndexesAsLongArray(ledgerId, entryId)[0], 0L);
+
+        cursor.delete(position);
+        assertNull(cursor.getDeletedBatchIndexesAsLongArray(ledgerId, entryId));
+    }
+
+    @Test
     public void testBatchIndexDelete() throws ManagedLedgerException, InterruptedException {
         ManagedLedger ledger = factory.open("test_batch_index_delete");
         ManagedCursor cursor = ledger.openCursor("c1");

--- a/microbench/src/main/java/org/apache/pulsar/broker/service/DispatchPositionBenchmark.java
+++ b/microbench/src/main/java/org/apache/pulsar/broker/service/DispatchPositionBenchmark.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.TimeUnit;
+import org.apache.bookkeeper.mledger.Entry;
+import org.apache.bookkeeper.mledger.Position;
+import org.apache.bookkeeper.mledger.PositionFactory;
+import org.apache.bookkeeper.mledger.impl.EntryImpl;
+import org.apache.pulsar.common.api.proto.MessageMetadata;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Models dispatch lookups in ManagedCursorImpl's batch-deleted-index map using cached ledger entries.
+ * Entry positions are already initialized by cache insertion, as in the broker cache-hit path.
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(2)
+public class DispatchPositionBenchmark {
+    private static final int ENTRY_COUNT = 10000;
+
+    @Param({"0", "128", "10000"})
+    public int acknowledgedEntries;
+
+    private Entry[] entries;
+    private ConcurrentSkipListMap<Position, long[]> ackSets;
+    private int index;
+
+    @Setup
+    public void setup() {
+        entries = new Entry[ENTRY_COUNT];
+        ackSets = new ConcurrentSkipListMap<>();
+        MessageMetadata metadata = new MessageMetadata().setProducerName("producer").setSequenceId(1)
+                .setPublishTime(1);
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            EntryImpl entry = EntryImpl.create(i / 1000, i % 1000, new byte[0]);
+            Position position = entry.getPosition();
+            entries[i] = EntryAndMetadata.create(entry, metadata);
+            if (i < acknowledgedEntries) {
+                ackSets.put(position, new long[] {1});
+            }
+        }
+    }
+
+    private Entry nextEntry() {
+        Entry entry = entries[index++];
+        if (index == entries.length) {
+            index = 0;
+        }
+        return entry;
+    }
+
+    @Benchmark
+    public long[] recreatedPosition() {
+        Entry entry = nextEntry();
+        return ackSets.get(PositionFactory.create(entry.getLedgerId(), entry.getEntryId()));
+    }
+
+    @Benchmark
+    public long[] cachedPosition() {
+        return ackSets.get(nextEntry().getPosition());
+    }
+
+    @Benchmark
+    public long[] skipPositionForEmptyMap() {
+        Entry entry = nextEntry();
+        if (ackSets.isEmpty()) {
+            return null;
+        }
+        return ackSets.get(PositionFactory.create(entry.getLedgerId(), entry.getEntryId()));
+    }
+
+    @TearDown
+    public void tearDown() {
+        for (Entry entry : entries) {
+            entry.release();
+        }
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java
@@ -242,13 +242,13 @@ public abstract class AbstractBaseDispatcher extends EntryFilterSupport implemen
             int batchSize = msgMetadata.getNumMessagesInBatch();
             long[] ackSet = null;
             if (indexesAcks != null && cursor != null) {
-                Position position = PositionFactory.create(entry.getLedgerId(), entry.getEntryId());
                 ackSet = cursor
-                        .getDeletedBatchIndexesAsLongArray(position);
+                        .getDeletedBatchIndexesAsLongArray(entry.getLedgerId(), entry.getEntryId());
                 // some batch messages ack bit sit will be in pendingAck state, so don't send all bit sit to consumer
                 if (subscription instanceof PersistentSubscription
                         && ((PersistentSubscription) subscription)
                         .getPendingAckHandle() instanceof PendingAckHandleImpl) {
+                    Position position = PositionFactory.create(entry.getLedgerId(), entry.getEntryId());
                     Position positionInPendingAck =
                             ((PersistentSubscription) subscription).getPositionInPendingAck(position);
                     // if this position not in pendingAck state, don't need to do any op

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/AbstractBaseDispatcherTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/AbstractBaseDispatcherTest.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.broker.service;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.pulsar.common.protocol.Commands.serializeMetadataAndPayload;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -96,6 +97,8 @@ public class AbstractBaseDispatcherTest {
         EntryBatchIndexesAcks indexesAcks = EntryBatchIndexesAcks.get(entries.entries.size());
         ManagedCursor cursor = mock(ManagedCursor.class);
         when(cursor.getDeletedBatchIndexesAsLongArray(any(Position.class))).thenReturn(null);
+        // Exercise the compatibility default for cursors that implement only the Position-based method.
+        when(cursor.getDeletedBatchIndexesAsLongArray(anyLong(), anyLong())).thenCallRealMethod();
         try {
             int size = this.helper.filterEntriesForConsumer(entries.entries, batchSizes, sendMessageInfo,
                     indexesAcks, cursor, false, null);


### PR DESCRIPTION
### Motivation

Dispatch constructs a Position for batch-index acknowledgment lookup even when the cursor has no batch-index state to query.

### Modifications

Add a default ManagedCursor overload accepting ledger and entry IDs and use it from dispatch. ManagedCursorImpl skips position construction when its batch-index map is absent or empty. Limit this shortcut to the exact implementation class so subclasses retain their existing position-based overrides. Preserve a delegating fallback for other implementations. Add lookup, snapshot-independence, default-method and subclass-override coverage plus a focused lookup benchmark.

### Verifying this change

Historical profiling of the original experiment removed a 2.665 GB position-allocation site and observed about 6.7% lower broker sampled allocation. Populated-map microbenchmarks added roughly 2–4 ns per lookup. The extraction adds the subclass guard, which was not in those measurements; no new performance claim is made for that additional guard. No new profiling/JMH experiments were run.

Local extraction validation passed: `spotlessCheck checkstyleMain checkstyleTest`, benchmark compilation, and 13 scoped tests with no failures or skips: org.apache.pulsar.broker.service.AbstractBaseDispatcherTest (7), org.apache.bookkeeper.mledger.impl.ManagedCursorTest (6). Retries were disabled; Gradle ran with `--max-workers=2 --no-parallel`.

- [ ] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [x] The public API — adds a default ManagedCursor overload; existing implementations retain a delegating fallback.
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
