### PR TITLE
[improve][ml] Build cached read results without an intermediate collection

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeCache.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeCache.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import lombok.CustomLog;
 import org.apache.bookkeeper.mledger.Position;
@@ -178,6 +179,24 @@ class RangeCache {
         }
 
         return values;
+    }
+
+    /**
+     * Visits matching entries in order without collecting them. Each entry is retained during the callback and
+     * released afterwards, including when the callback throws. The visitor must retain entries it needs to keep.
+     */
+    public void forEachInRange(Position first, Position last, Consumer<ReferenceCountedEntry> visitor) {
+        for (Map.Entry<Position, RangeCacheEntryWrapper> entry : entries.subMap(first, true, last, true)
+                .entrySet()) {
+            ReferenceCountedEntry value = getValueMatchingEntry(entry);
+            if (value != null) {
+                try {
+                    visitor.accept(value);
+                } finally {
+                    value.release();
+                }
+            }
+        }
     }
 
     /**

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImpl.java
@@ -26,13 +26,12 @@ import io.github.merlimat.slog.Logger;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.LongAdder;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.IntSupplier;
 import org.apache.bookkeeper.client.api.BKException;
@@ -398,39 +397,29 @@ public class RangeEntryCacheImpl implements EntryCache {
     void doAsyncReadEntriesByPosition(ReadHandle lh, Position firstPosition, Position lastPosition, int numberOfEntries,
                                       IntSupplier expectedReadCount, final ReadEntriesCallback callback,
                                       Object ctx) {
-        Collection<ReferenceCountedEntry> cachedEntries;
+        CachedEntries cachedEntries = new CachedEntries(firstPosition.getEntryId(), numberOfEntries);
         if (firstPosition.compareTo(lastPosition) == 0) {
             ReferenceCountedEntry cachedEntry = entries.get(firstPosition);
-            if (cachedEntry == null) {
-                cachedEntries = Collections.emptyList();
-            } else {
-                cachedEntries = Collections.singleton(cachedEntry);
+            if (cachedEntry != null) {
+                try {
+                    cachedEntries.accept(cachedEntry);
+                } finally {
+                    cachedEntry.release();
+                }
             }
         } else {
-            cachedEntries = entries.getRange(firstPosition, lastPosition);
+            entries.forEachInRange(firstPosition, lastPosition, cachedEntries);
         }
 
-        if (cachedEntries.size() > 0) {
-            long totalCachedSize = 0;
-            final List<Entry> entriesToReturn = new ArrayList<>(numberOfEntries);
-            for (int i = 0; i < numberOfEntries; i++) {
-                entriesToReturn.add(null); // Initialize with nulls
-            }
-
-            for (Entry entry : cachedEntries) {
-                int index = (int) (entry.getPosition().getEntryId() - firstPosition.getEntryId());
-                entriesToReturn.set(index, EntryImpl.create(entry));
-                totalCachedSize += entry.getLength();
-                entry.release();
-            }
-
-            manager.getMlFactoryMBean().recordCacheHits(cachedEntries.size(), totalCachedSize);
+        if (cachedEntries.count > 0) {
+            final List<Entry> entriesToReturn = cachedEntries.entries;
+            manager.getMlFactoryMBean().recordCacheHits(cachedEntries.count, cachedEntries.totalSize);
             log.debug().attr("numberOfEntries", numberOfEntries)
                     .attr("firstPosition", firstPosition)
                     .attr("lastPosition", lastPosition)
                     .log("Cache hit for entries");
 
-            if (cachedEntries.size() == numberOfEntries) {
+            if (cachedEntries.count == numberOfEntries) {
                 callback.readEntriesComplete(entriesToReturn, ctx);
             } else {
                 // read missing ranges
@@ -505,6 +494,34 @@ public class RangeEntryCacheImpl implements EntryCache {
             // Read all the entries from bookkeeper
             pendingReadsManager.readEntries(lh, firstPosition.getEntryId(), lastPosition.getEntryId(),
                     expectedReadCount, callback, ctx);
+        }
+    }
+
+    /** Builds the final sparse result directly, allocating its list only after the first cache hit. */
+    static final class CachedEntries implements Consumer<ReferenceCountedEntry> {
+        private final long firstEntryId;
+        private final int numberOfEntries;
+        List<Entry> entries;
+        private int count;
+        private long totalSize;
+
+        CachedEntries(long firstEntryId, int numberOfEntries) {
+            this.firstEntryId = firstEntryId;
+            this.numberOfEntries = numberOfEntries;
+        }
+
+        @Override
+        public void accept(ReferenceCountedEntry entry) {
+            if (entries == null) {
+                entries = new ArrayList<>(numberOfEntries);
+                for (int i = 0; i < numberOfEntries; i++) {
+                    entries.add(null);
+                }
+            }
+            int index = (int) (entry.getPosition().getEntryId() - firstEntryId);
+            entries.set(index, EntryImpl.create(entry));
+            count++;
+            totalSize += entry.getLength();
         }
     }
 

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/cache/RangeCacheTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/cache/RangeCacheTest.java
@@ -19,6 +19,7 @@
 package org.apache.bookkeeper.mledger.impl.cache;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -27,6 +28,8 @@ import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import io.netty.buffer.Unpooled;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -228,6 +231,54 @@ public class RangeCacheTest {
         cache.clear();
         assertEquals(cache.getSize(), 0);
         assertEquals(cache.getNumberOfEntries(), 0);
+    }
+
+    @Test
+    public void visitRangeReleasesReferencesAndPreservesOrder() {
+        RangeCache cache = new RangeCache(createRemovalQueue());
+        ReferenceCountedEntry first = createCachedEntry(1, "one");
+        ReferenceCountedEntry last = createCachedEntry(3, "three");
+        assertTrue(cache.put(first.getPosition(), first));
+        assertTrue(cache.put(last.getPosition(), last));
+        try {
+            List<Position> visited = new ArrayList<>();
+            cache.forEachInRange(createPosition(1), createPosition(3), entry -> {
+                assertEquals(entry.refCnt(), 2);
+                visited.add(entry.getPosition());
+            });
+            assertThat(visited).containsExactly(createPosition(1), createPosition(3));
+            assertEquals(first.refCnt(), 1);
+            assertEquals(last.refCnt(), 1);
+            cache.forEachInRange(createPosition(4), createPosition(5), entry -> fail("Unexpected cache hit"));
+
+            RuntimeException failure = new RuntimeException("visitor failed");
+            assertThatThrownBy(() -> cache.forEachInRange(createPosition(1), createPosition(3), entry -> {
+                throw failure;
+            })).isSameAs(failure);
+            assertEquals(first.refCnt(), 1);
+            assertEquals(last.refCnt(), 1);
+        } finally {
+            cache.clear();
+        }
+        assertEquals(first.refCnt(), 0);
+        assertEquals(last.refCnt(), 0);
+    }
+
+    @Test
+    public void visitRangeKeepsEntryAliveDuringEviction() {
+        RangeCache cache = new RangeCache(createRemovalQueue());
+        ReferenceCountedEntry entry = createCachedEntry(1, "one");
+        assertTrue(cache.put(entry.getPosition(), entry));
+        try {
+            cache.forEachInRange(createPosition(1), createPosition(1), value -> {
+                cache.clear();
+                assertEquals(value.refCnt(), 1);
+                assertEquals(new String(value.getData()), "one");
+            });
+            assertEquals(entry.refCnt(), 0);
+        } finally {
+            cache.clear();
+        }
     }
 
     @Test

--- a/microbench/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeCacheReadBenchmark.java
+++ b/microbench/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeCacheReadBenchmark.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.mledger.impl.cache;
+
+import java.util.Collection;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import org.apache.bookkeeper.mledger.Entry;
+import org.apache.bookkeeper.mledger.Position;
+import org.apache.bookkeeper.mledger.PositionFactory;
+import org.apache.bookkeeper.mledger.ReferenceCountedEntry;
+import org.apache.bookkeeper.mledger.impl.EntryImpl;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+/** Measures range reads, including retaining and releasing hits, for dense, partial and empty cache ranges. */
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(2)
+public class RangeCacheReadBenchmark {
+    private static final int RANGE_COUNT = 16;
+
+    @Param({"100", "1000"})
+    public int batchSize;
+
+    @Param({"0", "10", "100"})
+    public int hitPercent;
+
+    @Param({"false", "true"})
+    public boolean visit;
+
+    private RangeCache cache;
+    private Position[] firstPositions;
+    private Position[] lastPositions;
+    private int range;
+
+    @Setup
+    public void setup() {
+        cache = new RangeCache(new RangeCacheRemovalQueue(0, false));
+        firstPositions = new Position[RANGE_COUNT];
+        lastPositions = new Position[RANGE_COUNT];
+        for (int r = 0; r < RANGE_COUNT; r++) {
+            firstPositions[r] = PositionFactory.create(r, 0);
+            lastPositions[r] = PositionFactory.create(r, batchSize - 1);
+            for (int i = 0; i < batchSize; i++) {
+                if (i % 100 < hitPercent) {
+                    EntryImpl entry = EntryImpl.create(r, i, new byte[0]);
+                    if (!cache.put(entry.getPosition(), entry)) {
+                        entry.release();
+                        throw new IllegalStateException("Failed to populate range cache");
+                    }
+                }
+            }
+        }
+    }
+
+    @Benchmark
+    public int readRange() {
+        int currentRange = range++;
+        if (range == RANGE_COUNT) {
+            range = 0;
+        }
+        CountingVisitor visitor = new CountingVisitor();
+        if (visit) {
+            cache.forEachInRange(firstPositions[currentRange], lastPositions[currentRange], visitor);
+        } else {
+            Collection<ReferenceCountedEntry> entries =
+                    cache.getRange(firstPositions[currentRange], lastPositions[currentRange]);
+            for (ReferenceCountedEntry entry : entries) {
+                visitor.accept(entry);
+                entry.release();
+            }
+        }
+        return visitor.count;
+    }
+
+    @Benchmark
+    public int readAndCopyRange() {
+        int currentRange = range++;
+        if (range == RANGE_COUNT) {
+            range = 0;
+        }
+        RangeEntryCacheImpl.CachedEntries result = new RangeEntryCacheImpl.CachedEntries(0, batchSize);
+        if (visit) {
+            cache.forEachInRange(firstPositions[currentRange], lastPositions[currentRange], result);
+        } else {
+            Collection<ReferenceCountedEntry> entries =
+                    cache.getRange(firstPositions[currentRange], lastPositions[currentRange]);
+            for (ReferenceCountedEntry entry : entries) {
+                result.accept(entry);
+                entry.release();
+            }
+        }
+        int count = 0;
+        if (result.entries != null) {
+            for (Entry entry : result.entries) {
+                if (entry != null) {
+                    count++;
+                    entry.release();
+                }
+            }
+        }
+        return count;
+    }
+
+    private static class CountingVisitor implements Consumer<ReferenceCountedEntry> {
+        private int count;
+
+        @Override
+        public void accept(ReferenceCountedEntry entry) {
+            count++;
+        }
+    }
+
+    @TearDown
+    public void tearDown() {
+        cache.clear();
+    }
+}


### PR DESCRIPTION
### Motivation

Range cache reads first collect retained cache entries and then copy them into the final read-result list. This allocates an intermediate collection and traverses the entries twice.

### Modifications

Add an ordered range visitor with a retained reference during each callback and guaranteed release afterward. Build the final sparse result directly, allocating its list only on the first cache hit. Preserve missing-range storage reads and cache-hit accounting. Add visitor ordering, reference ownership and exceptional-callback tests plus a range-read benchmark.

### Verifying this change

Historical 1,000-entry JMH reduced allocation from about 29,873 to 129 B and time from 29,033 to 23,316 ns; a fanout profile observed 7.5% lower broker sampled allocation. A small partial-hit case cost about 116 ns more. These are prior experimental results; no new full-run throughput claim is made. Reference ownership and concurrent eviction remain relevant review areas.

Local extraction validation passed: `spotlessCheck checkstyleMain checkstyleTest`, benchmark compilation, and 43 scoped tests with no failures or skips: org.apache.bookkeeper.mledger.impl.InflightReadsLimiterIntegrationTest (14), org.apache.bookkeeper.mledger.impl.cache.RangeCacheTest (14), org.apache.bookkeeper.mledger.impl.cache.RangeEntryCacheImplTest (15). Retries were disabled; Gradle ran with `--max-workers=2 --no-parallel`.

- [ ] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
