### PR TITLE
[fix][client] Keep transactional and non-transactional messages in separate batches

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionProduceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionProduceTest.java
@@ -51,6 +51,7 @@ import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.api.transaction.Transaction;
@@ -90,6 +91,61 @@ public class TransactionProduceTest extends TransactionTestBase {
     @AfterClass(alwaysRun = true)
     protected void cleanup() throws Exception {
         super.internalCleanup();
+    }
+
+    /**
+     * A batch carries one transaction id in its metadata, so every message in it inherits that transaction.
+     * A plain message batched together with transactional ones is therefore discarded when that transaction
+     * aborts, even though the application never sent it inside a transaction.
+     */
+    @Test
+    public void testAbortedTransactionDoesNotDiscardPlainMessageBatchedWithIt() throws Exception {
+        final String topic = NAMESPACE1 + "/txn-batch-isolation";
+        admin.topics().createNonPartitionedTopic(topic);
+
+        @Cleanup
+        Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
+                .topic(topic)
+                .subscriptionName("txn-batch-isolation-sub")
+                .subscribe();
+
+        Transaction txn = pulsarClient.newTransaction()
+                .withTransactionTimeout(60, TimeUnit.SECONDS)
+                .build().get();
+
+        @Cleanup
+        Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
+                .topic(topic)
+                .sendTimeout(0, TimeUnit.SECONDS)
+                .enableBatching(true)
+                .batchingMaxMessages(100)
+                // Long enough that the two sends under test cannot be split into separate batches by the
+                // timer, short enough that a batch still closes on its own when a flush cannot reach it.
+                .batchingMaxPublishDelay(5, TimeUnit.SECONDS)
+                .create();
+
+        // The first transactional send on a topic waits for the topic to be registered with the transaction
+        // coordinator before the message reaches the batch. Get that round trip out of the way, so the two
+        // sends under test are added to the container synchronously and therefore land in one batch.
+        // A flush issued here would run before the message reaches the batch, so let the batch timer close it.
+        producer.newMessage(txn).value("warm-up").sendAsync().get(30, TimeUnit.SECONDS);
+
+        producer.newMessage(txn).value("in-txn").sendAsync();
+        CompletableFuture<MessageId> plainSend = producer.newMessage().value("plain").sendAsync();
+        producer.flush();
+        plainSend.get(30, TimeUnit.SECONDS);
+
+        // The topic's max read position does not advance past an ongoing transaction, so nothing on this topic
+        // is readable until the transaction ends. Abort it: that discards the transactional messages, and the
+        // plain one must survive because it was never part of the transaction.
+        txn.abort().get(60, TimeUnit.SECONDS);
+
+        Message<String> received = consumer.receive(30, TimeUnit.SECONDS);
+        Assert.assertNotNull(received, "the plain message was discarded by the aborted transaction");
+        Assert.assertEquals(received.getValue(), "plain");
+
+        // Both transactional messages were aborted, so nothing else may arrive.
+        Assert.assertNull(consumer.receive(3, TimeUnit.SECONDS));
     }
 
     @Test

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/AbstractBatchMessageContainer.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/AbstractBatchMessageContainer.java
@@ -120,14 +120,28 @@ public abstract class AbstractBatchMessageContainer implements BatchMessageConta
         this.maxBytesInBatch = producer.getConfiguration().getBatchingMaxBytes();
     }
 
+    /**
+     * Whether {@code msg} belongs to the same transaction as the messages already in this batch.
+     *
+     * <p>A batch carries a single transaction id in its metadata, so every message in it inherits that
+     * transaction. "No transaction" is therefore an identity of its own and is not compatible with any
+     * transaction: mixing the two in one batch would either enroll a plain message in a transaction (invisible
+     * until commit, dropped on abort) or publish a transactional message outside its transaction.
+     *
+     * <p>This is a pure query. The batch adopts its transaction id from its first message in {@code add}.
+     */
     @Override
     public boolean hasSameTxn(MessageImpl<?> msg) {
-        if (!msg.getMessageBuilder().hasTxnidMostBits() || !msg.getMessageBuilder().hasTxnidLeastBits()) {
+        if (numMessagesInBatch == 0) {
             return true;
         }
-        if (currentTxnidMostBits == -1 || currentTxnidLeastBits == -1) {
-            currentTxnidMostBits = msg.getMessageBuilder().getTxnidMostBits();
-            currentTxnidLeastBits = msg.getMessageBuilder().getTxnidLeastBits();
+        boolean msgHasTxn = msg.getMessageBuilder().hasTxnidMostBits()
+                && msg.getMessageBuilder().hasTxnidLeastBits();
+        boolean batchHasTxn = currentTxnidMostBits != -1L && currentTxnidLeastBits != -1L;
+        if (msgHasTxn != batchHasTxn) {
+            return false;
+        }
+        if (!msgHasTxn) {
             return true;
         }
         return currentTxnidMostBits == msg.getMessageBuilder().getTxnidMostBits()

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageKeyBasedContainer.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageKeyBasedContainer.java
@@ -49,10 +49,15 @@ class BatchMessageKeyBasedContainer extends AbstractBatchMessageContainer {
         if (numMessagesInBatch == 0) {
             // The whole container shares one transaction identity; hasSameTxn keeps later messages consistent
             // with it. Capturing it here rather than in hasSameTxn keeps that check side-effect free.
-            if (msg.getMessageBuilder().hasTxnidMostBits() && msg.getMessageBuilder().hasTxnidLeastBits()) {
-                currentTxnidMostBits = msg.getMessageBuilder().getTxnidMostBits();
-                currentTxnidLeastBits = msg.getMessageBuilder().getTxnidLeastBits();
-            }
+            //
+            // Both fields are assigned unconditionally, so a plain first message resets them. An inner batch
+            // whose first add fails to allocate clears itself and stays empty, which leaves the count at zero
+            // without clearing this container: a leftover transaction id would then be inherited by the next,
+            // plain, first message and would wrongly admit later messages of that transaction.
+            boolean msgHasTxn = msg.getMessageBuilder().hasTxnidMostBits()
+                    && msg.getMessageBuilder().hasTxnidLeastBits();
+            currentTxnidMostBits = msgHasTxn ? msg.getMessageBuilder().getTxnidMostBits() : -1L;
+            currentTxnidLeastBits = msgHasTxn ? msg.getMessageBuilder().getTxnidLeastBits() : -1L;
         }
         String key = getKey(msg);
         final BatchMessageContainerImpl batchMessageContainer = batches.computeIfAbsent(key,

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageKeyBasedContainer.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageKeyBasedContainer.java
@@ -46,6 +46,14 @@ class BatchMessageKeyBasedContainer extends AbstractBatchMessageContainer {
                     .attr("producerName", producer.getProducerName())
                     .attr("numMessagesInBatch", numMessagesInBatch)
                     .log("add message to batch");
+        if (numMessagesInBatch == 0) {
+            // The whole container shares one transaction identity; hasSameTxn keeps later messages consistent
+            // with it. Capturing it here rather than in hasSameTxn keeps that check side-effect free.
+            if (msg.getMessageBuilder().hasTxnidMostBits() && msg.getMessageBuilder().hasTxnidLeastBits()) {
+                currentTxnidMostBits = msg.getMessageBuilder().getTxnidMostBits();
+                currentTxnidLeastBits = msg.getMessageBuilder().getTxnidLeastBits();
+            }
+        }
         String key = getKey(msg);
         final BatchMessageContainerImpl batchMessageContainer = batches.computeIfAbsent(key,
                 __ -> new BatchMessageContainerImpl(producer));

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BatchMessageContainerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BatchMessageContainerImplTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import io.netty.buffer.ByteBufAllocator;
@@ -230,4 +231,84 @@ public class BatchMessageContainerImplTest {
         batchMessageContainer.clear();
         messages.forEach(ReferenceCountUtil::safeRelease);
     }
+
+    /**
+     * A batch carries one transaction id in its metadata, so every message in it inherits that transaction.
+     * Mixing a plain message into a transactional batch therefore silently enrolls it in the transaction: it
+     * stays invisible until commit and is dropped on abort, even though the application never sent it inside
+     * a transaction.
+     */
+    @Test
+    public void testPlainMessageIsNotBatchedWithTransactionalMessages() throws Exception {
+        BatchMessageContainerImpl container = new BatchMessageContainerImpl(createTestProducer());
+        container.add(newMessage(1L, 7L, 13L), null);
+
+        assertFalse(container.hasSameTxn(newMessage(2L, null, null)),
+                "a plain message was accepted into a transactional batch");
+    }
+
+    /**
+     * The mirror image: a transactional message joining a batch that already holds plain messages stamps its
+     * transaction id onto the whole batch, retroactively pulling those plain messages into the transaction.
+     */
+    @Test
+    public void testTransactionalMessageIsNotBatchedWithPlainMessages() throws Exception {
+        BatchMessageContainerImpl container = new BatchMessageContainerImpl(createTestProducer());
+        container.add(newMessage(1L, null, null), null);
+
+        assertFalse(container.hasSameTxn(newMessage(2L, 7L, 13L)),
+                "a transactional message was accepted into a plain batch");
+    }
+
+    /**
+     * Key-based batching fails the other way round: the guard reads the outer container's transaction state
+     * while the batch metadata is built by the per-key inner container, so a transactional message landing in
+     * a key bucket whose first message was plain is published with no transaction id at all — outside the
+     * transaction, and not rolled back on abort.
+     */
+    @Test
+    public void testKeyBasedContainerKeepsTransactionalAndPlainMessagesApart() throws Exception {
+        BatchMessageKeyBasedContainer container = new BatchMessageKeyBasedContainer();
+        container.setProducer(createTestProducer());
+        container.add(newMessage(1L, null, null), null);
+
+        assertFalse(container.hasSameTxn(newMessage(2L, 7L, 13L)),
+                "a transactional message was accepted into a plain key-based batch");
+    }
+
+    /** Messages of the same transaction must still batch together, and two different transactions must not. */
+    @Test
+    public void testSameTransactionStillBatchesTogether() throws Exception {
+        BatchMessageContainerImpl container = new BatchMessageContainerImpl(createTestProducer());
+        container.add(newMessage(1L, 7L, 13L), null);
+
+        assertTrue(container.hasSameTxn(newMessage(2L, 7L, 13L)),
+                "two messages of the same transaction were split across batches");
+        assertFalse(container.hasSameTxn(newMessage(3L, 7L, 14L)),
+                "messages of two different transactions were put in one batch");
+    }
+
+    /** Plain messages must still batch with each other. */
+    @Test
+    public void testPlainMessagesStillBatchTogether() throws Exception {
+        BatchMessageContainerImpl container = new BatchMessageContainerImpl(createTestProducer());
+        container.add(newMessage(1L, null, null), null);
+
+        assertTrue(container.hasSameTxn(newMessage(2L, null, null)),
+                "two plain messages were split across batches");
+    }
+
+    private static MessageImpl<byte[]> newMessage(long sequenceId, Long txnIdMostBits, Long txnIdLeastBits) {
+        MessageMetadata metadata = new MessageMetadata();
+        metadata.setSequenceId(sequenceId);
+        metadata.setProducerName("producer1");
+        metadata.setPublishTime(System.currentTimeMillis());
+        if (txnIdMostBits != null) {
+            metadata.setTxnidMostBits(txnIdMostBits);
+            metadata.setTxnidLeastBits(txnIdLeastBits);
+        }
+        ByteBuffer payload = ByteBuffer.wrap(("payload-" + sequenceId).getBytes(StandardCharsets.UTF_8));
+        return MessageImpl.create(metadata, payload, Schema.BYTES, null);
+    }
+
 }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BatchMessageContainerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BatchMessageContainerImplTest.java
@@ -20,7 +20,9 @@ package org.apache.pulsar.client.impl;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
@@ -241,10 +243,14 @@ public class BatchMessageContainerImplTest {
     @Test
     public void testPlainMessageIsNotBatchedWithTransactionalMessages() throws Exception {
         BatchMessageContainerImpl container = new BatchMessageContainerImpl(createTestProducer());
-        container.add(newMessage(1L, 7L, 13L), null);
+        try {
+            container.add(newMessage(1L, 7L, 13L), null);
 
-        assertFalse(container.hasSameTxn(newMessage(2L, null, null)),
-                "a plain message was accepted into a transactional batch");
+            assertFalse(container.hasSameTxn(newMessage(2L, null, null)),
+                    "a plain message was accepted into a transactional batch");
+        } finally {
+            container.discard(null);
+        }
     }
 
     /**
@@ -254,10 +260,14 @@ public class BatchMessageContainerImplTest {
     @Test
     public void testTransactionalMessageIsNotBatchedWithPlainMessages() throws Exception {
         BatchMessageContainerImpl container = new BatchMessageContainerImpl(createTestProducer());
-        container.add(newMessage(1L, null, null), null);
+        try {
+            container.add(newMessage(1L, null, null), null);
 
-        assertFalse(container.hasSameTxn(newMessage(2L, 7L, 13L)),
-                "a transactional message was accepted into a plain batch");
+            assertFalse(container.hasSameTxn(newMessage(2L, 7L, 13L)),
+                    "a transactional message was accepted into a plain batch");
+        } finally {
+            container.discard(null);
+        }
     }
 
     /**
@@ -270,32 +280,44 @@ public class BatchMessageContainerImplTest {
     public void testKeyBasedContainerKeepsTransactionalAndPlainMessagesApart() throws Exception {
         BatchMessageKeyBasedContainer container = new BatchMessageKeyBasedContainer();
         container.setProducer(createTestProducer());
-        container.add(newMessage(1L, null, null), null);
+        try {
+            container.add(newMessage(1L, null, null), null);
 
-        assertFalse(container.hasSameTxn(newMessage(2L, 7L, 13L)),
-                "a transactional message was accepted into a plain key-based batch");
+            assertFalse(container.hasSameTxn(newMessage(2L, 7L, 13L)),
+                    "a transactional message was accepted into a plain key-based batch");
+        } finally {
+            container.discard(null);
+        }
     }
 
     /** Messages of the same transaction must still batch together, and two different transactions must not. */
     @Test
     public void testSameTransactionStillBatchesTogether() throws Exception {
         BatchMessageContainerImpl container = new BatchMessageContainerImpl(createTestProducer());
-        container.add(newMessage(1L, 7L, 13L), null);
+        try {
+            container.add(newMessage(1L, 7L, 13L), null);
 
-        assertTrue(container.hasSameTxn(newMessage(2L, 7L, 13L)),
-                "two messages of the same transaction were split across batches");
-        assertFalse(container.hasSameTxn(newMessage(3L, 7L, 14L)),
-                "messages of two different transactions were put in one batch");
+            assertTrue(container.hasSameTxn(newMessage(2L, 7L, 13L)),
+                    "two messages of the same transaction were split across batches");
+            assertFalse(container.hasSameTxn(newMessage(3L, 7L, 14L)),
+                    "messages of two different transactions were put in one batch");
+        } finally {
+            container.discard(null);
+        }
     }
 
     /** Plain messages must still batch with each other. */
     @Test
     public void testPlainMessagesStillBatchTogether() throws Exception {
         BatchMessageContainerImpl container = new BatchMessageContainerImpl(createTestProducer());
-        container.add(newMessage(1L, null, null), null);
+        try {
+            container.add(newMessage(1L, null, null), null);
 
-        assertTrue(container.hasSameTxn(newMessage(2L, null, null)),
-                "two plain messages were split across batches");
+            assertTrue(container.hasSameTxn(newMessage(2L, null, null)),
+                    "two plain messages were split across batches");
+        } finally {
+            container.discard(null);
+        }
     }
 
     private static MessageImpl<byte[]> newMessage(long sequenceId, Long txnIdMostBits, Long txnIdLeastBits) {
@@ -309,6 +331,38 @@ public class BatchMessageContainerImplTest {
         }
         ByteBuffer payload = ByteBuffer.wrap(("payload-" + sequenceId).getBytes(StandardCharsets.UTF_8));
         return MessageImpl.create(metadata, payload, Schema.BYTES, null);
+    }
+
+    /**
+     * An inner batch whose first add fails to allocate clears itself and stays empty, so the outer container's
+     * message count is never incremented and the outer is not cleared either. Any transaction identity captured
+     * for that failed message must therefore not survive into the next first message, or a later message of that
+     * transaction would be admitted into a plain batch and published outside its transaction. Allocation failure
+     * is a recoverable path the client already handles.
+     */
+    @Test
+    public void testKeyBasedContainerDropsTheTransactionIdentityOfAFailedFirstAdd() throws Exception {
+        ProducerImpl<?> producer = createTestProducer();
+        MemoryLimitController memoryLimitController = producer.client.getMemoryLimitController();
+        // fail only the first inner-batch allocation
+        doThrow(new OutOfMemoryError("test")).doNothing()
+                .when(memoryLimitController).forceReserveMemory(anyLong());
+
+        BatchMessageKeyBasedContainer container = new BatchMessageKeyBasedContainer();
+        container.setProducer(producer);
+        try {
+            container.add(newMessage(1L, 7L, 13L), null);
+            assertEquals(container.getNumMessagesInBatch(), 0,
+                    "the failed add should have left the container empty");
+
+            container.add(newMessage(2L, null, null), null);
+
+            assertFalse(container.hasSameTxn(newMessage(3L, 7L, 13L)),
+                    "a transactional message was admitted into a plain batch through the transaction identity"
+                            + " left behind by a failed add");
+        } finally {
+            container.discard(null);
+        }
     }
 
 }


### PR DESCRIPTION
### Motivation

A batch carries a single transaction id in its metadata, so every message inside it inherits that
transaction — there is no per-message override:

```java
// BatchMessageContainerImpl.createOpSendMsg
if (currentTxnidMostBits != -1) {
    messageMetadata.setTxnidMostBits(currentTxnidMostBits);
}
```

`hasSameTxn`, the admission check meant to enforce that invariant, cannot express it:

```java
public boolean hasSameTxn(MessageImpl<?> msg) {
    if (!msg.getMessageBuilder().hasTxnidMostBits() || !msg.getMessageBuilder().hasTxnidLeastBits()) {
        return true;                                    // (1)
    }
    if (currentTxnidMostBits == -1 || currentTxnidLeastBits == -1) {
        currentTxnidMostBits = msg.getMessageBuilder().getTxnidMostBits();   // (2) mutates the batch
        currentTxnidLeastBits = msg.getMessageBuilder().getTxnidLeastBits();
        return true;
    }
    return currentTxnidMostBits == msg.getMessageBuilder().getTxnidMostBits()   // (3)
            && currentTxnidLeastBits == msg.getMessageBuilder().getTxnidLeastBits();
}
```

Branch (1) inspects only the message, never the batch, so a plain message is admitted into any batch
including a transactional one. Branch (2) performs a write inside a `hasSameXxx` query, and makes a
plain batch adopt the transaction of the first transactional message merely *offered* to it. Only
branch (3) actually compares, and it is reachable only when both sides carry a transaction. The check
can answer "are these two transactions the same?" but never "is one of them absent?".

Three consequences, all reachable from a single batching producer used for both `newMessage(txn)` and
`newMessage()` — legal API usage, with batching enabled by default:

1. A plain message batched after transactional ones inherits the transaction: it stays invisible until
   commit and is **silently discarded if the transaction aborts**, although the application never sent
   it inside a transaction.
2. A transactional message joining a batch that already holds plain messages stamps its transaction
   onto the whole batch, retroactively enrolling those plain messages in it.
3. The side effect in branch (2) also fires on the duplicate-sequence-id path in `ProducerImpl`:
   `canAddToCurrentBatch` adopts the transaction, and the caller then flushes the **current** batch via
   `doBatchSendAndAdd` and puts the new message into a fresh one — so a batch of plain messages is
   published stamped with a transaction that none of its messages belongs to.

`BatchMessageKeyBasedContainer` fails the other way round. The guard reads the outer container's
transaction state, while the batch metadata is built by the per-key inner container from *its own*
first message. A transactional message landing in a key bucket whose first message was plain is
therefore published with no transaction id at all — outside the transaction, and not rolled back when
it aborts.

For reference, the sibling admission check on the same line of `canAddToCurrentBatch` is already the
correct shape: `hasSameSchema` is a pure query that starts with `numMessagesInBatch == 0` and treats
"absent" as an identity that must match.

### Modifications

- `AbstractBatchMessageContainer.hasSameTxn` is now a pure query comparing transaction identities, with
  "no transaction" as an identity of its own that is incompatible with any transaction. An empty batch
  (`numMessagesInBatch == 0`) still accepts anything; testing the message count rather than the `-1`
  sentinel is what distinguishes "no identity yet" from "identity is *no transaction*". Adopting the
  identity is left solely to `add`, where it already happened — which also removes consequence 3 above.
- `BatchMessageKeyBasedContainer.add` captures the transaction id from the container's first message.
  This is required rather than cosmetic: with the side effect gone, the outer container's transaction
  state would otherwise stay unset forever, `batchHasTxn` would always be false, and plain messages
  would again be admitted into a transactional container.

Nothing changes at the call site. When the guard rejects a message, `ProducerImpl.doBatchSendAndAdd`
already flushes the current batch and opens a new one with that message, exactly as it does today when
the batch is full or the schema differs.

Applications that mix both kinds of send on one producer will see batches split more often. That is the
necessary cost: the two cannot share a batch without one of them inheriting the wrong transaction
identity. There is no wire format or API change, and no behaviour change for applications that do not
mix.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

  - *Added `BatchMessageContainerImplTest.testPlainMessageIsNotBatchedWithTransactionalMessages` and
    `...testTransactionalMessageIsNotBatchedWithPlainMessages`, covering both directions, and
    `...testKeyBasedContainerKeepsTransactionalAndPlainMessagesApart` for the key-based batcher. All
    three fail before the change.*
  - *Added `BatchMessageContainerImplTest.testSameTransactionStillBatchesTogether` and
    `...testPlainMessagesStillBatchTogether` as guards that messages of one transaction still share a
    batch, that two different transactions still do not, and that plain messages still batch together.*
  - *Added `TransactionProduceTest.testAbortedTransactionDoesNotDiscardPlainMessageBatchedWithIt`: a
    batching producer sends a transactional and a plain message into the same batch, the transaction is
    aborted, and the plain message must still be readable. It fails before the change with "the plain
    message was discarded by the aborted transaction".*
  - *`BatchMessageContainerImplTest` passes 9/9, the `pulsar-client` module suite shows no new failures,
    and `./gradlew quickCheck` is clean.*

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
