### PR TITLE
[improve][client] Serialize grouped acknowledgments using existing message IDs

### DIFF
--- a/microbench/src/main/java/org/apache/pulsar/client/impl/AckCommandAllocationBenchmark.java
+++ b/microbench/src/main/java/org/apache/pulsar/client/impl/AckCommandAllocationBenchmark.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import io.netty.buffer.ByteBuf;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.apache.pulsar.client.api.MessageIdAdv;
+import org.apache.pulsar.common.protocol.Commands;
+import org.apache.pulsar.common.util.collections.ConcurrentBitSet;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/** Measures ACK entry assembly and actual wire serialization; excludes pending-set draining and network writes. */
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(2)
+public class AckCommandAllocationBenchmark {
+    @Param({"1", "100", "1000"})
+    public int entries;
+
+    @Param({"false", "true"})
+    public boolean batchIndexes;
+
+    private MessageIdImpl[] messageIds;
+    private ConcurrentBitSet bitSet;
+    private List<Map.Entry<MessageIdAdv, ConcurrentBitSet>> pendingBatchAcks;
+
+    @Setup
+    public void setup() {
+        messageIds = new MessageIdImpl[entries];
+        for (int i = 0; i < entries; i++) {
+            // IDs above the Long cache expose the allocation cost of both boxed coordinates.
+            messageIds[i] = new MessageIdImpl(10000 + i / 100, 100000 + i, 0);
+        }
+        bitSet = new ConcurrentBitSet(100);
+        bitSet.set(5, 100);
+        pendingBatchAcks = new ArrayList<>(entries);
+        for (MessageIdImpl id : messageIds) {
+            // The pending map already supplies entries to the tracker; map draining is outside this benchmark.
+            pendingBatchAcks.add(new AbstractMap.SimpleImmutableEntry<>(id, bitSet));
+        }
+    }
+
+    @Benchmark
+    public int assembleAndSerialize() {
+        List<MessageIdAdv> acks;
+        List<Map.Entry<MessageIdAdv, ConcurrentBitSet>> batchAcks;
+        if (batchIndexes) {
+            acks = Collections.emptyList();
+            batchAcks = new ArrayList<>(entries);
+            for (Map.Entry<MessageIdAdv, ConcurrentBitSet> entry : pendingBatchAcks) {
+                batchAcks.add(entry);
+            }
+        } else {
+            acks = new ArrayList<>(entries);
+            for (MessageIdImpl id : messageIds) {
+                acks.add(id);
+            }
+            batchAcks = Collections.emptyList();
+        }
+        ByteBuf command = Commands.newMultiMessageAck(1, acks, batchAcks, -1);
+        try {
+            return command.readableBytes();
+        } finally {
+            command.release();
+        }
+    }
+}

--- a/microbench/src/main/java/org/apache/pulsar/client/impl/package-info.java
+++ b/microbench/src/main/java/org/apache/pulsar/client/impl/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/** Microbenchmarks for org.apache.pulsar.client.impl. */
+package org.apache.pulsar.client.impl;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java
@@ -42,7 +42,6 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Function;
 import lombok.CustomLog;
 import lombok.Getter;
-import org.apache.commons.lang3.tuple.Triple;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.MessageIdAdv;
 import org.apache.pulsar.client.api.PulsarClientException;
@@ -411,7 +410,7 @@ public class PersistentAcknowledgmentsGroupingTracker implements Acknowledgments
         }
 
         CompletableFuture<Void> completableFuture = newMessageAckCommandAndWrite(cnx, consumer.consumerId,
-                msgId.getLedgerId(), msgId.getEntryId(), bitSet, ackType, properties, true, null, null, null);
+                msgId.getLedgerId(), msgId.getEntryId(), bitSet, ackType, properties, true, null, null, null, null);
         bitSet.recycle();
         return completableFuture;
     }
@@ -446,13 +445,12 @@ public class PersistentAcknowledgmentsGroupingTracker implements Acknowledgments
             newMessageAckCommandAndWrite(cnx, consumer.consumerId, messageId.getLedgerId(), messageId.getEntryId(),
                     lastCumulativeAckToFlush.getBitSetRecyclable(), AckType.Cumulative,
                     Collections.emptyMap(), false,
-                    (TimedCompletableFuture<Void>) this.currentCumulativeAckFuture, null, null);
+                    (TimedCompletableFuture<Void>) this.currentCumulativeAckFuture, null, null, null);
             this.consumer.unAckedChunkedMessageIdSequenceMap.remove(messageId);
         }
 
         // Flush all individual acks
-        List<Triple<Long, Long, ConcurrentBitSet>> entriesToAck =
-                new ArrayList<>(pendingIndividualAcks.size() + pendingIndividualBatchIndexAcks.size());
+        List<MessageIdAdv> entriesToAck = new ArrayList<>(pendingIndividualAcks.size());
         List<MessageIdAdv> individualAcksToFlush = new ArrayList<>(pendingIndividualAcks.size());
         Map<MessageIdAdv, MessageIdImpl[]> chunkedMessageIdsToRestore = new HashMap<>();
         if (!pendingIndividualAcks.isEmpty()) {
@@ -472,13 +470,13 @@ public class PersistentAcknowledgmentsGroupingTracker implements Acknowledgments
                         chunkedMessageIdsToRestore.put(msgId, chunkMsgIds);
                         for (MessageIdImpl cMsgId : chunkMsgIds) {
                             if (cMsgId != null) {
-                                entriesToAck.add(Triple.of(cMsgId.getLedgerId(), cMsgId.getEntryId(), null));
+                                entriesToAck.add(cMsgId);
                             }
                         }
                         // messages will be acked so, remove checked message sequence
                         this.consumer.unAckedChunkedMessageIdSequenceMap.remove(msgId);
                     } else {
-                        entriesToAck.add(Triple.of(msgId.getLedgerId(), msgId.getEntryId(), null));
+                        entriesToAck.add(msgId);
                     }
                 }
             } else {
@@ -491,7 +489,7 @@ public class PersistentAcknowledgmentsGroupingTracker implements Acknowledgments
                     individualAcksToFlush.add(msgId);
                     newMessageAckCommandAndWrite(cnx, consumer.consumerId, msgId.getLedgerId(), msgId.getEntryId(),
                             null, AckType.Individual, Collections.emptyMap(), false,
-                            null, null, () -> restoreIndividualAck(msgId, null));
+                            null, null, null, () -> restoreIndividualAck(msgId, null));
                     shouldFlush = true;
                 }
             }
@@ -506,15 +504,13 @@ public class PersistentAcknowledgmentsGroupingTracker implements Acknowledgments
                 break;
             }
             batchIndexAcksToFlush.add(entry);
-            entriesToAck.add(Triple.of(
-                    entry.getKey().getLedgerId(), entry.getKey().getEntryId(), entry.getValue()));
         }
 
-        if (entriesToAck.size() > 0) {
+        if (!entriesToAck.isEmpty() || !batchIndexAcksToFlush.isEmpty()) {
 
             newMessageAckCommandAndWrite(cnx, consumer.consumerId, 0L, 0L,
                     null, AckType.Individual, null, true,
-                    (TimedCompletableFuture<Void>) currentIndividualAckFuture, entriesToAck,
+                    (TimedCompletableFuture<Void>) currentIndividualAckFuture, entriesToAck, batchIndexAcksToFlush,
                     () -> restoreIndividualAndBatchIndexAcks(individualAcksToFlush, chunkedMessageIdsToRestore,
                             batchIndexAcksToFlush));
             shouldFlush = true;
@@ -524,7 +520,7 @@ public class PersistentAcknowledgmentsGroupingTracker implements Acknowledgments
                 log.debug().attr("consumer", consumer)
                         .attr("lastCumulativeAck", lastCumulativeAck)
                         .attr("individualAcks", pendingIndividualAcks)
-                        .attr("individualBatchIndexAcks", entriesToAck)
+                        .attr("individualBatchIndexAcks", batchIndexAcksToFlush)
                         .log("Flushing pending acks to broker");
             cnx.ctx().flush();
         }
@@ -554,26 +550,26 @@ public class PersistentAcknowledgmentsGroupingTracker implements Acknowledgments
         // cumulative ack chunk by the last messageId
         if (chunkMsgIds != null &&  ackType != AckType.Cumulative) {
             if (Commands.peerSupportsMultiMessageAcknowledgment(cnx.getRemoteEndpointProtocolVersion())) {
-                List<Triple<Long, Long, ConcurrentBitSet>> entriesToAck = new ArrayList<>(chunkMsgIds.length);
+                List<MessageIdAdv> entriesToAck = new ArrayList<>(chunkMsgIds.length);
                 for (MessageIdImpl cMsgId : chunkMsgIds) {
                     if (cMsgId != null && chunkMsgIds.length > 1) {
-                        entriesToAck.add(Triple.of(cMsgId.getLedgerId(), cMsgId.getEntryId(), null));
+                        entriesToAck.add(cMsgId);
                     }
                 }
                 completableFuture = newMessageAckCommandAndWrite(cnx, consumer.consumerId, 0L, 0L,
-                        null, ackType, null, true, null, entriesToAck, null);
+                        null, ackType, null, true, null, entriesToAck, Collections.emptyList(), null);
             } else {
                 // if don't support multi message ack, it also support ack receipt, so we should not think about the
                 // ack receipt in this logic
                 for (MessageIdImpl cMsgId : chunkMsgIds) {
                     newMessageAckCommandAndWrite(cnx, consumerId, cMsgId.getLedgerId(), cMsgId.getEntryId(),
-                            bitSet, ackType, map, true, null, null, null);
+                            bitSet, ackType, map, true, null, null, null, null);
                 }
                 completableFuture = CompletableFuture.completedFuture(null);
             }
         } else {
             completableFuture = newMessageAckCommandAndWrite(cnx, consumerId, msgId.getLedgerId(), msgId.getEntryId(),
-                    bitSet, ackType, map, true, null, null, null);
+                    bitSet, ackType, map, true, null, null, null, null);
         }
         return completableFuture;
     }
@@ -583,7 +579,8 @@ public class PersistentAcknowledgmentsGroupingTracker implements Acknowledgments
             long entryId, BitSetRecyclable ackSet, AckType ackType,
             Map<String, Long> properties, boolean flush,
             TimedCompletableFuture<Void> timedCompletableFuture,
-            List<Triple<Long, Long, ConcurrentBitSet>> entriesToAck,
+            List<MessageIdAdv> entriesToAck,
+            List<Map.Entry<MessageIdAdv, ConcurrentBitSet>> batchIndexAcksToFlush,
             Runnable writeFailureCallback) {
         if (consumer.isAckReceiptEnabled()) {
             final long requestId = consumer.getClient().newRequestId();
@@ -592,7 +589,7 @@ public class PersistentAcknowledgmentsGroupingTracker implements Acknowledgments
                 cmd = Commands.newAck(consumerId, ledgerId, entryId, ackSet,
                         ackType, null, properties, requestId);
             } else {
-                cmd = Commands.newMultiMessageAck(consumerId, entriesToAck, requestId);
+                cmd = Commands.newMultiMessageAck(consumerId, entriesToAck, batchIndexAcksToFlush, requestId);
             }
             if (timedCompletableFuture == null) {
                 return cnx.newAckForReceipt(cmd, requestId);
@@ -623,7 +620,7 @@ public class PersistentAcknowledgmentsGroupingTracker implements Acknowledgments
                 cmd = Commands.newAck(consumerId, ledgerId, entryId, ackSet,
                         ackType, null, properties, -1);
             } else {
-                cmd = Commands.newMultiMessageAck(consumerId, entriesToAck, -1);
+                cmd = Commands.newMultiMessageAck(consumerId, entriesToAck, batchIndexAcksToFlush, -1);
             }
             if (flush) {
                 if (writeFailureCallback == null) {

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/AcknowledgementsGroupingTrackerTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/AcknowledgementsGroupingTrackerTest.java
@@ -48,6 +48,7 @@ import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
 import org.apache.pulsar.client.impl.metrics.InstrumentProvider;
 import org.apache.pulsar.client.util.TimedCompletableFuture;
+import org.apache.pulsar.common.api.proto.BaseCommand;
 import org.apache.pulsar.common.api.proto.CommandAck.AckType;
 import org.apache.pulsar.common.api.proto.ProtocolVersion;
 import org.testng.annotations.AfterClass;
@@ -357,6 +358,72 @@ public class AcknowledgementsGroupingTrackerTest {
         assertFalse(tracker.isDuplicate(msg1));
         assertEquals(tracker.getPendingIndividualAcksSize(), 0);
         tracker.close();
+    }
+
+    @Test
+    public void testMixedChunkAndBatchAcksRestoreAfterWriteFailure() {
+        ConsumerConfigurationData<?> conf = new ConsumerConfigurationData<>();
+        conf.setAcknowledgementsGroupTimeMicros(TimeUnit.SECONDS.toMicros(10));
+        boolean wasConnected = returnCnx.getAndSet(true);
+        boolean receiptEnabled = consumer.isAckReceiptEnabled();
+        int protocolVersion = cnx.getRemoteEndpointProtocolVersion();
+        doReturn(false).when(consumer).isAckReceiptEnabled();
+        doReturn(ProtocolVersion.v12_VALUE).when(cnx).getRemoteEndpointProtocolVersion();
+        PersistentAcknowledgmentsGroupingTracker tracker =
+                new PersistentAcknowledgmentsGroupingTracker(consumer, conf, eventLoopGroup);
+        MessageIdImpl individual = new MessageIdImpl(5, 1, 0);
+        MessageIdImpl firstChunk = new MessageIdImpl(5, 2, 0);
+        MessageIdImpl lastChunk = new MessageIdImpl(5, 3, 0);
+        ChunkMessageIdImpl chunked = new ChunkMessageIdImpl(firstChunk, lastChunk);
+        MessageIdImpl[] chunks = {firstChunk, null, lastChunk};
+        MessageIdImpl batchPosition = new MessageIdImpl(5, 4, 0);
+        List<BaseCommand> written = new ArrayList<>();
+        ChannelHandlerContext failed = createFailedChannelHandlerContext();
+        ChannelHandlerContext capturing = mock(ChannelHandlerContext.class);
+        doAnswer(invocation -> {
+            ByteBuf command = invocation.getArgument(0);
+            ByteBuf view = command.duplicate();
+            view.skipBytes(4);
+            int commandSize = view.readInt();
+            BaseCommand parsed = new BaseCommand();
+            parsed.parseFrom(view, commandSize);
+            parsed.materialize();
+            written.add(parsed);
+            return failed.writeAndFlush(command);
+        }).when(capturing).writeAndFlush(any());
+        try {
+            consumer.unAckedChunkedMessageIdSequenceMap.put(chunked, chunks);
+            tracker.addAcknowledgment(individual, AckType.Individual, Collections.emptyMap());
+            tracker.addAcknowledgment(chunked, AckType.Individual, Collections.emptyMap());
+            tracker.doIndividualBatchAckAsync(new BatchMessageIdImpl(5, 4, 0, 3, 10, null));
+            doReturn(capturing).when(cnx).ctx();
+            tracker.flush();
+
+            assertEquals(written.size(), 1);
+            var ack = written.get(0).getAck();
+            assertEquals(ack.getMessageIdsCount(), 4);
+            for (int i = 0; i < 4; i++) {
+                assertEquals(ack.getMessageIdAt(i).getLedgerId(), 5L);
+                assertEquals(ack.getMessageIdAt(i).getEntryId(), i + 1L);
+            }
+            assertEquals(ack.getMessageIdAt(3).getAckSetAt(0), 1015L);
+            assertEquals(tracker.getPendingIndividualAcksSize(), 2);
+            assertEquals(consumer.unAckedChunkedMessageIdSequenceMap.get(chunked), chunks);
+            assertFalse(tracker.pendingIndividualBatchIndexAcks.get(batchPosition).get(3));
+
+            doReturn(successCtx).when(cnx).ctx();
+            tracker.flush();
+            assertEquals(tracker.getPendingIndividualAcksSize(), 0);
+            assertFalse(consumer.unAckedChunkedMessageIdSequenceMap.containsKey(chunked));
+            assertTrue(tracker.pendingIndividualBatchIndexAcks.isEmpty());
+        } finally {
+            doReturn(successCtx).when(cnx).ctx();
+            tracker.close();
+            consumer.unAckedChunkedMessageIdSequenceMap.remove(chunked);
+            returnCnx.set(wasConnected);
+            doReturn(receiptEnabled).when(consumer).isAckReceiptEnabled();
+            doReturn(protocolVersion).when(cnx).getRemoteEndpointProtocolVersion();
+        }
     }
 
     @Test

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
@@ -47,6 +47,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Triple;
 import org.apache.pulsar.PulsarVersion;
 import org.apache.pulsar.client.api.KeySharedPolicy;
+import org.apache.pulsar.client.api.MessageIdAdv;
 import org.apache.pulsar.client.api.ProducerAccessMode;
 import org.apache.pulsar.client.api.Range;
 import org.apache.pulsar.client.api.transaction.TxnID;
@@ -1130,6 +1131,42 @@ public class Commands {
             if (requestId >= 0) {
                 cmd.getAck().setRequestId(requestId);
             }
+        return serializeWithSize(cmd);
+    }
+
+    /**
+     * Serialize existing message IDs without allocating a tuple and boxed coordinates for each acknowledgement.
+     * Individual IDs are written first, followed by batch-index IDs with their supplied acknowledgement masks.
+     * Both lists and the masks are read synchronously and are not retained by the returned command.
+     */
+    public static ByteBuf newMultiMessageAck(long consumerId,
+                                            List<? extends MessageIdAdv> individualAcks,
+                                            List<? extends Map.Entry<? extends MessageIdAdv, ConcurrentBitSet>>
+                                                    batchIndexAcks,
+                                            long requestId) {
+        BaseCommand cmd = localCmd(Type.ACK);
+        CommandAck ack = cmd.setAck()
+                .setConsumerId(consumerId)
+                .setAckType(AckType.Individual);
+        for (int i = 0; i < individualAcks.size(); i++) {
+            MessageIdAdv id = individualAcks.get(i);
+            ack.addMessageId().setLedgerId(id.getLedgerId()).setEntryId(id.getEntryId());
+        }
+        for (int i = 0; i < batchIndexAcks.size(); i++) {
+            Map.Entry<? extends MessageIdAdv, ConcurrentBitSet> entry = batchIndexAcks.get(i);
+            MessageIdAdv id = entry.getKey();
+            MessageIdData msgId = ack.addMessageId().setLedgerId(id.getLedgerId()).setEntryId(id.getEntryId());
+            ConcurrentBitSet bitSet = entry.getValue();
+            if (bitSet != null) {
+                long[] ackSet = bitSet.toLongArray();
+                for (int j = 0; j < ackSet.length; j++) {
+                    msgId.addAckSet(ackSet[j]);
+                }
+            }
+        }
+        if (requestId >= 0) {
+            ack.setRequestId(requestId);
+        }
         return serializeWithSize(cmd);
     }
 

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/protocol/CommandsAckSerializationTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/protocol/CommandsAckSerializationTest.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.protocol;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.lang3.tuple.Triple;
+import org.apache.pulsar.client.api.MessageIdAdv;
+import org.apache.pulsar.common.api.proto.BaseCommand;
+import org.apache.pulsar.common.api.proto.CommandAck;
+import org.apache.pulsar.common.api.proto.MessageIdData;
+import org.apache.pulsar.common.util.collections.ConcurrentBitSet;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class CommandsAckSerializationTest {
+    @DataProvider
+    public Object[][] ackGroups() {
+        List<Object[]> cases = new ArrayList<>();
+        for (int group = 0; group < 4; group++) {
+            for (long requestId : new long[]{-1, 0, Long.MAX_VALUE}) {
+                cases.add(new Object[]{group, requestId});
+            }
+        }
+        return cases.toArray(new Object[0][]);
+    }
+
+    @Test(dataProvider = "ackGroups")
+    public void existingIdsProduceIdenticalWireCommand(int group, long requestId) {
+        List<MessageIdAdv> individual = new ArrayList<>();
+        List<Map.Entry<MessageIdAdv, ConcurrentBitSet>> batch = new ArrayList<>();
+        if ((group & 1) != 0) {
+            individual.add(id(1L << 40, Long.MAX_VALUE));
+            individual.add(id(0, 0));
+        }
+        if ((group & 2) != 0) {
+            ConcurrentBitSet mask = new ConcurrentBitSet(192);
+            mask.set(0);
+            mask.set(65);
+            mask.set(191);
+            batch.add(new AbstractMap.SimpleImmutableEntry<>(id(1L << 41, 1L << 42), mask));
+            batch.add(new AbstractMap.SimpleImmutableEntry<>(id(3, 4), new ConcurrentBitSet()));
+            batch.add(new AbstractMap.SimpleImmutableEntry<>(id(5, 6), null));
+        }
+        List<Triple<Long, Long, ConcurrentBitSet>> legacy = new ArrayList<>();
+        for (MessageIdAdv id : individual) {
+            legacy.add(Triple.of(id.getLedgerId(), id.getEntryId(), null));
+        }
+        for (Map.Entry<MessageIdAdv, ConcurrentBitSet> entry : batch) {
+            legacy.add(Triple.of(entry.getKey().getLedgerId(), entry.getKey().getEntryId(), entry.getValue()));
+        }
+        ByteBuf expected = Commands.newMultiMessageAck(123, legacy, requestId);
+        ByteBuf actual = Commands.newMultiMessageAck(123, individual, batch, requestId);
+        try {
+            assertTrue(ByteBufUtil.equals(actual, expected), "The existing wire encoding must be preserved");
+            actual.skipBytes(4);
+            int size = actual.readInt();
+            BaseCommand parsed = new BaseCommand();
+            parsed.parseFrom(actual, size);
+            assertEquals(parsed.getType(), BaseCommand.Type.ACK);
+            CommandAck ack = parsed.getAck();
+            assertEquals(ack.getConsumerId(), 123L);
+            assertEquals(ack.getAckType(), CommandAck.AckType.Individual);
+            assertEquals(ack.hasRequestId(), requestId >= 0);
+            if (requestId >= 0) {
+                assertEquals(ack.getRequestId(), requestId);
+            }
+            assertEquals(ack.getMessageIdsCount(), legacy.size());
+            for (int i = 0; i < legacy.size(); i++) {
+                MessageIdData id = ack.getMessageIdAt(i);
+                Triple<Long, Long, ConcurrentBitSet> entry = legacy.get(i);
+                assertEquals(id.getLedgerId(), entry.getLeft().longValue());
+                assertEquals(id.getEntryId(), entry.getMiddle().longValue());
+                long[] words = entry.getRight() == null ? new long[0] : entry.getRight().toLongArray();
+                assertEquals(id.getAckSetsCount(), words.length);
+                for (int word = 0; word < words.length; word++) {
+                    assertEquals(id.getAckSetAt(word), words[word]);
+                }
+            }
+        } finally {
+            actual.release();
+            expected.release();
+        }
+    }
+
+    private static MessageIdAdv id(long ledgerId, long entryId) {
+        return new TestMessageId(ledgerId, entryId);
+    }
+
+    private record TestMessageId(long ledgerId, long entryId) implements MessageIdAdv {
+        @Override
+        public long getLedgerId() {
+            return ledgerId;
+        }
+
+        @Override
+        public long getEntryId() {
+            return entryId;
+        }
+
+        @Override
+        public byte[] toByteArray() {
+            throw new UnsupportedOperationException("Only the ID coordinates are used by command serialization");
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

Grouped acknowledgments create temporary triples and boxed ledger/entry IDs before serializing information already present in the message IDs and pending batch-index entries.

### Modifications

Add a Commands.newMultiMessageAck overload consuming existing individual IDs and batch-index map entries, and use it from grouped and chunked ACK paths. Preserve the existing overload, wire ordering, request IDs, receipt behavior and failed-write restoration. Read IDs and masks synchronously without retaining them in the command. Add byte-for-byte serialization equivalence and grouping/restoration tests plus a serialization benchmark.

### Verifying this change

Historical JMH saved approximately 88 B per acknowledged ID outside the boxed-Long cache. Matched profiling observed 9.3% lower consumer sampled allocation with flat CPU. No throughput gain is claimed, and these historical experimental results are not fresh measurements of this extraction. Validation includes mixed/empty/batch-index wire commands, receipt modes and chunked-message paths.

Local extraction validation passed: `spotlessCheck checkstyleMain checkstyleTest`, benchmark compilation, and 34 scoped tests with no failures or skips: org.apache.pulsar.client.impl.AcknowledgementsGroupingTrackerTest (17), org.apache.pulsar.client.impl.MessageChunkingTest (5), org.apache.pulsar.common.protocol.CommandsAckSerializationTest (12). Retries were disabled; Gradle ran with `--max-workers=2 --no-parallel`.

- [ ] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [x] The public API — adds a Commands serialization overload; the existing overload is preserved.
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
