### PR TITLE
[fix][misc] Restore PKCS#1 RSA support and add SEC1 EC private key parsing

### DIFF
--- a/pulsar-common/build.gradle.kts
+++ b/pulsar-common/build.gradle.kts
@@ -212,6 +212,7 @@ dependencies {
     // module; bc-fips must not be on a classpath that also has the non-FIPS provider because both
     // jars define org.bouncycastle.* and the JVM rejects the mismatched signers.
     testImplementation(libs.bcprov.jdk18on)
+    testImplementation(libs.bcpkix.jdk18on)
     // Same reflective-loading rationale for the BouncyCastle JSSE provider (BCJSSE): JcaProviders
     // registers it from the classpath on demand, so it is a test-only dependency here. bctls ships no
     // META-INF/services entry, which is why on-demand registration exists at all.

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/tls/PemReader.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/tls/PemReader.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.common.util.tls;
 
 import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -44,16 +45,12 @@ import lombok.CustomLog;
 import org.apache.commons.lang3.StringUtils;
 
 /**
- * Parses PEM-encoded X.509 certificates and PKCS#8 private keys from files and streams. This is the single
- * shared PEM-parsing primitive extracted from the {@code SecurityUtility} grab-bag (PIP-478): it holds
- * no TLS-context assembly or security-provider concerns, only the file/stream-to-material parsing that several
- * callers (the file-based TLS material sources and {@code AuthenticationDataTls}) reuse.
+ * Parses PEM-encoded X.509 certificates and PKCS#8 or PKCS#1 RSA private keys from files and streams.
  *
- * <p>Every entry point has an overload taking a pinned JCA {@link Provider} (the PIP-478 {@code jcaProvider}):
- * with {@code null} — and in the no-provider overloads — the JVM provider search order is used, exactly as
- * before; with a provider the {@code CertificateFactory}/{@code KeyFactory} engines that manufacture the
- * {@code X509Certificate}/{@code PrivateKey} objects come from that provider, so a FIPS deployment parses its
- * material inside the validated module.
+ * <p>Every entry point has an overload taking a pinned JCA {@link Provider}. With {@code null}, or in the
+ * no-provider overloads, the JVM provider search order is used. With a provider, the
+ * {@code CertificateFactory} and {@code KeyFactory} engines that create the certificates and private keys
+ * come from that provider.
  */
 @CustomLog
 public final class PemReader {
@@ -128,7 +125,7 @@ public final class PemReader {
     }
 
     /**
-     * Load a PKCS#8 PEM private key, manufacturing the key object with a pinned JCA provider.
+     * Load a PKCS#8 or PKCS#1 RSA PEM private key, manufacturing the key object with a pinned JCA provider.
      *
      * @param keyFilePath the PEM file path
      * @param jcaProvider the pinned JCA provider, or {@code null} for the JVM provider search order
@@ -157,7 +154,8 @@ public final class PemReader {
     }
 
     /**
-     * Load a PKCS#8 PEM private key from a stream, manufacturing the key object with a pinned JCA provider.
+     * Load a PKCS#8 or PKCS#1 RSA PEM private key from a stream, manufacturing the key object
+     * with a pinned JCA provider.
      *
      * <p>The existing per-algorithm loop degrades naturally: an algorithm the pinned provider does not supply
      * is skipped like an algorithm that does not match the key, and the same loud "algorithm is not supported"
@@ -174,8 +172,6 @@ public final class PemReader {
             return null;
         }
 
-        PrivateKey privateKey;
-
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(inStream, StandardCharsets.UTF_8))) {
             if (inStream.markSupported()) {
                 inStream.reset();
@@ -183,20 +179,33 @@ public final class PemReader {
             StringBuilder sb = new StringBuilder();
             String currentLine = null;
 
-            // Jump to the first line after -----BEGIN [RSA] PRIVATE KEY-----.
-            // One line is consumed per iteration: the extracted-from version discarded a second line in the
-            // loop body, so a file whose BEGIN line sat at an ODD offset (one leading comment, blank line, or
-            // openssl "Bag Attributes" header) had that BEGIN line swallowed, ran the scan to EOF, and failed
-            // with the misleading "private key algorithm is not supported" below.
-            while ((currentLine = reader.readLine()) != null && !currentLine.startsWith("-----BEGIN")) {
-                // skip preamble
+            // Skip preamble lines and allow whitespace around PEM boundaries.
+            while ((currentLine = reader.readLine()) != null) {
+                currentLine = currentLine.strip();
+                if (currentLine.startsWith("-----BEGIN")) {
+                    break;
+                }
             }
 
-            // Stop (and skip) at the last line that has, say, -----END [RSA] PRIVATE KEY-----
-            while ((currentLine = reader.readLine()) != null && !currentLine.startsWith("-----END")) {
-                sb.append(currentLine);
+            boolean pkcs1Rsa = "-----BEGIN RSA PRIVATE KEY-----".equals(currentLine);
+
+            // BufferedReader handles LF, CRLF and CR. Ignore whitespace in the Base64 body (RFC 7468 section 2).
+            while ((currentLine = reader.readLine()) != null) {
+                if (currentLine.strip().startsWith("-----END")) {
+                    break;
+                }
+                for (int i = 0; i < currentLine.length(); i++) {
+                    char c = currentLine.charAt(i);
+                    if (c != ' ' && (c < '\t' || c > '\r')) {
+                        sb.append(c);
+                    }
+                }
             }
-            final KeySpec keySpec = new PKCS8EncodedKeySpec(Base64.getDecoder().decode(sb.toString()));
+            byte[] encodedKey = Base64.getDecoder().decode(sb.toString());
+            if (pkcs1Rsa) {
+                encodedKey = wrapRsaPkcs1Key(encodedKey);
+            }
+            final KeySpec keySpec = new PKCS8EncodedKeySpec(encodedKey);
             final List<String> failedAlgorithm = new ArrayList<>(KEY_FACTORY_ALGORITHMS.size());
             for (String algorithm : KEY_FACTORY_ALGORITHMS) {
                 try {
@@ -216,5 +225,39 @@ public final class PemReader {
             throw new KeyManagementException("Private key loading error", e);
         }
 
+    }
+
+    /**
+     * PKCS#8 PrivateKeyInfo contains a version, an AlgorithmIdentifier and the PKCS#1 key in an OCTET STRING.
+     * Only add the envelope here; key parsing and validation remain with the selected JCA provider.
+     *
+     * @see <a href="https://www.rfc-editor.org/rfc/rfc5208.html#section-5">RFC 5208 section 5: PrivateKeyInfo</a>
+     * @see <a href="https://www.rfc-editor.org/rfc/rfc8017.html#appendix-A.1">RFC 8017 appendix A.1:
+     *      rsaEncryption identifier and NULL parameters</a>
+     */
+    private static byte[] wrapRsaPkcs1Key(byte[] pkcs1Key) {
+        ByteArrayOutputStream content = new ByteArrayOutputStream();
+        content.writeBytes(new byte[]{0x02, 0x01, 0x00}); // version 0
+        // rsaEncryption (1.2.840.113549.1.1.1), with NULL parameters.
+        content.writeBytes(new byte[]{0x30, 0x0d, 0x06, 0x09, 0x2a, (byte) 0x86, 0x48,
+                (byte) 0x86, (byte) 0xf7, 0x0d, 0x01, 0x01, 0x01, 0x05, 0x00});
+        content.writeBytes(encodeDerValue(0x04, pkcs1Key));
+        return encodeDerValue(0x30, content.toByteArray());
+    }
+
+    private static byte[] encodeDerValue(int tag, byte[] value) {
+        ByteArrayOutputStream encoded = new ByteArrayOutputStream();
+        encoded.write(tag);
+        if (value.length < 128) {
+            encoded.write(value.length);
+        } else {
+            int lengthBytes = (Integer.SIZE - Integer.numberOfLeadingZeros(value.length) + 7) / 8;
+            encoded.write(0x80 | lengthBytes);
+            for (int shift = (lengthBytes - 1) * 8; shift >= 0; shift -= 8) {
+                encoded.write(value.length >>> shift);
+            }
+        }
+        encoded.writeBytes(value);
+        return encoded.toByteArray();
     }
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/tls/PemReader.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/tls/PemReader.java
@@ -18,12 +18,16 @@
  */
 package org.apache.pulsar.common.util.tls;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.StringReader;
+import java.lang.reflect.InvocationTargetException;
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.KeyFactory;
@@ -45,7 +49,9 @@ import lombok.CustomLog;
 import org.apache.commons.lang3.StringUtils;
 
 /**
- * Parses PEM-encoded X.509 certificates and PKCS#8 or PKCS#1 RSA private keys from files and streams.
+ * Parses PEM-encoded X.509 certificates and PKCS#8, PKCS#1 RSA or SEC1 EC private keys from files and streams.
+ *
+ * <p>SEC1 EC keys require Bouncy Castle bcpkix and its matching dependencies on the class path.
  *
  * <p>Every entry point has an overload taking a pinned JCA {@link Provider}. With {@code null}, or in the
  * no-provider overloads, the JVM provider search order is used. With a provider, the
@@ -125,7 +131,7 @@ public final class PemReader {
     }
 
     /**
-     * Load a PKCS#8 or PKCS#1 RSA PEM private key, manufacturing the key object with a pinned JCA provider.
+     * Load a PKCS#8, PKCS#1 RSA or SEC1 EC PEM private key, manufacturing the key object with a pinned JCA provider.
      *
      * @param keyFilePath the PEM file path
      * @param jcaProvider the pinned JCA provider, or {@code null} for the JVM provider search order
@@ -154,7 +160,7 @@ public final class PemReader {
     }
 
     /**
-     * Load a PKCS#8 or PKCS#1 RSA PEM private key from a stream, manufacturing the key object
+     * Load a PKCS#8, PKCS#1 RSA or SEC1 EC PEM private key from a stream, manufacturing the key object
      * with a pinned JCA provider.
      *
      * <p>The existing per-algorithm loop degrades naturally: an algorithm the pinned provider does not supply
@@ -187,6 +193,7 @@ public final class PemReader {
                 }
             }
 
+            boolean sec1Ec = "-----BEGIN EC PRIVATE KEY-----".equals(currentLine);
             boolean pkcs1Rsa = "-----BEGIN RSA PRIVATE KEY-----".equals(currentLine);
 
             // BufferedReader handles LF, CRLF and CR. Ignore whitespace in the Base64 body (RFC 7468 section 2).
@@ -201,9 +208,14 @@ public final class PemReader {
                     }
                 }
             }
-            byte[] encodedKey = Base64.getDecoder().decode(sb.toString());
-            if (pkcs1Rsa) {
-                encodedKey = wrapRsaPkcs1Key(encodedKey);
+            byte[] encodedKey;
+            if (sec1Ec) {
+                encodedKey = convertEcPrivateKey(sb.toString(), PemReader.class.getClassLoader());
+            } else {
+                encodedKey = Base64.getDecoder().decode(sb.toString());
+                if (pkcs1Rsa) {
+                    encodedKey = wrapRsaPkcs1Key(encodedKey);
+                }
             }
             final KeySpec keySpec = new PKCS8EncodedKeySpec(encodedKey);
             final List<String> failedAlgorithm = new ArrayList<>(KEY_FACTORY_ALGORITHMS.size());
@@ -225,6 +237,35 @@ public final class PemReader {
             throw new KeyManagementException("Private key loading error", e);
         }
 
+    }
+
+    /**
+     * Use optional Bouncy Castle PKIX classes only for SEC1 decoding. The resulting PKCS#8 bytes still
+     * pass through the selected JCA provider; parsing does not register or select a BC provider.
+     */
+    @VisibleForTesting
+    static byte[] convertEcPrivateKey(String base64, ClassLoader classLoader) throws KeyManagementException {
+        try {
+            Class<?> parserClass = Class.forName("org.bouncycastle.openssl.PEMParser", true, classLoader);
+            Class<?> keyPairClass = Class.forName("org.bouncycastle.openssl.PEMKeyPair", true, classLoader);
+            Class<?> keyInfoClass = Class.forName("org.bouncycastle.asn1.pkcs.PrivateKeyInfo", true, classLoader);
+            String pem = "-----BEGIN EC PRIVATE KEY-----\n" + base64 + "\n-----END EC PRIVATE KEY-----\n";
+            try (Reader parser = (Reader) parserClass.getConstructor(Reader.class).newInstance(new StringReader(pem))) {
+                Object keyPair = parserClass.getMethod("readObject").invoke(parser);
+                if (!keyPairClass.isInstance(keyPair)) {
+                    throw new KeyManagementException("Invalid BEGIN EC PRIVATE KEY file: expected an EC key pair");
+                }
+                Object keyInfo = keyPairClass.getMethod("getPrivateKeyInfo").invoke(keyPair);
+                return (byte[]) keyInfoClass.getMethod("getEncoded").invoke(keyInfo);
+            }
+        } catch (ClassNotFoundException | LinkageError e) {
+            throw new KeyManagementException("Bouncy Castle bcpkix and its matching dependencies must be on the "
+                    + "class path to parse BEGIN EC PRIVATE KEY files, or convert the key to PKCS#8", e);
+        } catch (InvocationTargetException e) {
+            throw new KeyManagementException("Failed to parse BEGIN EC PRIVATE KEY file", e.getCause());
+        } catch (ReflectiveOperationException | IOException e) {
+            throw new KeyManagementException("Failed to parse BEGIN EC PRIVATE KEY file", e);
+        }
     }
 
     /**

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/tls/PemReaderTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/tls/PemReaderTest.java
@@ -29,6 +29,8 @@ import java.security.KeyManagementException;
 import java.security.KeyPairGenerator;
 import java.security.PrivateKey;
 import java.security.Provider;
+import java.security.interfaces.ECPrivateKey;
+import java.security.spec.ECGenParameterSpec;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
@@ -171,6 +173,70 @@ public class PemReaderTest {
         Provider emptyProvider = new Provider("NoKeyFactories", "1.0", "No key factories for testing") { };
         assertThatThrownBy(() -> PemReader.loadPrivateKeyFromPemStream(
                 new ByteArrayInputStream(pem.getBytes(StandardCharsets.UTF_8)), emptyProvider))
+                .isInstanceOf(KeyManagementException.class);
+    }
+
+    @DataProvider(name = "ecCurves")
+    public static Object[][] ecCurves() {
+        return new Object[][]{{"secp256r1"}, {"secp384r1"}, {"secp521r1"}};
+    }
+
+    @Test(dataProvider = "ecCurves")
+    public void loadsTraditionalEcPrivateKey(String curve) throws Exception {
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("EC");
+        generator.initialize(new ECGenParameterSpec(curve));
+        ECPrivateKey expected = (ECPrivateKey) generator.generateKeyPair().getPrivate();
+        PrivateKeyInfo info = PrivateKeyInfo.getInstance(expected.getEncoded());
+        // The ASN.1 and JCA types share a simple name; keep the less-used ASN.1 type qualified.
+        byte[] sec1 = new org.bouncycastle.asn1.sec.ECPrivateKey(expected.getParams().getOrder().bitLength(),
+                expected.getS(), info.getPrivateKeyAlgorithm().getParameters()).getEncoded();
+        String pem = toPem("EC PRIVATE KEY", sec1);
+        for (Provider provider : new Provider[]{null, KeyFactory.getInstance("EC").getProvider()}) {
+            Path file = writeKeyWithPreamble(3, pem);
+            ECPrivateKey actual = (ECPrivateKey) PemReader.loadPrivateKeyFromPemFile(file.toString(), provider);
+            assertThat(actual.getS()).isEqualTo(expected.getS());
+            assertThat(actual.getParams().getOrder()).isEqualTo(expected.getParams().getOrder());
+            String whitespacePem = pem.replace("\n", " \t\r\n");
+            assertThat(((ECPrivateKey) PemReader.loadPrivateKeyFromPemStream(new ByteArrayInputStream(
+                    whitespacePem.getBytes(StandardCharsets.UTF_8)), provider)).getS()).isEqualTo(expected.getS());
+        }
+        Provider emptyProvider = new Provider("NoKeyFactories", "1.0", "No key factories for testing") { };
+        assertThatThrownBy(() -> PemReader.loadPrivateKeyFromPemStream(
+                new ByteArrayInputStream(pem.getBytes(StandardCharsets.UTF_8)), emptyProvider))
+                .isInstanceOf(KeyManagementException.class)
+                .hasMessageContaining("algorithm is not supported");
+    }
+
+    @Test
+    public void explainsMissingBcpkixForTraditionalEcKey() {
+        ClassLoader withoutBcpkix = new ClassLoader(PemReader.class.getClassLoader()) {
+            @Override
+            protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+                if (name.startsWith("org.bouncycastle.openssl.")) {
+                    throw new ClassNotFoundException(name);
+                }
+                return super.loadClass(name, resolve);
+            }
+        };
+        assertThatThrownBy(() -> PemReader.convertEcPrivateKey("MAA=", withoutBcpkix))
+                .isInstanceOf(KeyManagementException.class)
+                .hasMessageContaining("bcpkix")
+                .hasMessageContaining("class path")
+                .hasMessageContaining("BEGIN EC PRIVATE KEY")
+                .hasMessageContaining("convert the key to PKCS#8")
+                .hasCauseInstanceOf(ClassNotFoundException.class);
+    }
+
+    @DataProvider(name = "malformedEcKeys")
+    public static Object[][] malformedEcKeys() {
+        return new Object[][]{{new byte[]{0x30, 0x00}}, {new byte[]{0x30, 0x7f}}};
+    }
+
+    @Test(dataProvider = "malformedEcKeys")
+    public void rejectsMalformedTraditionalEcKey(byte[] encoded) {
+        String pem = toPem("EC PRIVATE KEY", encoded);
+        assertThatThrownBy(() -> PemReader.loadPrivateKeyFromPemStream(
+                new ByteArrayInputStream(pem.getBytes(StandardCharsets.UTF_8))))
                 .isInstanceOf(KeyManagementException.class);
     }
 

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/tls/PemReaderTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/tls/PemReaderTest.java
@@ -19,15 +19,21 @@
 package org.apache.pulsar.common.util.tls;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import com.google.common.io.Resources;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.security.KeyFactory;
+import java.security.KeyManagementException;
+import java.security.KeyPairGenerator;
 import java.security.PrivateKey;
+import java.security.Provider;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 import org.apache.commons.io.FileUtils;
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
@@ -43,9 +49,6 @@ import org.testng.annotations.Test;
  */
 public class PemReaderTest {
 
-    private static final String KEY = Resources.getResource(
-            "certificate-authority/server-keys/broker.key-pk8.pem").getPath();
-
     private Path dir;
 
     @BeforeMethod
@@ -60,45 +63,134 @@ public class PemReaderTest {
         }
     }
 
-    @DataProvider(name = "preambleLineCounts")
-    public static Object[][] preambleLineCounts() {
-        // Both parities matter: pre-fix, even counts parsed and odd counts failed.
-        return new Object[][]{{0}, {1}, {2}, {3}, {4}};
+    @DataProvider(name = "privateKeyFormats")
+    public static Object[][] privateKeyFormats() throws Exception {
+        List<Object[]> cases = new ArrayList<>();
+        for (String algorithm : List.of("RSA", "EC")) {
+            KeyPairGenerator generator = KeyPairGenerator.getInstance(algorithm);
+            generator.initialize("RSA".equals(algorithm) ? 2048 : 256);
+            PrivateKey key = generator.generateKeyPair().getPrivate();
+            Provider provider = KeyFactory.getInstance(algorithm).getProvider();
+            for (boolean pkcs1 : new boolean[]{false, true}) {
+                if (pkcs1 && !"RSA".equals(algorithm)) {
+                    continue;
+                }
+                byte[] encoded = pkcs1
+                        ? PrivateKeyInfo.getInstance(key.getEncoded()).parsePrivateKey().toASN1Primitive().getEncoded()
+                        : key.getEncoded();
+                String pem = toPem(pkcs1 ? "RSA PRIVATE KEY" : "PRIVATE KEY", encoded);
+                for (int preambleLines = 0; preambleLines <= 4; preambleLines++) {
+                    for (Provider pinned : new Provider[]{null, provider}) {
+                        cases.add(new Object[]{pem, key, preambleLines, pinned});
+                    }
+                }
+            }
+        }
+        return cases.toArray(new Object[0][]);
     }
 
-    @Test(dataProvider = "preambleLineCounts")
-    public void loadsPrivateKeyRegardlessOfPreambleLineCount(int preambleLines) throws Exception {
-        Path keyFile = writeKeyWithPreamble(preambleLines);
+    @Test(dataProvider = "privateKeyFormats")
+    public void loadsPrivateKeyRegardlessOfFormatAndPreamble(String pem, PrivateKey expected, int preambleLines,
+                                                            Provider provider) throws Exception {
+        Path keyFile = writeKeyWithPreamble(preambleLines, pem);
 
-        PrivateKey key = PemReader.loadPrivateKeyFromPemFile(keyFile.toString());
+        PrivateKey key = PemReader.loadPrivateKeyFromPemFile(keyFile.toString(), provider);
 
-        assertThat(key).as("key with %s preamble line(s) parses", preambleLines).isNotNull();
-        assertThat(key.getAlgorithm()).isEqualTo("RSA");
+        assertThat(key.getAlgorithm()).isEqualTo(expected.getAlgorithm());
+        assertThat(key.getEncoded()).as("key with %s preamble line(s) parses", preambleLines)
+                .isEqualTo(expected.getEncoded());
+    }
+
+    @DataProvider(name = "pemWhitespace")
+    public static Object[][] pemWhitespace() throws Exception {
+        List<Object[]> cases = new ArrayList<>();
+        for (Object[] format : privateKeyFormats()) {
+            if ((int) format[2] != 0 || format[3] != null) {
+                continue;
+            }
+            for (String newline : List.of("\n", "\r\n", "\r")) {
+                for (int whitespace = 0; whitespace < 4; whitespace++) {
+                    StringBuilder pem = new StringBuilder();
+                    for (String line : ((String) format[0]).lines().toList()) {
+                        if (whitespace == 1) {
+                            line = " \t" + line + "\t ";
+                        } else if (whitespace == 2) {
+                            pem.append(" \t").append(newline).append(newline);
+                        } else if (whitespace == 3 && !line.startsWith("-----")) {
+                            line = line.substring(0, 4) + " \t\f\u000b" + line.substring(4);
+                        }
+                        pem.append(line).append(newline);
+                    }
+                    cases.add(new Object[]{pem.toString(), format[1]});
+                }
+            }
+        }
+        return cases.toArray(new Object[0][]);
+    }
+
+    @Test(dataProvider = "pemWhitespace")
+    public void loadsPrivateKeyWithWhitespace(String pem, PrivateKey expected) throws Exception {
+        PrivateKey key = PemReader.loadPrivateKeyFromPemStream(
+                new ByteArrayInputStream(pem.getBytes(StandardCharsets.UTF_8)));
+        assertThat(key.getEncoded()).isEqualTo(expected.getEncoded());
     }
 
     @Test
     public void loadsPrivateKeyFromAnOpenSslBagAttributesPreamble() throws Exception {
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+        generator.initialize(2048);
+        PrivateKey expected = generator.generateKeyPair().getPrivate();
+        byte[] pkcs1 = PrivateKeyInfo.getInstance(expected.getEncoded())
+                .parsePrivateKey().toASN1Primitive().getEncoded();
         List<String> lines = new ArrayList<>();
         lines.add("Bag Attributes");
         lines.add("    friendlyName: broker");
         lines.add("    localKeyID: 54 69 6D 65 20 31 32 33");
         lines.add("Key Attributes: <No Attributes>");
-        Path keyFile = writeKeyWithPreamble(lines);
+        Path keyFile = writeKeyWithPreamble(lines, toPem("RSA PRIVATE KEY", pkcs1));
 
-        assertThat(PemReader.loadPrivateKeyFromPemFile(keyFile.toString())).isNotNull();
+        assertThat(PemReader.loadPrivateKeyFromPemFile(keyFile.toString()).getEncoded())
+                .isEqualTo(expected.getEncoded());
     }
 
-    private Path writeKeyWithPreamble(int preambleLines) throws Exception {
+    @Test
+    public void rejectsMalformedPkcs1Key() {
+        String pem = toPem("RSA PRIVATE KEY", new byte[]{0x30, 0x00});
+        assertThatThrownBy(() -> PemReader.loadPrivateKeyFromPemStream(
+                new ByteArrayInputStream(pem.getBytes(StandardCharsets.UTF_8))))
+                .isInstanceOf(KeyManagementException.class);
+    }
+
+    @Test
+    public void doesNotFallBackFromPinnedProviderForPkcs1Key() throws Exception {
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+        generator.initialize(2048);
+        byte[] pkcs1 = PrivateKeyInfo.getInstance(generator.generateKeyPair().getPrivate().getEncoded())
+                .parsePrivateKey().toASN1Primitive().getEncoded();
+        String pem = toPem("RSA PRIVATE KEY", pkcs1);
+        Provider emptyProvider = new Provider("NoKeyFactories", "1.0", "No key factories for testing") { };
+        assertThatThrownBy(() -> PemReader.loadPrivateKeyFromPemStream(
+                new ByteArrayInputStream(pem.getBytes(StandardCharsets.UTF_8)), emptyProvider))
+                .isInstanceOf(KeyManagementException.class);
+    }
+
+    private static String toPem(String label, byte[] encoded) {
+        return "-----BEGIN " + label + "-----\n"
+                + Base64.getMimeEncoder(64, new byte[]{'\n'}).encodeToString(encoded)
+                + "\n-----END " + label + "-----\n";
+    }
+
+    private Path writeKeyWithPreamble(int preambleLines, String pem) throws Exception {
         List<String> preamble = new ArrayList<>();
         for (int i = 0; i < preambleLines; i++) {
             preamble.add("# preamble line " + i);
         }
-        return writeKeyWithPreamble(preamble);
+        return writeKeyWithPreamble(preamble, pem);
     }
 
-    private Path writeKeyWithPreamble(List<String> preamble) throws Exception {
+    private Path writeKeyWithPreamble(List<String> preamble, String pem) throws Exception {
         List<String> lines = new ArrayList<>(preamble);
-        lines.addAll(Files.readAllLines(Paths.get(KEY), StandardCharsets.UTF_8));
+        lines.addAll(pem.lines().toList());
         Path keyFile = dir.resolve("key-" + lines.size() + ".pem");
         Files.write(keyFile, lines, StandardCharsets.UTF_8);
         return keyFile;

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/tls/PemReaderTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/tls/PemReaderTest.java
@@ -69,21 +69,24 @@ public class PemReaderTest {
     public static Object[][] privateKeyFormats() throws Exception {
         List<Object[]> cases = new ArrayList<>();
         for (String algorithm : List.of("RSA", "EC")) {
-            KeyPairGenerator generator = KeyPairGenerator.getInstance(algorithm);
-            generator.initialize("RSA".equals(algorithm) ? 2048 : 256);
-            PrivateKey key = generator.generateKeyPair().getPrivate();
-            Provider provider = KeyFactory.getInstance(algorithm).getProvider();
-            for (boolean pkcs1 : new boolean[]{false, true}) {
-                if (pkcs1 && !"RSA".equals(algorithm)) {
-                    continue;
-                }
-                byte[] encoded = pkcs1
-                        ? PrivateKeyInfo.getInstance(key.getEncoded()).parsePrivateKey().toASN1Primitive().getEncoded()
-                        : key.getEncoded();
-                String pem = toPem(pkcs1 ? "RSA PRIVATE KEY" : "PRIVATE KEY", encoded);
-                for (int preambleLines = 0; preambleLines <= 4; preambleLines++) {
-                    for (Provider pinned : new Provider[]{null, provider}) {
-                        cases.add(new Object[]{pem, key, preambleLines, pinned});
+            for (int keySize : "RSA".equals(algorithm) ? new int[]{2048, 3072, 4096} : new int[]{256}) {
+                KeyPairGenerator generator = KeyPairGenerator.getInstance(algorithm);
+                generator.initialize(keySize);
+                PrivateKey key = generator.generateKeyPair().getPrivate();
+                Provider provider = KeyFactory.getInstance(algorithm).getProvider();
+                for (boolean pkcs1 : new boolean[]{false, true}) {
+                    if (pkcs1 && !"RSA".equals(algorithm)) {
+                        continue;
+                    }
+                    byte[] encoded = pkcs1
+                            ? PrivateKeyInfo.getInstance(key.getEncoded()).parsePrivateKey()
+                                .toASN1Primitive().getEncoded()
+                            : key.getEncoded();
+                    String pem = toPem(pkcs1 ? "RSA PRIVATE KEY" : "PRIVATE KEY", encoded);
+                    for (int preambleLines = 0; preambleLines <= 4; preambleLines++) {
+                        for (Provider pinned : new Provider[]{null, provider}) {
+                            cases.add(new Object[]{pem, key, preambleLines, pinned});
+                        }
                     }
                 }
             }


### PR DESCRIPTION
PIP: [478](https://github.com/apache/pulsar/blob/master/pip/pip-478.md)

### Motivation

PIP-478 accidentally dropped support for PKCS#1 RSA private keys when migrating TLS material loading to the shared `PemReader`. Existing deployments using PEM files with `-----BEGIN RSA PRIVATE KEY-----` can no longer load their keys because the reader passes the PKCS#1 bytes directly to `PKCS8EncodedKeySpec`. Restore compatibility with those existing keys.

The general recommendation is to use PKCS#8 for new PEM private keys and replace PKCS#1 files with PKCS#8 as part of routine maintenance. PKCS#1 is a legacy private-key file format: [OpenSSL calls it "traditional" and uses PKCS#8 by default](https://docs.openssl.org/3.0/man1/openssl-pkey/#output-options). This does not mean that an unencrypted PKCS#1 key is deprecated or inherently insecure; PKCS#8 wraps the same RSA key material, so existing keys do not need urgent replacement. Pulsar will continue to support reading PKCS#1 RSA private keys.

Supported formats are:

- **PKCS#1:** unencrypted RSA private keys in PEM files (`BEGIN RSA PRIVATE KEY`).
- **PKCS#8:** unencrypted private keys in PEM files (`BEGIN PRIVATE KEY`), including RSA and EC. PKCS#8 remains the recommended PEM format and does not require Bouncy Castle for parsing.
- **SEC1:** unencrypted EC private keys in PEM files (`BEGIN EC PRIVATE KEY`), when Bouncy Castle `bcpkix` and its matching dependencies are on the classpath.
- **PKCS#12:** keystore-based TLS configuration with `tlsKeyStoreType=PKCS12` and the corresponding keystore settings.

### Modifications

- Recognize the PKCS#1 RSA PEM boundary and wrap its DER bytes in a PKCS#8 `PrivateKeyInfo` envelope before JCA decoding. Key parsing and validation remain with the selected JCA provider, including provider pinning.
- Load Bouncy Castle `PEMParser` reflectively for SEC1 EC keys and obtain PKCS#8 bytes for the existing provider-pinned JCA decoding path. This does not register or select a Bouncy Castle provider. If the parser dependencies are unavailable, report that `bcpkix` must be on the classpath or the key must be converted to PKCS#8.
- Add `bcpkix` as a test-only dependency; production parsing remains optional.
- Accept surrounding PEM-boundary whitespace and whitespace within the Base64 body, while retaining preamble handling.
- Expand generated-key regression coverage for PKCS#1 RSA, PKCS#8 RSA and EC, preambles, line endings, whitespace, malformed RSA and EC data, and provider pinning. EC coverage includes P-256, P-384, P-521, and the missing-`bcpkix` diagnostic.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change adds regression tests in `PemReaderTest`. Local validation passed: `quickCheck` and all 75 `PemReaderTest` cases.

```shell
./gradlew quickCheck :pulsar-common:test --tests org.apache.pulsar.common.util.tls.PemReaderTest -PtestRetryCount=0
```

### Does this pull request potentially affect one of the following parts:

- [x] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [x] Anything that affects deployment

Adds a test-only `bcpkix` dependency. Restores loading of existing PKCS#1 RSA PEM private keys for TLS without requiring conversion, and supports SEC1 EC PEM keys when the optional Bouncy Castle PKIX dependencies are available. PKCS#8 remains the recommended format.

