### PR TITLE
[improve][build] Upgrade Oxia Java client to 0.9.5

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -489,8 +489,8 @@ The Apache Software License, Version 2.0
   * Prometheus
     - io.prometheus-simpleclient_httpserver-0.16.0.jar
   * Oxia
-    - io.github.oxia-db-oxia-client-api-0.9.4.jar
-    - io.github.oxia-db-oxia-client-0.9.4.jar
+    - io.github.oxia-db-oxia-client-api-0.9.5.jar
+    - io.github.oxia-db-oxia-client-0.9.5.jar
   * OpenHFT
     - net.openhft-zero-allocation-hashing-0.16.jar
   * Java JSON WebTokens

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -169,7 +169,7 @@ javax-servlet = "4.0.1"
 jakarta-servlet = "6.0.0"
 felix-http-wrappers = "1.1.10"
 # Oxia / etcd
-oxia = "0.9.4"
+oxia = "0.9.5"
 oxia-testcontainers = "0.7.4"
 # Build plugins
 lightproto = "0.8.1"


### PR DESCRIPTION
### Motivation

Adopt the connection reliability and subscription recovery fixes in [Oxia Java Client 0.9.5](https://github.com/oxia-db/oxia-client-java/releases/tag/v0.9.5), including bounded stream establishment and renewal of long-lived subscriptions. The release also restores compatibility with the legacy token authentication class name.

### Modifications

Upgrade the Oxia Java client from 0.9.4 to 0.9.5 in the Gradle version catalog and update the client and client API JAR versions in the server distribution license inventory.

### Verifying this change

This change is covered by the existing `OxiaMetadataStoreErrorTest`, `OxiaPartitionKeyTest`, and `OxiaSequenceKeysTest` tests.

Validation:

- `./gradlew spotlessCheck checkstyleMain checkstyleTest checkBinaryLicense :pulsar-metadata:test --tests 'org.apache.pulsar.metadata.Oxia*'`

### Does this pull request potentially affect one of the following parts:

- [x] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
