### PR TITLE
[improve][ml] Avoid temporary positions when deleting cursor entries

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -2623,14 +2623,16 @@ public class ManagedCursorImpl implements ManagedCursor {
                     // make the RangeSet recognize the "continuity" between adjacent Positions.
                     // Before https://github.com/apache/pulsar/pull/21105 is merged, the range does not support crossing
                     // multi ledgers, so the first position's entryId maybe "-1".
-                    Position previousPosition;
-                    if (position.getEntryId() == 0) {
-                        previousPosition = PositionFactory.create(position.getLedgerId(), -1);
+                    long ledgerId = position.getLedgerId();
+                    long entryId = position.getEntryId();
+                    if (entryId >= 0) {
+                        // For entry zero, keep the lower bound in this ledger, as before.
+                        individualDeletedMessages.addOpenClosed(ledgerId, entryId - 1, ledgerId, entryId);
                     } else {
-                        previousPosition = ledger.getPreviousPosition(position);
+                        Position previousPosition = ledger.getPreviousPosition(position);
+                        individualDeletedMessages.addOpenClosed(previousPosition.getLedgerId(),
+                                previousPosition.getEntryId(), ledgerId, entryId);
                     }
-                    individualDeletedMessages.addOpenClosed(previousPosition.getLedgerId(),
-                        previousPosition.getEntryId(), position.getLedgerId(), position.getEntryId());
                     MSG_CONSUMED_COUNTER_UPDATER.incrementAndGet(this);
 
                     log.debug().attr("deletedMessages", individualDeletedMessages).log("Individually deleted messages");

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -1992,6 +1992,55 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
     }
 
     @Test(timeOut = 20000)
+    void testGroupedDeleteAcrossLedgerBoundaries() throws Exception {
+        ManagedLedger ledger = factory.open("grouped_delete_boundaries",
+                new ManagedLedgerConfig().setMaxEntriesPerLedger(3));
+        ManagedCursor cursor = ledger.openCursor("c1");
+        List<Position> positions = new ArrayList<>();
+        for (int i = 0; i < 9; i++) {
+            positions.add(ledger.addEntry(new byte[] {(byte) i}));
+        }
+        assertEquals(positions.get(3).getEntryId(), 0L);
+        assertEquals(positions.get(6).getEntryId(), 0L);
+        Position initialMarkDelete = cursor.getMarkDeletedPosition();
+        cursor.delete(initialMarkDelete);
+        cursor.delete(List.of(positions.get(3), positions.get(7), positions.get(1)));
+        assertEquals(cursor.getMarkDeletedPosition(), initialMarkDelete);
+        assertEquals(cursor.getNumberOfEntriesInBacklog(false), 6L);
+
+        cursor.delete(List.of(positions.get(8), positions.get(0), positions.get(2), positions.get(4),
+                positions.get(5), positions.get(6), positions.get(3)));
+        assertEquals(cursor.getMarkDeletedPosition(), positions.get(8));
+        assertEquals(cursor.getNumberOfEntriesInBacklog(false), 0L);
+        cursor.close();
+        cursor = ledger.openCursor("c1");
+        assertEquals(cursor.getMarkDeletedPosition(), positions.get(8));
+        assertEquals(cursor.getNumberOfEntriesInBacklog(false), 0L);
+    }
+
+    @Test(timeOut = 20000)
+    void testIndividualDeleteNegativeEntryAcrossLedgers() throws Exception {
+        ManagedLedger ledger = factory.open("delete_negative_entry",
+                new ManagedLedgerConfig().setMaxEntriesPerLedger(3));
+        ManagedCursor cursor = ledger.openCursor("c1");
+        List<Position> positions = new ArrayList<>();
+        for (int i = 0; i < 6; i++) {
+            positions.add(ledger.addEntry(new byte[] {(byte) i}));
+        }
+        assertEquals(positions.get(3).getEntryId(), 0L);
+        Position initialMarkDelete = cursor.getMarkDeletedPosition();
+        Position beforeSecondLedger = PositionFactory.create(positions.get(3).getLedgerId(), -1);
+        cursor.delete(beforeSecondLedger);
+        // A negative entry marker must not delete the real entries on either side of the boundary.
+        assertFalse(cursor.isMessageDeleted(positions.get(2)));
+        assertFalse(cursor.isMessageDeleted(positions.get(3)));
+        assertEquals(cursor.getMarkDeletedPosition(), initialMarkDelete);
+
+        cursor.close();
+        ledger.close();
+    }
+
+    @Test(timeOut = 20000)
     void testFilteringReadEntries() throws Exception {
         ManagedLedger ledger = factory.open("my_test_ledger", new ManagedLedgerConfig().setMaxEntriesPerLedger(3));
         ManagedCursor cursor = ledger.openCursor("c1");

--- a/microbench/src/main/java/org/apache/bookkeeper/mledger/impl/CursorDeleteRangeBenchmark.java
+++ b/microbench/src/main/java/org/apache/bookkeeper/mledger/impl/CursorDeleteRangeBenchmark.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.mledger.impl;
+
+import java.util.concurrent.TimeUnit;
+import org.apache.bookkeeper.mledger.Position;
+import org.apache.bookkeeper.mledger.PositionFactory;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Compares temporary-position versus primitive-bound assembly for the actual cursor range set.
+ * The isolated temporary position may be escape-eliminated; this does not reproduce the full asyncDelete JIT context.
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(2)
+public class CursorDeleteRangeBenchmark {
+    @Param({"1", "100", "1000"})
+    public int messageCount;
+
+    @Param({"false", "true"})
+    public boolean primitiveBounds;
+
+    private Position[] positions;
+    private PositionRangeSet ranges;
+
+    @Setup
+    public void setup() {
+        ranges = new PositionRangeSet(PositionFactory::create, false);
+        positions = new Position[messageCount];
+        for (int i = 0; i < messageCount; i++) {
+            positions[i] = PositionFactory.create(1, i);
+        }
+    }
+
+    @Benchmark
+    public int assembleRanges() {
+        ranges.clear();
+        for (Position position : positions) {
+            if (primitiveBounds) {
+                ranges.addOpenClosed(position.getLedgerId(), position.getEntryId() - 1,
+                        position.getLedgerId(), position.getEntryId());
+            } else {
+                Position previous = PositionFactory.create(position.getLedgerId(), position.getEntryId() - 1);
+                ranges.addOpenClosed(previous.getLedgerId(), previous.getEntryId(),
+                        position.getLedgerId(), position.getEntryId());
+            }
+        }
+        return ranges.size();
+    }
+}


### PR DESCRIPTION
### Motivation

Individual cursor deletion constructs a previous Position only to immediately read its ledger and entry IDs into the deletion range set. That range set already accepts primitive bounds. Avoiding the temporary object removes dependence on escape analysis in the larger asyncDelete method.

### Modifications

Pass (ledgerId, entryId - 1, ledgerId, entryId) directly to addOpenClosed for non-negative entry IDs. Entry zero keeps its existing same-ledger -1 lower bound; negative entry IDs retain getPreviousPosition and its cross-ledger fallback. Locking, batch-index processing, counters and acknowledgment persistence are unchanged.

Add regression coverage for grouped, out-of-order and duplicate deletes across ledger boundaries with cursor reopen, and for negative-entry deletion preserving real entries on both sides of a boundary. Include a JMH comparison using the actual PositionRangeSet.

### Verifying this change

Historical E009 profiling removed the temporary previous-position allocation site, which had accounted for about 1.124 GB in the preceding sampled broker profile. Aggregate broker allocation remained approximately flat, so this is not evidence of a general throughput or total-allocation improvement. The site varied substantially between otherwise related recordings, consistent with JIT/escape-analysis sensitivity.

The included JMH benchmark compares groups of 1, 100 and 1,000 positions. Historical runs (Corretto 25, ZGC, 1 GiB heap, two forks, three 1-second warmups, five 1-second measurements, GC profiler) showed no per-message allocation saving: escape analysis already eliminated the temporary object in that isolated benchmark. Fixed group-level differences were small and did not scale with the removed object. No new JMH or full profiling measurements were run for this extraction.

Scoped tests cover single/grouped/duplicate deletion, ledger boundaries, negative entry markers, batch-index and empty-ACK-set handling, persistence/reopen and mark-delete properties. The new negative-entry boundary checks were also exercised against unchanged upstream production code.

Local extraction validation passed: `spotlessCheck checkstyleMain checkstyleTest`, benchmark compilation, and 14 scoped tests with no failures or skips: org.apache.bookkeeper.mledger.impl.ManagedCursorTest (14). Retries were disabled; Gradle ran with `--max-workers=2 --no-parallel`.

- [ ] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
