### PR TITLE
[fix][test] Wait for compaction before reloading deleted topic policies

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicPoliciesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicPoliciesTest.java
@@ -4057,6 +4057,8 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         // Reload polices into memory.
         // Verify: policies was deleted.
         admin.topics().delete(tpName, false);
+        // Finish compacting the deletion events before a new reader checks for available messages.
+        triggerAndWaitNewTopicCompaction(tpNameChangeEvents);
         Awaitility.await().untilAsserted(() -> {
             // Reload polices into memory.
             // Verify: policies was affected.


### PR DESCRIPTION
### Motivation

In [this CI job](https://github.com/apache/pulsar/actions/runs/34479444987/job/102880537089?pr=26523), `TopicPoliciesTest.testTopicPoliciesAfterCompaction(Clean_Cache)` timed out reloading policies after deleting the topic. Its `afterMethodCleanup` then failed waiting for the same initialization to reach its 60-second timeout.

The test's deletion phase says to compact `__change_events` before reloading policies, but omits that step. The CI report shows compaction removing the remaining policy records concurrently with creation of the fresh system-topic reader. Checking message availability does not guarantee that the subsequent read will not block; reloading during this transition can leave initialization waiting for another event.

### Modifications

Call the existing `triggerAndWaitNewTopicCompaction` helper after topic deletion and before reloading policies, matching the first two phases of the test. This ensures the deletion phase verifies the policies after compaction, as intended. Both reload modes and all assertions are preserved.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is covered by `TopicPoliciesTest.testTopicPoliciesAfterCompaction` for both `Clean_Cache` and `Recreate_Service`. Both modes passed 10/10 repetitions locally with retries disabled (20 test invocations total). The temporary `invocationCount = 10` was removed after verification. `./gradlew quickCheck` passed. The unpatched test also passed 20 invocations locally; the original failure was observed in CI.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
