### PR TITLE
[improve][broker] Add a random value upto 5% to avoid rollover multiple cursor ledgers 

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -50,6 +50,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -311,6 +312,8 @@ public class ManagedCursorImpl implements ManagedCursor {
     @SuppressWarnings("unused")
     private volatile int pendingMarkDeletedSubmittedCount = 0;
     private volatile long lastLedgerSwitchTimestamp;
+    private volatile long maximumLedgerRolloverTimeMs;
+    private volatile long maximumLedgerRolloverEntries;
     private final Clock clock;
 
     // The last active time (Unix time, milliseconds) of the cursor
@@ -386,6 +389,7 @@ public class ManagedCursorImpl implements ManagedCursor {
         this.clock = getConfig().getClock();
         this.lastActive = this.clock.millis();
         this.lastLedgerSwitchTimestamp = this.clock.millis();
+        updateRolloverThresholds(getConfig());
 
         if (getConfig().getThrottleMarkDelete() > 0.0) {
             markDeleteLimiter = RateLimiter.create(getConfig().getThrottleMarkDelete());
@@ -3613,8 +3617,8 @@ public class ManagedCursorImpl implements ManagedCursor {
     boolean shouldCloseLedger(LedgerHandle lh) {
         long now = clock.millis();
         if (ledger.getFactory().isMetadataServiceAvailable()
-                && (lh.getLastAddConfirmed() >= getConfig().getMetadataMaxEntriesPerLedger()
-                || lastLedgerSwitchTimestamp < (now - getConfig().getLedgerRolloverTimeout() * 1000))
+                && (lh.getLastAddConfirmed() >= maximumLedgerRolloverEntries
+                || lastLedgerSwitchTimestamp < (now - maximumLedgerRolloverTimeMs))
                 && !state.isClosed()) {
             // It's safe to modify the timestamp since this method will be only called from a callback, implying that
             // calls will be serialized on one single thread
@@ -4020,6 +4024,25 @@ public class ManagedCursorImpl implements ManagedCursor {
             // Disable mark-delete rate limiter
             markDeleteLimiter = null;
         }
+    }
+
+    /**
+     * Recalculate cached cursor-ledger rollover thresholds from {@code config}.
+     * Adds up to 5% jitter so multiple cursors do not rollover at the same time.
+     */
+    void updateRolloverThresholds(ManagedLedgerConfig config) {
+        this.maximumLedgerRolloverTimeMs = getMaximumRolloverTimeMs(config);
+        this.maximumLedgerRolloverEntries = getMaximumRolloverEntries(config);
+    }
+
+    private static long getMaximumRolloverTimeMs(ManagedLedgerConfig config) {
+        return (long) (config.getLedgerRolloverTimeout() * 1000L
+                * (1 + ThreadLocalRandom.current().nextDouble() * 0.05));
+    }
+
+    private static long getMaximumRolloverEntries(ManagedLedgerConfig config) {
+        return (long) (config.getMetadataMaxEntriesPerLedger()
+                * (1 + ThreadLocalRandom.current().nextDouble() * 0.05));
     }
 
     @Override

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -4533,7 +4533,12 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
     public void setConfig(ManagedLedgerConfig config) {
         this.config = config;
         this.maximumRolloverTimeMs = getMaximumRolloverTimeMs(config);
-        this.cursors.forEach(c -> c.setThrottleMarkDelete(config.getThrottleMarkDelete()));
+        this.cursors.forEach(c -> {
+            if (c instanceof ManagedCursorImpl cursor) {
+                cursor.updateRolloverThresholds(config);
+            }
+            c.setThrottleMarkDelete(config.getThrottleMarkDelete());
+        });
     }
 
     private static long getMaximumRolloverTimeMs(ManagedLedgerConfig config) {


### PR DESCRIPTION
### Motivation

If topic has multiple subscriptions, the cursor ledgers of subscriptions may rollover at the same time, which may bring additional pressure on zk. 

<img width="1729" height="279" alt="企业微信截图_bf29c0d9-b029-4ff2-8bdc-30f72670d5e2" src="https://github.com/user-attachments/assets/3fbb540a-c088-4de1-a646-e44eea4fb9dd" />


Topic ledger has added the random value to avoid rollover at the same time. While cursor ledger do not have this mechanism.

https://github.com/apache/pulsar/blob/6d9f9ce2aac7b77ff9963662305260f78d03de91/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java#L411-L412


### Modifications

Also add the 5% random value in rollover cursor ledger.


### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment