### PR TITLE
[improve][broker] Conflate concurrent readMoreEntries calls

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/AbstractPersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/AbstractPersistentDispatcherMultipleConsumers.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.broker.service.persistent;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedCursor;
@@ -32,6 +33,11 @@ import org.apache.pulsar.common.policies.data.stats.TopicMetricBean;
 
 public abstract class AbstractPersistentDispatcherMultipleConsumers extends AbstractDispatcherMultipleConsumers
         implements Dispatcher, AsyncCallbacks.ReadEntriesCallback {
+    private static final int IDLE = 0;
+    private static final int RUNNING = 1;
+    private static final int RUNNING_REQUESTED = 2;
+    private final AtomicInteger readMoreEntriesState = new AtomicInteger(IDLE);
+
     public AbstractPersistentDispatcherMultipleConsumers(Subscription subscription,
                                                          ServiceConfiguration serviceConfig) {
         super(subscription, serviceConfig);
@@ -40,6 +46,46 @@ public abstract class AbstractPersistentDispatcherMultipleConsumers extends Abst
     public abstract void unBlockDispatcherOnUnackedMsgs();
 
     public abstract void readMoreEntriesAsync();
+
+    /**
+     * Conflate concurrent and reentrant requests into follow-up passes driven by the owning caller.
+     */
+    public final void readMoreEntries() {
+        for (;;) {
+            int state = readMoreEntriesState.get();
+            if (state == IDLE) {
+                if (readMoreEntriesState.compareAndSet(IDLE, RUNNING)) {
+                    break;
+                }
+            } else if (state == RUNNING) {
+                if (readMoreEntriesState.compareAndSet(RUNNING, RUNNING_REQUESTED)) {
+                    return;
+                }
+            } else {
+                // A follow-up pass is already requested.
+                return;
+            }
+        }
+        try {
+            for (;;) {
+                // Requests received before this pass are covered by this pass.
+                readMoreEntriesState.set(RUNNING);
+                internalReadMoreEntries();
+                if (readMoreEntriesState.compareAndSet(RUNNING, IDLE)) {
+                    return;
+                }
+                // A request arrived during the pass. Run another pass without recursion.
+            }
+        } catch (Throwable t) {
+            readMoreEntriesState.set(IDLE);
+            throw t;
+        }
+    }
+
+    /**
+     * Execute one read pass. Implementations must synchronize on this dispatcher to protect read state.
+     */
+    protected abstract void internalReadMoreEntries();
 
     public abstract String getName();
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/AbstractPersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/AbstractPersistentDispatcherMultipleConsumers.java
@@ -49,6 +49,7 @@ public abstract class AbstractPersistentDispatcherMultipleConsumers extends Abst
 
     /**
      * Conflate concurrent and reentrant requests into follow-up passes driven by the owning caller.
+     * If a pass fails, drain registered follow-ups before propagating the first failure to the owner.
      */
     public final void readMoreEntries() {
         for (;;) {
@@ -66,19 +67,29 @@ public abstract class AbstractPersistentDispatcherMultipleConsumers extends Abst
                 return;
             }
         }
-        try {
-            for (;;) {
-                // Requests received before this pass are covered by this pass.
-                readMoreEntriesState.set(RUNNING);
+        Throwable failure = null;
+        for (;;) {
+            // Requests received before this pass are covered by this pass.
+            readMoreEntriesState.set(RUNNING);
+            try {
                 internalReadMoreEntries();
-                if (readMoreEntriesState.compareAndSet(RUNNING, IDLE)) {
-                    return;
+            } catch (RuntimeException | Error t) {
+                // Keep ownership so a failure cannot discard an already-registered follow-up.
+                if (failure == null) {
+                    failure = t;
+                } else if (failure != t) {
+                    failure.addSuppressed(t);
                 }
-                // A request arrived during the pass. Run another pass without recursion.
             }
-        } catch (Throwable t) {
-            readMoreEntriesState.set(IDLE);
-            throw t;
+            if (readMoreEntriesState.compareAndSet(RUNNING, IDLE)) {
+                break;
+            }
+            // A request arrived during the pass. Run another pass without recursion, even after a failure.
+        }
+        if (failure instanceof RuntimeException runtimeException) {
+            throw runtimeException;
+        } else if (failure instanceof Error error) {
+            throw error;
         }
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -135,6 +135,10 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
     protected Optional<DispatchRateLimiter> dispatchRateLimiter = Optional.empty();
     private AtomicBoolean isRescheduleReadInProgress = new AtomicBoolean(false);
     private final AtomicBoolean readMoreEntriesAsyncRequested = new AtomicBoolean(false);
+    private static final int IDLE = 0;
+    private static final int RUNNING = 1;
+    private static final int RUNNING_REQUESTED = 2;
+    private final AtomicInteger readMoreEntriesState = new AtomicInteger(IDLE);
     protected final ExecutorService dispatchMessagesThread;
     private final SharedConsumerAssignor assignor;
     // tracks how many entries were processed by consumers in the last trySendMessagesToConsumers call
@@ -358,7 +362,39 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
         }
     }
 
-    public synchronized void readMoreEntries() {
+    public void readMoreEntries() {
+        for (;;) {
+            int state = readMoreEntriesState.get();
+            if (state == IDLE) {
+                if (readMoreEntriesState.compareAndSet(IDLE, RUNNING)) {
+                    break;
+                }
+            } else if (state == RUNNING) {
+                if (readMoreEntriesState.compareAndSet(RUNNING, RUNNING_REQUESTED)) {
+                    return;
+                }
+            } else {
+                // A follow-up pass is already requested.
+                return;
+            }
+        }
+        try {
+            for (;;) {
+                // Requests received before this pass are covered by this pass.
+                readMoreEntriesState.set(RUNNING);
+                internalReadMoreEntries();
+                if (readMoreEntriesState.compareAndSet(RUNNING, IDLE)) {
+                    return;
+                }
+                // A request arrived during the pass. Run another pass without recursion.
+            }
+        } catch (Throwable t) {
+            readMoreEntriesState.set(IDLE);
+            throw t;
+        }
+    }
+
+    private synchronized void internalReadMoreEntries() {
         if (cursor.isClosed()) {
             log.debug("Cursor is already closed, skipping read more entries");
             return;
@@ -378,7 +414,7 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
             return;
         }
 
-        // increment the counter for readMoreEntries calls, to track the number of times readMoreEntries is called
+        // Count executed passes, not conflated requests, for pending-read rescheduling.
         readMoreEntriesCallCount++;
 
         // totalAvailablePermits may be updated by other threads

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -135,10 +135,6 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
     protected Optional<DispatchRateLimiter> dispatchRateLimiter = Optional.empty();
     private AtomicBoolean isRescheduleReadInProgress = new AtomicBoolean(false);
     private final AtomicBoolean readMoreEntriesAsyncRequested = new AtomicBoolean(false);
-    private static final int IDLE = 0;
-    private static final int RUNNING = 1;
-    private static final int RUNNING_REQUESTED = 2;
-    private final AtomicInteger readMoreEntriesState = new AtomicInteger(IDLE);
     protected final ExecutorService dispatchMessagesThread;
     private final SharedConsumerAssignor assignor;
     // tracks how many entries were processed by consumers in the last trySendMessagesToConsumers call
@@ -362,39 +358,8 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
         }
     }
 
-    public void readMoreEntries() {
-        for (;;) {
-            int state = readMoreEntriesState.get();
-            if (state == IDLE) {
-                if (readMoreEntriesState.compareAndSet(IDLE, RUNNING)) {
-                    break;
-                }
-            } else if (state == RUNNING) {
-                if (readMoreEntriesState.compareAndSet(RUNNING, RUNNING_REQUESTED)) {
-                    return;
-                }
-            } else {
-                // A follow-up pass is already requested.
-                return;
-            }
-        }
-        try {
-            for (;;) {
-                // Requests received before this pass are covered by this pass.
-                readMoreEntriesState.set(RUNNING);
-                internalReadMoreEntries();
-                if (readMoreEntriesState.compareAndSet(RUNNING, IDLE)) {
-                    return;
-                }
-                // A request arrived during the pass. Run another pass without recursion.
-            }
-        } catch (Throwable t) {
-            readMoreEntriesState.set(IDLE);
-            throw t;
-        }
-    }
-
-    private synchronized void internalReadMoreEntries() {
+    @Override
+    protected synchronized void internalReadMoreEntries() {
         if (cursor.isClosed()) {
             log.debug("Cursor is already closed, skipping read more entries");
             return;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumersClassic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumersClassic.java
@@ -329,7 +329,8 @@ public class PersistentDispatcherMultipleConsumersClassic extends AbstractPersis
         topic.getBrokerService().executor().execute(this::readMoreEntries);
     }
 
-    public synchronized void readMoreEntries() {
+    @Override
+    protected synchronized void internalReadMoreEntries() {
         if (cursor.isClosed()) {
             log.debug("Cursor is already closed, skipping read more entries");
             return;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumersTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumersTest.java
@@ -18,11 +18,14 @@
  */
 package org.apache.pulsar.broker.service.persistent;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.carrotsearch.hppc.ObjectSet;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -48,6 +51,101 @@ import org.testng.annotations.Test;
 @CustomLog
 @Test(groups = "broker-api")
 public class PersistentDispatcherMultipleConsumersTest extends SharedPulsarBaseTest {
+
+    @Test(timeOut = 30_000)
+    public void testReadMoreEntriesConflatesConcurrentRequests() throws Exception {
+        ManagedCursor cursor = Mockito.mock(ManagedCursor.class);
+        PersistentDispatcherMultipleConsumers dispatcher = createReadConflationDispatcher(cursor);
+        CountDownLatch[] passStarted = {new CountDownLatch(1), new CountDownLatch(1)};
+        CountDownLatch[] releasePass = {new CountDownLatch(1), new CountDownLatch(1)};
+        AtomicInteger passes = new AtomicInteger();
+        Mockito.doAnswer(inv -> {
+            int pass = passes.getAndIncrement();
+            if (pass < passStarted.length) {
+                passStarted[pass].countDown();
+                assertThat(releasePass[pass].await(10, TimeUnit.SECONDS)).isTrue();
+            }
+            return true;
+        }).when(cursor).isClosed();
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            Future<?> owner = executor.submit(dispatcher::readMoreEntries);
+            for (int pass = 0; pass < passStarted.length; pass++) {
+                assertThat(passStarted[pass].await(10, TimeUnit.SECONDS)).isTrue();
+                // All callers must return while the owner still holds the dispatcher monitor.
+                executor.submit(() -> {
+                    for (int request = 0; request < 100; request++) {
+                        dispatcher.readMoreEntries();
+                    }
+                }).get(10, TimeUnit.SECONDS);
+                assertThat(passes.get()).isEqualTo(pass + 1);
+                releasePass[pass].countDown();
+            }
+            owner.get(10, TimeUnit.SECONDS);
+            assertThat(passes.get()).isEqualTo(3);
+            dispatcher.readMoreEntries();
+            assertThat(passes.get()).isEqualTo(4);
+        } finally {
+            for (CountDownLatch latch : releasePass) {
+                latch.countDown();
+            }
+            executor.shutdownNow();
+            assertThat(executor.awaitTermination(10, TimeUnit.SECONDS)).isTrue();
+        }
+    }
+
+    @Test(timeOut = 30_000)
+    public void testReadMoreEntriesConflatesReentrantRequests() throws Exception {
+        ManagedCursor cursor = Mockito.mock(ManagedCursor.class);
+        PersistentDispatcherMultipleConsumers dispatcher = createReadConflationDispatcher(cursor);
+        AtomicInteger passes = new AtomicInteger();
+        AtomicInteger depth = new AtomicInteger();
+        Mockito.doAnswer(inv -> {
+            assertThat(depth.incrementAndGet()).isEqualTo(1);
+            try {
+                if (passes.incrementAndGet() < 1000) {
+                    dispatcher.readMoreEntries();
+                    dispatcher.readMoreEntries();
+                }
+                return true;
+            } finally {
+                depth.decrementAndGet();
+            }
+        }).when(cursor).isClosed();
+
+        dispatcher.readMoreEntries();
+        assertThat(passes.get()).isEqualTo(1000);
+    }
+
+    @Test(timeOut = 30_000)
+    public void testReadMoreEntriesRecoversAfterFailure() throws Exception {
+        ManagedCursor cursor = Mockito.mock(ManagedCursor.class);
+        PersistentDispatcherMultipleConsumers dispatcher = createReadConflationDispatcher(cursor);
+        IllegalStateException failure = new IllegalStateException("read failed");
+        Mockito.doAnswer(inv -> {
+            dispatcher.readMoreEntries();
+            throw failure;
+        }).when(cursor).isClosed();
+        assertThatThrownBy(dispatcher::readMoreEntries).isSameAs(failure);
+
+        Mockito.doReturn(true).when(cursor).isClosed();
+        Mockito.clearInvocations(cursor);
+        dispatcher.readMoreEntries();
+        Mockito.verify(cursor).isClosed();
+    }
+
+    private PersistentDispatcherMultipleConsumers createReadConflationDispatcher(ManagedCursor cursor)
+            throws Exception {
+        String topicName = newTopicName();
+        admin.topics().createNonPartitionedTopic(topicName);
+        admin.topics().createSubscription(topicName, "s1", MessageId.earliest);
+        PersistentTopic topic = (PersistentTopic) getTopic(topicName, false).join().orElseThrow();
+        Mockito.doReturn("s1").when(cursor).getName();
+        Subscription subscription = Mockito.mock(PersistentSubscription.class);
+        Mockito.doReturn(topic).when(subscription).getTopic();
+        return new PersistentDispatcherMultipleConsumers(topic, cursor, subscription);
+    }
 
     @Test(timeOut = 30 * 1000)
     public void testTopicDeleteIfConsumerSetMismatchConsumerList() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumersTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumersTest.java
@@ -46,20 +46,22 @@ import org.apache.pulsar.common.api.proto.MessageMetadata;
 import org.awaitility.reflect.WhiteboxImpl;
 import org.mockito.Mockito;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 @CustomLog
 @Test(groups = "broker-api")
 public class PersistentDispatcherMultipleConsumersTest extends SharedPulsarBaseTest {
 
-    @Test(timeOut = 30_000)
-    public void testReadMoreEntriesConflatesConcurrentRequests() throws Exception {
+    @Test(timeOut = 30_000, dataProvider = "readConflationDispatcherTypes")
+    public void testReadMoreEntriesConflatesConcurrentRequests(boolean classic) throws Exception {
         ManagedCursor cursor = Mockito.mock(ManagedCursor.class);
-        PersistentDispatcherMultipleConsumers dispatcher = createReadConflationDispatcher(cursor);
+        AbstractPersistentDispatcherMultipleConsumers dispatcher = createReadConflationDispatcher(cursor, classic);
         CountDownLatch[] passStarted = {new CountDownLatch(1), new CountDownLatch(1)};
         CountDownLatch[] releasePass = {new CountDownLatch(1), new CountDownLatch(1)};
         AtomicInteger passes = new AtomicInteger();
         Mockito.doAnswer(inv -> {
+            assertThat(Thread.holdsLock(dispatcher)).isTrue();
             int pass = passes.getAndIncrement();
             if (pass < passStarted.length) {
                 passStarted[pass].countDown();
@@ -95,10 +97,10 @@ public class PersistentDispatcherMultipleConsumersTest extends SharedPulsarBaseT
         }
     }
 
-    @Test(timeOut = 30_000)
-    public void testReadMoreEntriesConflatesReentrantRequests() throws Exception {
+    @Test(timeOut = 30_000, dataProvider = "readConflationDispatcherTypes")
+    public void testReadMoreEntriesConflatesReentrantRequests(boolean classic) throws Exception {
         ManagedCursor cursor = Mockito.mock(ManagedCursor.class);
-        PersistentDispatcherMultipleConsumers dispatcher = createReadConflationDispatcher(cursor);
+        AbstractPersistentDispatcherMultipleConsumers dispatcher = createReadConflationDispatcher(cursor, classic);
         AtomicInteger passes = new AtomicInteger();
         AtomicInteger depth = new AtomicInteger();
         Mockito.doAnswer(inv -> {
@@ -118,10 +120,10 @@ public class PersistentDispatcherMultipleConsumersTest extends SharedPulsarBaseT
         assertThat(passes.get()).isEqualTo(1000);
     }
 
-    @Test(timeOut = 30_000)
-    public void testReadMoreEntriesRecoversAfterFailure() throws Exception {
+    @Test(timeOut = 30_000, dataProvider = "readConflationDispatcherTypes")
+    public void testReadMoreEntriesRecoversAfterFailure(boolean classic) throws Exception {
         ManagedCursor cursor = Mockito.mock(ManagedCursor.class);
-        PersistentDispatcherMultipleConsumers dispatcher = createReadConflationDispatcher(cursor);
+        AbstractPersistentDispatcherMultipleConsumers dispatcher = createReadConflationDispatcher(cursor, classic);
         IllegalStateException failure = new IllegalStateException("read failed");
         Mockito.doAnswer(inv -> {
             dispatcher.readMoreEntries();
@@ -135,7 +137,13 @@ public class PersistentDispatcherMultipleConsumersTest extends SharedPulsarBaseT
         Mockito.verify(cursor).isClosed();
     }
 
-    private PersistentDispatcherMultipleConsumers createReadConflationDispatcher(ManagedCursor cursor)
+    @DataProvider
+    public Object[][] readConflationDispatcherTypes() {
+        return new Object[][] {{false}, {true}};
+    }
+
+    private AbstractPersistentDispatcherMultipleConsumers createReadConflationDispatcher(ManagedCursor cursor,
+                                                                                       boolean classic)
             throws Exception {
         String topicName = newTopicName();
         admin.topics().createNonPartitionedTopic(topicName);
@@ -144,7 +152,8 @@ public class PersistentDispatcherMultipleConsumersTest extends SharedPulsarBaseT
         Mockito.doReturn("s1").when(cursor).getName();
         Subscription subscription = Mockito.mock(PersistentSubscription.class);
         Mockito.doReturn(topic).when(subscription).getTopic();
-        return new PersistentDispatcherMultipleConsumers(topic, cursor, subscription);
+        return classic ? new PersistentDispatcherMultipleConsumersClassic(topic, cursor, subscription)
+                : new PersistentDispatcherMultipleConsumers(topic, cursor, subscription);
     }
 
     @Test(timeOut = 30 * 1000)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumersTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumersTest.java
@@ -125,16 +125,71 @@ public class PersistentDispatcherMultipleConsumersTest extends SharedPulsarBaseT
         ManagedCursor cursor = Mockito.mock(ManagedCursor.class);
         AbstractPersistentDispatcherMultipleConsumers dispatcher = createReadConflationDispatcher(cursor, classic);
         IllegalStateException failure = new IllegalStateException("read failed");
-        Mockito.doAnswer(inv -> {
-            dispatcher.readMoreEntries();
-            throw failure;
-        }).when(cursor).isClosed();
+        Mockito.doThrow(failure).when(cursor).isClosed();
         assertThatThrownBy(dispatcher::readMoreEntries).isSameAs(failure);
 
         Mockito.doReturn(true).when(cursor).isClosed();
         Mockito.clearInvocations(cursor);
         dispatcher.readMoreEntries();
         Mockito.verify(cursor).isClosed();
+    }
+
+    @Test(timeOut = 30_000, dataProvider = "readConflationDispatcherTypes")
+    public void testReadMoreEntriesRunsReentrantRequestsAfterFailure(boolean classic) throws Exception {
+        ManagedCursor cursor = Mockito.mock(ManagedCursor.class);
+        AbstractPersistentDispatcherMultipleConsumers dispatcher = createReadConflationDispatcher(cursor, classic);
+        IllegalStateException failure = new IllegalStateException("read failed");
+        IllegalStateException followUpFailure = new IllegalStateException("follow-up read failed");
+        AtomicInteger passes = new AtomicInteger();
+        Mockito.doAnswer(inv -> {
+            int pass = passes.incrementAndGet();
+            if (pass <= 3) {
+                dispatcher.readMoreEntries();
+                // Reusing the first exception must not cause self-suppression.
+                throw pass == 2 ? followUpFailure : failure;
+            }
+            return true;
+        }).when(cursor).isClosed();
+
+        assertThatThrownBy(dispatcher::readMoreEntries).isSameAs(failure);
+        assertThat(passes.get()).as("Registered follow-ups run before propagating the failure").isEqualTo(4);
+        assertThat(failure.getSuppressed()).containsExactly(followUpFailure);
+        dispatcher.readMoreEntries();
+        assertThat(passes.get()).isEqualTo(5);
+    }
+
+    @Test(timeOut = 30_000, dataProvider = "readConflationDispatcherTypes")
+    public void testReadMoreEntriesRunsConcurrentRequestAfterFailure(boolean classic) throws Exception {
+        ManagedCursor cursor = Mockito.mock(ManagedCursor.class);
+        AbstractPersistentDispatcherMultipleConsumers dispatcher = createReadConflationDispatcher(cursor, classic);
+        IllegalStateException failure = new IllegalStateException("read failed");
+        CountDownLatch passStarted = new CountDownLatch(1);
+        CountDownLatch releasePass = new CountDownLatch(1);
+        AtomicInteger passes = new AtomicInteger();
+        Mockito.doAnswer(inv -> {
+            if (passes.incrementAndGet() == 1) {
+                passStarted.countDown();
+                assertThat(releasePass.await(10, TimeUnit.SECONDS)).isTrue();
+                throw failure;
+            }
+            return true;
+        }).when(cursor).isClosed();
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            Future<?> owner = executor.submit(dispatcher::readMoreEntries);
+            assertThat(passStarted.await(10, TimeUnit.SECONDS)).isTrue();
+            executor.submit(dispatcher::readMoreEntries).get(10, TimeUnit.SECONDS);
+            releasePass.countDown();
+            assertThatThrownBy(() -> owner.get(10, TimeUnit.SECONDS)).hasCause(failure);
+            assertThat(passes.get()).as("The registered follow-up runs without a new caller").isEqualTo(2);
+            dispatcher.readMoreEntries();
+            assertThat(passes.get()).isEqualTo(3);
+        } finally {
+            releasePass.countDown();
+            executor.shutdownNow();
+            assertThat(executor.awaitTermination(10, TimeUnit.SECONDS)).isTrue();
+        }
     }
 
     @DataProvider

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumersTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumersTest.java
@@ -955,7 +955,7 @@ public class PersistentStickyKeyDispatcherMultipleConsumersTest {
                 }
 
                 @Override
-                public synchronized void readMoreEntries() {
+                protected synchronized void internalReadMoreEntries() {
                     readMoreEntriesCalled.incrementAndGet();
                 }
 
@@ -976,7 +976,7 @@ public class PersistentStickyKeyDispatcherMultipleConsumersTest {
                 }
 
                 @Override
-                public synchronized void readMoreEntries() {
+                protected synchronized void internalReadMoreEntries() {
                     readMoreEntriesCalled.incrementAndGet();
                 }
 


### PR DESCRIPTION
### Motivation

Concurrent callers of the modern and classic persistent multiple-consumer dispatchers' `readMoreEntries()` methods queue on the dispatcher monitor and each execute a full pass. The modern dispatcher's existing `readMoreEntriesAsync()` deduplication only collapses queued executor submissions, so direct calls do not benefit from it.

### Modifications

- Add a final `readMoreEntries()` method in `AbstractPersistentDispatcherMultipleConsumers` with a shared three-state atomic conflation loop. Calls arriving during a running pass request a single follow-up pass and return; requests during that follow-up can trigger another pass.
- Move the modern and classic dispatchers' read bodies into protected synchronized `internalReadMoreEntries()` overrides. Shared and Key_Shared dispatchers in both families, along with the entry-bucket dispatcher, inherit the wrapper. Follow-up passes run iteratively to avoid recursive stack growth, and ownership resets if a pass throws.
- Preserve the existing async submission behavior. The modern dispatcher's read-operation counter remains inside its read body and counts executed passes that reach it, rather than conflated callers, for pending-read rescheduling.
- Migrate the Key_Shared test overrides to the new hook and parameterize the conflation tests for modern and classic dispatchers.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

Added deterministic tests covering concurrent requests during both the initial and follow-up passes, reentrant requests without recursive execution, recovery after an exception with a follow-up requested, and monitor ownership during a pass. The concurrent-caller regression test was verified to fail against the original modern implementation because callers block on the dispatcher monitor.

Passed locally:

- `./gradlew :pulsar-broker:test --tests '*PersistentDispatcherMultipleConsumersTest.testReadMoreEntries*' --tests '*PersistentStickyKeyDispatcherMultipleConsumersTest.testNoBackoffDelayWhenDelayedMessages' --tests '*PersistentDispatcherMultipleConsumersClassicTest' --tests '*RescheduleReadHandlerTest' -PtestRetryCount=0` — 20 tests.
- `./gradlew quickCheck` — includes license, Spotless and main/test Checkstyle checks.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [x] The public API — the dispatcher implementation method `readMoreEntries()` becomes final; subclasses customizing the read pass must override protected `internalReadMoreEntries()` instead.
- [ ] The schema
- [ ] The default values of configurations
- [x] The threading model — concurrent read requests return after requesting a follow-up; the owning caller executes synchronized passes.
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
