### PR TITLE
[fix][broker] Stop reporting a deliberate ownership release as an expired resource lock

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/OwnershipCache.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/OwnershipCache.java
@@ -114,8 +114,19 @@ public class OwnershipCache {
                         OwnedBundle ownedBundle = new OwnedBundle(namespaceBundle, rl);
                         rl.getLockExpiredFuture()
                                 .thenRun(() -> {
-                                    log.info().attr("path", rl.getPath()).log("Resource lock has expired");
-                                    locallyAcquiredLocks.remove(namespaceBundle, rl);
+                                    // ResourceLockImpl completes the expiry future on a deliberate release()
+                                    // as well, and both removeOwnership overloads take the lock out of
+                                    // locallyAcquiredLocks before releasing it. So the lock is still registered
+                                    // here only when it died on its own — a lost metadata session or a failed
+                                    // revalidation — which is the case worth an INFO line. A deliberate release,
+                                    // or a stale listener whose generation has already been replaced, is routine
+                                    // and would otherwise report one false expiry per unload.
+                                    if (locallyAcquiredLocks.remove(namespaceBundle, rl)) {
+                                        log.info().attr("path", rl.getPath()).log("Resource lock has expired");
+                                    } else {
+                                        log.debug().attr("path", rl.getPath())
+                                                .log("Resource lock was released; running the expiry listener");
+                                    }
                                     // Only unload the generation this listener belongs to.
                                     // unloadNamespaceBundle resolves the owner by bundle name, so a listener
                                     // that runs late (the load already failed the publication check below and

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/OwnershipCacheTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/OwnershipCacheTest.java
@@ -55,6 +55,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import lombok.Cleanup;
 import org.apache.bookkeeper.common.util.OrderedScheduler;
+import org.apache.logging.log4j.Level;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.service.BrokerService;
@@ -71,6 +72,7 @@ import org.apache.pulsar.metadata.api.coordination.ResourceLock;
 import org.apache.pulsar.metadata.api.extended.CreateOption;
 import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
 import org.apache.pulsar.metadata.coordination.impl.CoordinationServiceImpl;
+import org.apache.pulsar.utils.TestLogAppender;
 import org.apache.pulsar.zookeeper.ZookeeperServerTest;
 import org.awaitility.Awaitility;
 import org.testng.annotations.AfterMethod;
@@ -935,6 +937,54 @@ public class OwnershipCacheTest {
         assertSame(cache.getLocallyAcquiredLocks().get(bundle), currentLock);
         assertTrue(store.exists(ServiceUnitUtils.path(bundle)).join());
         assertTrue(cache.checkOwnershipAsync(bundle).get());
+    }
+
+    private static boolean loggedLockExpiredAtInfo(TestLogAppender logAppender) {
+        return logAppender.getEvents().stream()
+                .anyMatch(event -> event.getLevel() == Level.INFO
+                        && event.getMessage().getFormattedMessage().contains("Resource lock has expired"));
+    }
+
+    @Test
+    public void testReleasingOwnershipDoesNotReportTheLockAsExpired() throws Exception {
+        @Cleanup
+        TestLogAppender logAppender = TestLogAppender.create(OwnershipCache.class);
+        OwnershipCache cache = new OwnershipCache(this.pulsar, nsService);
+        NamespaceBundle bundle = new NamespaceBundle(NamespaceName.get("pulsar/ns-release-not-expiry"),
+                Range.closedOpen(0L, (long) Integer.MAX_VALUE),
+                bundleFactory);
+
+        cache.tryAcquiringOwnership(bundle).get(10, TimeUnit.SECONDS);
+        logAppender.clearEvents();
+
+        // ResourceLockImpl.release() completes the lock's expiry future too, so the expiry listener also runs at
+        // the tail of every deliberate release. That is not an expiry and must not be reported as one: operators
+        // searching for lost metadata sessions would otherwise get one false hit per unload.
+        cache.removeOwnership(bundle).get(10, TimeUnit.SECONDS);
+
+        assertFalse(loggedLockExpiredAtInfo(logAppender),
+                "a deliberate ownership release reported the resource lock as expired");
+    }
+
+    @Test
+    public void testLockDyingOutsideOfReleaseIsReportedAsExpired() throws Exception {
+        @Cleanup
+        TestLogAppender logAppender = TestLogAppender.create(OwnershipCache.class);
+        OwnershipCache cache = new OwnershipCache(this.pulsar, nsService);
+        NamespaceBundle bundle = new NamespaceBundle(NamespaceName.get("pulsar/ns-real-expiry-logged"),
+                Range.closedOpen(0L, (long) Integer.MAX_VALUE),
+                bundleFactory);
+
+        cache.tryAcquiringOwnership(bundle).get(10, TimeUnit.SECONDS);
+        ResourceLock<NamespaceEphemeralData> lock = cache.getLocallyAcquiredLocks().get(bundle);
+        assertNotNull(lock);
+        logAppender.clearEvents();
+
+        // The lock dies without the cache asking for it, as on a metadata session loss or a failed revalidation
+        lock.release().join();
+
+        Awaitility.await().untilAsserted(() -> assertTrue(loggedLockExpiredAtInfo(logAppender),
+                "a resource lock that died on its own was not reported as expired"));
     }
 
 }


### PR DESCRIPTION
### Motivation

`ResourceLockImpl.release()` completes the lock's expiry future, so `OwnershipCache`'s lock-expiry
listener also runs at the tail of every deliberate release: every bundle unload, the split cleanup,
and shutdown. The listener logs `Resource lock has expired` at INFO unconditionally, so a routine
unload emits a line that reads like a lost metadata session. Operators get one false hit per unload,
which buries the cases that line is meant to surface — a lost session or a failed revalidation.

### Modifications

Both `removeOwnership` overloads take the lock out of `locallyAcquiredLocks` before calling
`release()`, so the lock is still registered when the listener runs only if it died on its own. The
INFO line is now gated on the two-arg `locallyAcquiredLocks.remove` returning true; a deliberate
release, or a stale listener whose generation has already been replaced, logs at DEBUG instead.
Nothing outside logging changes.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

  - *Added `OwnershipCacheTest.testReleasingOwnershipDoesNotReportTheLockAsExpired`: a normal
    `removeOwnership` must not produce an INFO `Resource lock has expired`. Fails before the change.*
  - *Added `OwnershipCacheTest.testLockDyingOutsideOfReleaseIsReportedAsExpired`: a lock that dies
    without going through `removeOwnership` is still reported at INFO, so the line cannot be dropped
    instead of gated.*
  - *Both use the existing `TestLogAppender`. `OwnershipCacheTest` (20), `NamespaceUnloadingTest`,
    `NamespaceOwnershipListenerTest` and the unload / split cases of `NamespaceServiceTest` pass
    locally; `./gradlew quickCheck` is clean.*

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
