### PR TITLE
[fix][client] Cancel pending HTTP requests on authentication client shutdown

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/v5/FrameworkHttpClient.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/v5/FrameworkHttpClient.java
@@ -24,7 +24,9 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.CustomLog;
 import org.apache.pulsar.http.HttpRequest;
@@ -36,6 +38,8 @@ import org.asynchttpclient.AsyncCompletionHandlerBase;
 import org.asynchttpclient.AsyncHttpClient;
 import org.asynchttpclient.HttpResponseBodyPart;
 import org.asynchttpclient.HttpResponseStatus;
+import org.asynchttpclient.ListenableFuture;
+import org.asynchttpclient.Request;
 import org.asynchttpclient.RequestBuilder;
 import org.asynchttpclient.Response;
 
@@ -69,6 +73,7 @@ public final class FrameworkHttpClient implements PulsarHttpClient {
     // Deregisters this client from its factory on close(), or null for the legacy fallback (no factory).
     private final Runnable onClose;
     private final AtomicBoolean closed = new AtomicBoolean();
+    private final Set<ListenableFuture<Response>> pendingRequests = ConcurrentHashMap.newKeySet();
 
     public FrameworkHttpClient(AsyncHttpClient asyncHttpClient, PulsarHttpClientConfig config,
             NameResolver<InetAddress> nameResolver, TlsHandle<?> tlsSubscription, Runnable onClose) {
@@ -81,17 +86,25 @@ public final class FrameworkHttpClient implements PulsarHttpClient {
 
     @Override
     public CompletableFuture<HttpResponse> execute(HttpRequest request) {
-        // A CompletableFuture-returning method must not throw synchronously (CODING.md): convert any
-        // request-building error into an exceptionally-completed future.
-        final org.asynchttpclient.Request ahcRequest;
         try {
-            ahcRequest = toAhcRequest(request);
+            if (closed.get()) {
+                return CompletableFuture.failedFuture(new IOException("HTTP client is closed"));
+            }
+            ListenableFuture<Response> pending =
+                    asyncHttpClient.executeRequest(toAhcRequest(request), new BoundedResponseHandler());
+            pendingRequests.add(pending);
+            CompletableFuture<Response> response = pending.toCompletableFuture();
+            response.whenComplete((__, error) -> pendingRequests.remove(pending));
+            // close() may have run between submission and registration. In that case this request
+            // may have been missed by close() and must be cancelled here.
+            if (closed.get()) {
+                pending.cancel(true);
+            }
+            return response.thenCompose(this::toHttpResponse);
         } catch (Throwable t) {
+            // Request construction and submission can both fail synchronously.
             return CompletableFuture.failedFuture(t);
         }
-        return asyncHttpClient.executeRequest(ahcRequest, new BoundedResponseHandler())
-                .toCompletableFuture()
-                .thenCompose(this::toHttpResponse);
     }
 
     /**
@@ -122,7 +135,7 @@ public final class FrameworkHttpClient implements PulsarHttpClient {
         }
     }
 
-    private org.asynchttpclient.Request toAhcRequest(HttpRequest request) {
+    private Request toAhcRequest(HttpRequest request) {
         RequestBuilder builder = new RequestBuilder(request.method().name())
                 .setUrl(request.uri().toString());
         if (nameResolver != null) {
@@ -164,6 +177,10 @@ public final class FrameworkHttpClient implements PulsarHttpClient {
         if (!closed.compareAndSet(false, true)) {
             return;
         }
+        // AsyncHttpClient.close() closes channels but can leave their request futures pending.
+        // Cancel explicitly before the owning client stops the shared event loop and timeout timer.
+        pendingRequests.forEach(pending -> pending.cancel(true));
+        pendingRequests.clear();
         if (onClose != null) {
             try {
                 onClose.run();

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/v5/FrameworkHttpClientFactoryTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/v5/FrameworkHttpClientFactoryTest.java
@@ -20,6 +20,9 @@ package org.apache.pulsar.client.impl.auth.v5;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpServer;
 import io.netty.channel.EventLoopGroup;
@@ -32,6 +35,8 @@ import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
@@ -40,6 +45,11 @@ import org.apache.pulsar.http.HttpResponse;
 import org.apache.pulsar.http.PulsarHttpClient;
 import org.apache.pulsar.http.PulsarHttpClientConfig;
 import org.apache.pulsar.tls.TlsPurpose;
+import org.asynchttpclient.AsyncHandler;
+import org.asynchttpclient.AsyncHttpClient;
+import org.asynchttpclient.DefaultAsyncHttpClient;
+import org.asynchttpclient.DefaultAsyncHttpClientConfig;
+import org.asynchttpclient.Request;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -228,6 +238,58 @@ public class FrameworkHttpClientFactoryTest {
                     .hasCauseInstanceOf(IOException.class)
                     .cause().hasMessageContaining("exceeds the configured maximum");
             client.close();
+        }
+    }
+
+    @Test
+    public void testFactoryCloseCompletesPendingRequest() throws Exception {
+        CompletableFuture<Void> requestReceived = new CompletableFuture<>();
+        // Leave the response pending until the client closes the connection.
+        server.createContext("/pending", exchange -> requestReceived.complete(null));
+        try (FrameworkHttpClientFactory factory = newFactory()) {
+            PulsarHttpClient client = factory.newHttpClient(genericConfig().build());
+            HttpRequest request = HttpRequest.builder(
+                    HttpRequest.Method.GET, URI.create(baseUrl + "/pending")).build();
+            CompletableFuture<HttpResponse> response = client.execute(request);
+            requestReceived.get(10, TimeUnit.SECONDS);
+            factory.close();
+            // The owning PulsarClient stops the shared timer after closing the factory.
+            timer.stop();
+            assertThatThrownBy(() -> response.get(5, TimeUnit.SECONDS))
+                    .isInstanceOf(ExecutionException.class)
+                    .hasCauseInstanceOf(CancellationException.class);
+        }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testCloseWhileRequestIsBeingSubmitted() throws Exception {
+        CompletableFuture<Void> requestReceived = new CompletableFuture<>();
+        CompletableFuture<Void> releaseSubmission = new CompletableFuture<>();
+        server.createContext("/pending", exchange -> requestReceived.complete(null));
+        AsyncHttpClient transport = spy(new DefaultAsyncHttpClient(new DefaultAsyncHttpClientConfig.Builder()
+                .setEventLoopGroup(eventLoopGroup).setNettyTimer(timer).build()));
+        try (FrameworkHttpClient client = new FrameworkHttpClient(
+                transport, genericConfig().build(), null, null, null)) {
+            doAnswer(invocation -> {
+                Object pending = invocation.callRealMethod();
+                releaseSubmission.get(10, TimeUnit.SECONDS);
+                return pending;
+            }).when(transport).executeRequest(any(Request.class), any(AsyncHandler.class));
+            HttpRequest request = HttpRequest.builder(
+                    HttpRequest.Method.GET, URI.create(baseUrl + "/pending")).build();
+            CompletableFuture<HttpResponse> response = CompletableFuture
+                    .supplyAsync(() -> client.execute(request)).thenCompose(future -> future);
+            try {
+                requestReceived.get(10, TimeUnit.SECONDS);
+                // The transport has accepted the request, but execute() has not registered its future yet.
+                client.close();
+            } finally {
+                releaseSubmission.complete(null);
+            }
+            assertThatThrownBy(() -> response.get(5, TimeUnit.SECONDS))
+                    .isInstanceOf(ExecutionException.class)
+                    .hasCauseInstanceOf(CancellationException.class);
         }
     }
 


### PR DESCRIPTION
### Motivation

Closing a Pulsar client during an OAuth2 token exchange can hang indefinitely. The framework HTTP client closes AsyncHttpClient, but pending request futures can remain incomplete. Once shutdown stops the shared timer, the request timeout cannot release the token-fetch thread. That thread holds the authentication monitor, so `AuthenticationOAuth2.close()` cannot acquire it.

[This CI job](https://github.com/apache/pulsar/actions/runs/34458811489/job/102814620807?pr=26311) reached its one-hour limit in `TokenOauth2AuthenticatedProducerConsumerTest.cleanup`. The thread dump shows cleanup waiting for the authentication monitor while a token-fetch thread holds it in `TokenClient.exchangeClientCredentials`, waiting on a request future.

### Modifications

Track outstanding AsyncHttpClient request futures in `FrameworkHttpClient` and explicitly cancel them before closing the transport. Remove completed requests from tracking. Recheck the closed flag after registration so a request submitted concurrently with shutdown is also cancelled. Reject requests after closure through failed futures and propagate synchronous submission errors through the returned future.

Add regressions for closing a factory with a pending response and closing a client between transport submission and request registration. Both use a real HTTP transport and server; the submission-race test pauses the transport return to control the interleaving.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

The pending-response regression failed before the fix with `TimeoutException`, reproducing the unresolved request future. After the fix, validation passed with retries disabled:

- `FrameworkHttpClientFactoryTest`: 27 invocations, including 10/10 repetitions of each new regression.
- `StandaloneOAuth2HttpClientFactoryTest`: 3 tests.
- `TokenClientTest`: 4 tests.
- `TokenOauth2AuthenticatedProducerConsumerTest`: 2 tests, including cleanup.
- `./gradlew quickCheck` passed.

Temporary `invocationCount = 10` settings were removed after verification.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
