### PR TITLE
[fix][client] Stop tracking ack timeouts on non-persistent topics

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -254,9 +254,18 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
         }
     }
 
+    /**
+     * Whether unacknowledged messages should be tracked so that the ack timeout can redeliver them.
+     * Overridden by {@link ConsumerImpl} to exclude non-persistent topics, where the broker keeps nothing to
+     * replay and a timeout can therefore never produce a redelivery.
+     */
+    protected boolean isAckTimeoutTrackingEnabled() {
+        return conf.getAckTimeoutMillis() > 0;
+    }
+
     // if listener is not null, we will track unAcked msg in callMessageListener
     protected void trackUnAckedMsgIfNoListener(MessageId messageId, int redeliveryCount) {
-        if (listener == null) {
+        if (listener == null && isAckTimeoutTrackingEnabled()) {
             unAckedMessageTracker.add(messageId, redeliveryCount);
         }
     }
@@ -1286,7 +1295,9 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
             } else {
                 id = msg.getMessageId();
             }
-            unAckedMessageTracker.add(id, msg.getRedeliveryCount());
+            if (isAckTimeoutTrackingEnabled()) {
+                unAckedMessageTracker.add(id, msg.getRedeliveryCount());
+            }
             beforeConsume(msg);
             Optional<EncryptionContext> encryptionCtx = msg.getEncryptionCtx();
             if (decryptFailListener != null && encryptionCtx.isPresent() && encryptionCtx.get().isEncrypted()) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -399,6 +399,11 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         } else {
             this.acknowledgmentsGroupingTracker =
                     NonPersistentAcknowledgmentGroupingTracker.of();
+            if (conf.getAckTimeoutMillis() > 0) {
+                log.warn().attr("topic", topic).attr("ackTimeoutMillis", conf.getAckTimeoutMillis())
+                        .log("Ignoring the configured ack timeout: a non-persistent topic keeps nothing to"
+                                + " replay, so unacknowledged messages can never be redelivered");
+            }
         }
 
         if (conf.getDeadLetterPolicy() != null) {
@@ -1916,8 +1921,20 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
             trackMessage(messageId, 0);
     }
 
+    /**
+     * Never track on a non-persistent topic. The broker stores nothing to replay there, so an ack timeout can
+     * never produce a redelivery, and an ack does not clear the tracker either: the consumer installs
+     * {@link NonPersistentAcknowledgmentGroupingTracker}, whose {@code addAcknowledgment} is a no-op, while the
+     * tracker is only cleared from the persistent one. Tracking would therefore fill up even for an application
+     * that acks everything, and the resulting timeout clears the receive queue, destroying messages for good.
+     */
+    @Override
+    protected boolean isAckTimeoutTrackingEnabled() {
+        return super.isAckTimeoutTrackingEnabled() && topicName.isPersistent();
+    }
+
     protected void trackMessage(MessageId messageId, int redeliveryCount) {
-        if (conf.getAckTimeoutMillis() > 0 && messageId instanceof MessageIdImpl) {
+        if (isAckTimeoutTrackingEnabled() && messageId instanceof MessageIdImpl) {
             MessageId id = MessageIdAdvUtils.discardBatch(messageId);
             if (hasParentConsumer) {
                 //TODO: check parent consumer here
@@ -2101,7 +2118,9 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                         .log("Message delivery failed since unable to decrypt incoming message");
             }
             MessageId m = new MessageIdImpl(messageId.getLedgerId(), messageId.getEntryId(), partitionIndex);
-            unAckedMessageTracker.add(m, redeliveryCount);
+            if (isAckTimeoutTrackingEnabled()) {
+                unAckedMessageTracker.add(m, redeliveryCount);
+            }
             return DecryptResult.discard();
         default:
             log.warn("Invalid crypto failure state found, continue message consumption.");

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ZeroQueueConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ZeroQueueConsumerImpl.java
@@ -170,8 +170,10 @@ public class ZeroQueueConsumerImpl<T> extends ConsumerImpl<T> {
                             .log("Calling message listener for unqueued message");
                 waitingOnListenerForZeroQueueSize = true;
                 trackMessage(message);
-                unAckedMessageTracker.add(
-                        MessageIdAdvUtils.discardBatch(message.getMessageId()), message.getRedeliveryCount());
+                if (isAckTimeoutTrackingEnabled()) {
+                    unAckedMessageTracker.add(
+                            MessageIdAdvUtils.discardBatch(message.getMessageId()), message.getRedeliveryCount());
+                }
                 if (decryptFailListener != null
                         && message.getEncryptionCtx().isPresent()
                         && message.getEncryptionCtx().get().isEncrypted()

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerImplTest.java
@@ -48,6 +48,7 @@ import lombok.Cleanup;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageIdAdv;
+import org.apache.pulsar.client.api.MessageListener;
 import org.apache.pulsar.client.api.MessagePayload;
 import org.apache.pulsar.client.api.Messages;
 import org.apache.pulsar.client.api.PulsarClient;
@@ -82,6 +83,10 @@ public class ConsumerImplTest {
 
     @SuppressWarnings({"rawtypes", "unchecked"})
     private void createConsumer(ConsumerConfigurationData consumerConf) {
+        createConsumer(consumerConf, topic);
+    }
+
+    private void createConsumer(ConsumerConfigurationData consumerConf, String topicName) {
         executorProvider = new ExecutorProvider(1, "ConsumerImplTest");
         internalExecutor = Executors.newSingleThreadScheduledExecutor();
 
@@ -92,7 +97,7 @@ public class ConsumerImplTest {
         CompletableFuture<Consumer<byte[]>> subscribeFuture = new CompletableFuture<>();
 
         consumerConf.setSubscriptionName("test-sub");
-        consumer = ConsumerImpl.newConsumerImpl(client, topic, consumerConf,
+        consumer = ConsumerImpl.newConsumerImpl(client, topicName, consumerConf,
                 executorProvider, -1, false, subscribeFuture, null, null, null,
                 true);
         consumer.setState(HandlerState.State.Ready);
@@ -398,4 +403,69 @@ public class ConsumerImplTest {
             context.recycle();
         }
     }
+
+    /**
+     * On a non-persistent topic the broker keeps nothing to replay, so an ack timeout can never lead to a
+     * redelivery: {@code NonPersistentSubscription.redeliverUnacknowledgedMessages} is a no-op. Tracking
+     * messages anyway is worse than useless, because acks do not clear the tracker either — the consumer
+     * installs {@code NonPersistentAcknowledgmentGroupingTracker}, whose {@code addAcknowledgment} is a no-op,
+     * and the tracker is only cleared from the persistent one. The tracker therefore fills up even for an
+     * application that acks every message, and once it times out the consumer clears its receive queue,
+     * destroying messages that nothing can replay.
+     */
+    @Test
+    public void testMessagesAreNotTrackedForAckTimeoutOnNonPersistentTopic() {
+        ConsumerConfigurationData<byte[]> conf = new ConsumerConfigurationData<>();
+        conf.setAckTimeoutMillis(TimeUnit.SECONDS.toMillis(10));
+        createConsumer(conf, "non-persistent://tenant/ns1/ack-timeout-topic");
+
+        consumer.trackMessage(new MessageIdImpl(1L, 1L, -1), 0);
+
+        Assert.assertTrue(consumer.getUnAckedMessageTracker().isEmpty(),
+                "a message was tracked for ack timeout on a non-persistent topic, where an ack never clears"
+                        + " the tracker and a redelivery can never happen");
+    }
+
+    /** The same configuration must keep working on a persistent topic, where redelivery is possible. */
+    @Test
+    public void testMessagesAreStillTrackedForAckTimeoutOnPersistentTopic() {
+        ConsumerConfigurationData<byte[]> conf = new ConsumerConfigurationData<>();
+        conf.setAckTimeoutMillis(TimeUnit.SECONDS.toMillis(10));
+        createConsumer(conf, "persistent://tenant/ns1/ack-timeout-topic");
+
+        consumer.trackMessage(new MessageIdImpl(1L, 1L, -1), 0);
+
+        Assert.assertFalse(consumer.getUnAckedMessageTracker().isEmpty(),
+                "messages are no longer tracked for ack timeout on a persistent topic");
+    }
+
+    /**
+     * The listener dispatch path adds to the tracker itself, bypassing {@code trackMessage} entirely
+     * ({@code trackUnAckedMsgIfNoListener} only adds when no listener is set). Consumers with a
+     * {@code messageListener} are the common case, so this path must honour the same rule.
+     */
+    @Test
+    public void testMessagesAreNotTrackedForAckTimeoutOnNonPersistentTopicWithListener() {
+        ConsumerConfigurationData<byte[]> conf = new ConsumerConfigurationData<>();
+        conf.setAckTimeoutMillis(TimeUnit.SECONDS.toMillis(10));
+        conf.setMessageListener((MessageListener<byte[]>) (c, msg) -> { });
+        createConsumer(conf, "non-persistent://tenant/ns1/ack-timeout-listener-topic");
+
+        Assert.assertFalse(consumer.isAckTimeoutTrackingEnabled(),
+                "ack timeout tracking is still enabled on a non-persistent topic, so the listener dispatch path"
+                        + " would keep filling the tracker");
+    }
+
+    /** On a persistent topic the listener path must keep tracking. */
+    @Test
+    public void testMessagesAreStillTrackedForAckTimeoutOnPersistentTopicWithListener() {
+        ConsumerConfigurationData<byte[]> conf = new ConsumerConfigurationData<>();
+        conf.setAckTimeoutMillis(TimeUnit.SECONDS.toMillis(10));
+        conf.setMessageListener((MessageListener<byte[]>) (c, msg) -> { });
+        createConsumer(conf, "persistent://tenant/ns1/ack-timeout-listener-topic");
+
+        Assert.assertTrue(consumer.isAckTimeoutTrackingEnabled(),
+                "ack timeout tracking was disabled on a persistent topic");
+    }
+
 }


### PR DESCRIPTION
### Motivation

A consumer on a non-persistent topic tracks messages for the ack timeout but never removes them again, so
an application that acks everything still loses messages once per ack-timeout period.

The consumer picks its ack grouping tracker by topic type (`ConsumerImpl`), and the non-persistent one is a
stateless singleton whose methods are all no-ops:

```java
// NonPersistentAcknowledgmentGroupingTracker
public CompletableFuture<Void> addAcknowledgment(MessageId msgId, AckType ackType, Map<String, Long> properties) {
    // no-op
    return CompletableFuture.completedFuture(null);
}
```

That is where a non-transactional ack ends up — `ConsumerImpl.doAcknowledge` returns
`acknowledgmentsGroupingTracker.addAcknowledgment(...)`. But clearing the un-acked message tracker only
happens inside the *persistent* implementation:

```java
// PersistentAcknowledgmentsGroupingTracker.addIndividualAcknowledgment
consumer.getUnAckedMessageTracker().remove(msgId);
```

The write side, meanwhile, never looked at the topic type: `trackMessage` only checked
`conf.getAckTimeoutMillis() > 0`, and `ConsumerBuilder.ackTimeout(...)` only validates the minimum value.
Entries therefore go in and never come out.

When the timeout fires, `ConsumerImpl.redeliverUnacknowledgedMessages` clears the receive queue for
Exclusive and Failover subscriptions:

```java
currentSize = incomingMessages.size();
clearIncomingMessages();
unAckedMessageTracker.clear();
```

and then asks the broker to redeliver — which on a non-persistent topic does nothing at all:

```java
// NonPersistentSubscription
public synchronized void redeliverUnacknowledgedMessages(Consumer consumer, long consumerEpoch) {
 // No-op
}
```

The broker keeps nothing to replay, so the messages that were sitting in the receive queue are gone. This
needs only `ackTimeout` to be configured on a non-persistent topic; nothing warns about it.

### Modifications

Rather than teach the non-persistent grouping tracker to clean up, this stops the tracking altogether:
an ack timeout on a non-persistent topic can never lead to a redelivery, so the tracking has no purpose
and the timeout it drives is purely destructive.

- `ConsumerBase.isAckTimeoutTrackingEnabled()` is a new overridable predicate, and `ConsumerImpl` overrides
  it to also require a persistent topic.
- Every write into the un-acked tracker owned by `ConsumerImpl` now consults it. There are four, and three of
  them bypass `trackMessage` entirely: the message-listener dispatch in `ConsumerBase.callMessageListener`
  (`trackUnAckedMsgIfNoListener` adds only when no listener is set, so listener-based consumers — the common
  case — take this path instead), the decryption-failure path in `ConsumerImpl`, and `ZeroQueueConsumerImpl`.
- `ConsumerImpl` logs a warning at subscribe time when `ackTimeout` is set on a non-persistent topic, so the
  option is not silently ignored.

`MultiTopicsConsumerImpl` is deliberately left alone: its `doAcknowledge` calls
`unAckedMessageTracker.remove(messageId)` itself for individual acks rather than relying on the grouping
tracker, so its parent tracker is cleaned regardless of topic type.

Two things checked and found not to need a change: the dead-letter candidate map is written only when
`redeliveryCount >= maxRedeliverCount`, and `redeliveryCount` stays 0 on a non-persistent topic while
`ConsumerBuilderImpl` requires `maxRedeliverCount > 0`, so it is never populated there; and no test in the
repository asserts ack-timeout redelivery on a non-persistent topic, consistent with the broker-side no-op.

Known residual, not addressed here: on a non-persistent *partitioned* topic the parent
`MultiTopicsConsumerImpl` still tracks. Individual acks clean it, so nothing accumulates, but a genuinely
un-acked backlog would still time out and clear the receive queue. Covering that needs a per-message
decision, because one multi-topic consumer can span both topic types.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

  - *Added `ConsumerImplTest.testMessagesAreNotTrackedForAckTimeoutOnNonPersistentTopic`: with `ackTimeout`
    set on a non-persistent topic, delivering a message must leave the un-acked tracker empty. It fails
    before the change.*
  - *Added `ConsumerImplTest.testMessagesAreStillTrackedForAckTimeoutOnPersistentTopic` as the control: the
    same configuration must keep tracking on a persistent topic.*
  - *Added four further cases pinning the shared predicate for the paths that bypass `trackMessage` — the
    listener path on both topic types, and the zero-queue consumer.*
  - *`ConsumerImplTest` passes 21/21; the `pulsar-client` module suite (470 tests),
    `PatternTopicsConsumerImplTest` (24) and `NonPersistentTopicTest` (5) show no new failures, and
    `./gradlew quickCheck` is clean.*

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

`ackTimeout` is now ignored on non-persistent topics, where it could never produce a redelivery. The change
is behavioural rather than configurational: the setting is still accepted, and a warning is logged.
