### PR TITLE
[fix][test] Make consistent hashing consumer selection test deterministic

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsistentHashingStickyKeyConsumerSelectorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsistentHashingStickyKeyConsumerSelectorTest.java
@@ -32,7 +32,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.commons.lang3.mutable.MutableInt;
@@ -61,13 +60,14 @@ public class ConsistentHashingStickyKeyConsumerSelectorTest {
         when(consumer2.consumerName()).thenReturn("c2");
         selector.addConsumer(consumer2);
 
+        // Use repeatable keys so random sampling cannot make the distribution assertions flaky.
         final int num = 1000;
         final double percentError = 0.20; // 20 %
 
         Map<String, Integer> selectionMap = new HashMap<>();
         for (int i = 0; i < num; i++) {
-            String key = UUID.randomUUID().toString();
-            Consumer selectedConsumer = selector.select(key.getBytes());
+            String key = "key " + i;
+            Consumer selectedConsumer = selector.select(key.getBytes(StandardCharsets.UTF_8));
             int count = selectionMap.computeIfAbsent(selectedConsumer.consumerName(), c -> 0);
             selectionMap.put(selectedConsumer.consumerName(), count + 1);
         }
@@ -82,8 +82,8 @@ public class ConsistentHashingStickyKeyConsumerSelectorTest {
         selector.addConsumer(consumer3);
 
         for (int i = 0; i < num; i++) {
-            String key = UUID.randomUUID().toString();
-            Consumer selectedConsumer = selector.select(key.getBytes());
+            String key = "key " + i;
+            Consumer selectedConsumer = selector.select(key.getBytes(StandardCharsets.UTF_8));
             int count = selectionMap.computeIfAbsent(selectedConsumer.consumerName(), c -> 0);
             selectionMap.put(selectedConsumer.consumerName(), count + 1);
         }
@@ -98,8 +98,8 @@ public class ConsistentHashingStickyKeyConsumerSelectorTest {
         selector.addConsumer(consumer4);
 
         for (int i = 0; i < num; i++) {
-            String key = UUID.randomUUID().toString();
-            Consumer selectedConsumer = selector.select(key.getBytes());
+            String key = "key " + i;
+            Consumer selectedConsumer = selector.select(key.getBytes(StandardCharsets.UTF_8));
             int count = selectionMap.computeIfAbsent(selectedConsumer.consumerName(), c -> 0);
             selectionMap.put(selectedConsumer.consumerName(), count + 1);
         }
@@ -113,8 +113,8 @@ public class ConsistentHashingStickyKeyConsumerSelectorTest {
         selector.removeConsumer(consumer1);
 
         for (int i = 0; i < num; i++) {
-            String key = UUID.randomUUID().toString();
-            Consumer selectedConsumer = selector.select(key.getBytes());
+            String key = "key " + i;
+            Consumer selectedConsumer = selector.select(key.getBytes(StandardCharsets.UTF_8));
             int count = selectionMap.computeIfAbsent(selectedConsumer.consumerName(), c -> 0);
             selectionMap.put(selectedConsumer.consumerName(), count + 1);
         }
@@ -126,8 +126,8 @@ public class ConsistentHashingStickyKeyConsumerSelectorTest {
 
         selector.removeConsumer(consumer2);
         for (int i = 0; i < num; i++) {
-            String key = UUID.randomUUID().toString();
-            Consumer selectedConsumer = selector.select(key.getBytes());
+            String key = "key " + i;
+            Consumer selectedConsumer = selector.select(key.getBytes(StandardCharsets.UTF_8));
             int count = selectionMap.computeIfAbsent(selectedConsumer.consumerName(), c -> 0);
             selectionMap.put(selectedConsumer.consumerName(), count + 1);
         }
@@ -139,8 +139,8 @@ public class ConsistentHashingStickyKeyConsumerSelectorTest {
 
         selector.removeConsumer(consumer3);
         for (int i = 0; i < num; i++) {
-            String key = UUID.randomUUID().toString();
-            Consumer selectedConsumer = selector.select(key.getBytes());
+            String key = "key " + i;
+            Consumer selectedConsumer = selector.select(key.getBytes(StandardCharsets.UTF_8));
             int count = selectionMap.computeIfAbsent(selectedConsumer.consumerName(), c -> 0);
             selectionMap.put(selectedConsumer.consumerName(), count + 1);
         }


### PR DESCRIPTION
Fixes #22089

### Motivation

`ConsistentHashingStickyKeyConsumerSelectorTest.testConsumerSelect` generates fresh random UUID keys for each distribution check. Sampling variation can exceed the existing 20% tolerance even when the hash ring behaves correctly. In [this CI job](https://github.com/apache/pulsar/actions/runs/34488364250/job/102911156750?pr=26532), consumer `c1` received 198 keys instead of the permitted 200–300 when four consumers were present.

### Modifications

Use deterministic indexed keys encoded as UTF-8 in every distribution check, following the pattern already used by `testConsumersGetSufficientlyAccuratelyEvenlyMapped`. Preserve the 1,000-key sample size, all consumer additions and removals, and all existing assertions and tolerances.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is covered by `ConsistentHashingStickyKeyConsumerSelectorTest`. The full class passed locally with retries disabled: 21 invocations, including 10/10 repetitions of `testConsumerSelect` using temporary `invocationCount = 10`, removed after verification. `./gradlew quickCheck` also passed, including Spotless and Checkstyle checks.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
