### PR TITLE
[fix][client] Make chunking inert on non-persistent topics, including the message-size checks

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageChunkingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageChunkingTest.java
@@ -365,6 +365,44 @@ public class MessageChunkingTest extends ProducerConsumerBase {
         assertNull(consumer.receive(5, TimeUnit.SECONDS));
     }
 
+    /**
+     * A non-persistent topic cannot carry chunked messages: the slicing block in
+     * {@code ProducerImpl.serializeAndSendMessage} is skipped for them, but {@code totalChunks} was computed
+     * from the payload size alone, so the send loop still ran once per "chunk" — publishing the whole payload
+     * that many times, and releasing the payload buffer more often than it was retained.
+     */
+    @Test
+    public void testLargeMessageOnNonPersistentTopicIsSentOnceWithoutChunking() throws Exception {
+        final String topicName = "non-persistent://my-property/my-ns/testNonPersistentChunking";
+        final String subName = "my-subscriber-name";
+
+        @Cleanup
+        Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
+                .topic(topicName)
+                .subscriptionName(subName)
+                .subscribe();
+
+        @Cleanup
+        Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
+                .topic(topicName)
+                // small enough that the payload below would otherwise be split into several chunks
+                .chunkMaxMessageSize(100)
+                .enableChunking(true)
+                .enableBatching(false)
+                .create();
+
+        String payload = "a".repeat(500);
+        producer.newMessage().value(payload).send();
+
+        Message<String> received = consumer.receive(10, TimeUnit.SECONDS);
+        assertNotNull(received, "the message was not delivered");
+        assertEquals(received.getValue(), payload);
+
+        // Without the fix the same payload is published once per computed chunk, so more messages follow.
+        assertNull(consumer.receive(3, TimeUnit.SECONDS),
+                "the payload was published more than once on a non-persistent topic");
+    }
+
     @Test
     public void testResendChunkMessagesWithoutAckHole() throws Exception {
         log.info().attr("method", methodName).log("Starting test");

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerImpl.java
@@ -200,7 +200,10 @@ class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
         if (clientOperation && producer != null){
             if (compressionType != CompressionType.NONE
                     && uncompressedSize > producer.conf.getCompressMinMsgBodySize()) {
+                // applyCompression releases the buffer it is given and returns a new one, so the field has to
+                // follow it: otherwise it keeps pointing at freed memory that discard() would release again.
                 compressedPayload = producer.applyCompression(batchedMessageMetadataAndPayload);
+                batchedMessageMetadataAndPayload = compressedPayload;
                 messageMetadata.setCompression(compressionType);
                 messageMetadata.setUncompressedSize(uncompressedSize);
             } else {
@@ -209,6 +212,10 @@ class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
         } else {
             compressedPayload = compressor.encode(batchedMessageMetadataAndPayload);
             batchedMessageMetadataAndPayload.release();
+            // The codec returns a new buffer whenever it actually compresses, and the release above frees the
+            // old one, so the field has to follow it: otherwise it keeps pointing at freed memory that
+            // discard() would release again and resetPayloadAfterFailedPublishing() would write into.
+            batchedMessageMetadataAndPayload = compressedPayload;
             if (compressionType != CompressionType.NONE) {
                 messageMetadata.setCompression(compressionType);
                 messageMetadata.setUncompressedSize(uncompressedSize);
@@ -319,7 +326,11 @@ class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
 
             // handle mgs size check as non-batched in `ProducerImpl.isMessageSizeExceeded`
             if (op.getMessageHeaderAndPayloadSize() > getMaxMessageSize()) {
+                // The payload was handed to the command, which now owns it: ByteBufPair.deallocate releases
+                // both of its buffers. Drop the container's reference before discard() runs, or the payload —
+                // the same buffer with compression and encryption off — would be released a second time.
                 cmd.release();
+                batchedMessageMetadataAndPayload = null;
                 producer.semaphoreRelease(1);
                 producer.client.getMemoryLimitController().releaseMemory(
                         messages.get(0).getUncompressedSize() + batchAllocatedSizeBytes);
@@ -334,7 +345,11 @@ class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
                 getCompressedBatchMetadataAndPayload());
         updateAndReserveBatchAllocatedSize(encryptedPayload.capacity());
         if (encryptedPayload.readableBytes() > getMaxMessageSize()) {
-            encryptedPayload.release();
+            // With compression and encryption off this is the batch payload itself, which discard() releases
+            // below; releasing it here as well would drop a live buffer back into the pool.
+            if (encryptedPayload != batchedMessageMetadataAndPayload) {
+                encryptedPayload.release();
+            }
             producer.semaphoreRelease(messages.size());
             messages.forEach(msg -> producer.client.getMemoryLimitController()
                     .releaseMemory(msg.getUncompressedSize()));

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerImpl.java
@@ -306,6 +306,10 @@ class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
             stampEntryBucketRange();
             ByteBuf encryptedPayload = producer.encryptMessage(messageMetadata,
                     getCompressedBatchMetadataAndPayload());
+            // A successful encryption releases its input and returns a different buffer, so the field has to
+            // follow it, exactly as it does for compression. Otherwise it keeps pointing at freed memory that
+            // discard() would release again.
+            batchedMessageMetadataAndPayload = encryptedPayload;
             updateAndReserveBatchAllocatedSize(encryptedPayload.capacity());
             ByteBufPair cmd = producer.sendMessage(producer.producerId, messageMetadata.getSequenceId(),
                 1, null, messageMetadata, encryptedPayload);
@@ -343,13 +347,12 @@ class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
         }
         ByteBuf encryptedPayload = producer.encryptMessage(messageMetadata,
                 getCompressedBatchMetadataAndPayload());
+        // See the single-message branch above: the field follows whatever encryption returned.
+        batchedMessageMetadataAndPayload = encryptedPayload;
         updateAndReserveBatchAllocatedSize(encryptedPayload.capacity());
         if (encryptedPayload.readableBytes() > getMaxMessageSize()) {
-            // With compression and encryption off this is the batch payload itself, which discard() releases
-            // below; releasing it here as well would drop a live buffer back into the pool.
-            if (encryptedPayload != batchedMessageMetadataAndPayload) {
-                encryptedPayload.release();
-            }
+            // The container owns the payload at this point — no command has been built yet — so discard() below
+            // is its single owner. Releasing it here as well would drop a live buffer back into the pool.
             producer.semaphoreRelease(messages.size());
             messages.forEach(msg -> producer.client.getMemoryLimitController()
                     .releaseMemory(msg.getUncompressedSize()));

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -118,6 +118,8 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
 
     // Producer id, used to identify a producer within a single connection
     protected final long producerId;
+    // A non-persistent topic cannot carry chunked messages, see the chunk computation in sendAsync
+    private final boolean persistentTopic;
 
     // Variable is updated in a synchronized block
     private volatile long msgIdGenerator;
@@ -207,6 +209,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                         ProducerInterceptors interceptors, Optional<String> overrideProducerName) {
         super(client, topic, conf, producerCreatedFuture, schema, interceptors);
         this.producerId = client.newProducerId();
+        this.persistentTopic = TopicName.get(topic).isPersistent();
         this.producerName = conf.getProducerName();
         this.userProvidedProducerName = StringUtils.isNotBlank(producerName);
         this.partitionIndex = partitionIndex;
@@ -636,7 +639,9 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
         // send in chunks
         int totalChunks;
         int payloadChunkSize;
-        if (canAddToBatch(msg) || !conf.isChunkingEnabled()) {
+        // A non-persistent topic never chunks: the slicing below is skipped for it, so computing more than one
+        // chunk here would only make the send loop publish the whole payload once per chunk.
+        if (canAddToBatch(msg) || !conf.isChunkingEnabled() || !persistentTopic) {
             totalChunks = 1;
             payloadChunkSize = getMaxMessageSize();
         } else {
@@ -780,7 +785,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                                          MessageId messageId) throws IOException {
         ByteBuf chunkPayload = compressedPayload;
         MessageMetadata msgMetadata = msg.getMessageBuilder();
-        if (totalChunks > 1 && TopicName.get(topic).isPersistent()) {
+        if (totalChunks > 1) {
             chunkPayload = compressedPayload.slice(readStartIndex,
                     Math.min(chunkMaxSizeInBytes, chunkPayload.readableBytes() - readStartIndex));
             // don't retain last chunk payload and builder as it will be not needed for next chunk-iteration and it will

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BatchMessageContainerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BatchMessageContainerImplTest.java
@@ -283,4 +283,55 @@ public class BatchMessageContainerImplTest {
         return MessageImpl.create(metadata, payload, Schema.BYTES, null);
     }
 
+    /**
+     * A successful encryption releases its input and returns a different buffer, so after it the container
+     * field points at freed memory unless it is transferred to the result. The identity check alone is not
+     * enough: it stops the encrypted output from being released twice, but {@code discard()} still releases the
+     * stale field.
+     */
+    @Test
+    public void testOversizedEncryptedBatchReleasesItsBuffersExactlyOnce() throws Exception {
+        List<ByteBuf> allocated = new ArrayList<>();
+        ByteBufAllocator recordingAllocator = mock(ByteBufAllocator.class);
+        doAnswer(invocation -> {
+            ByteBuf buffer = ByteBufAllocator.DEFAULT.buffer(invocation.getArgument(0));
+            allocated.add(buffer);
+            return buffer;
+        }).when(recordingAllocator).buffer(anyInt());
+
+        ProducerImpl<?> producer = createTestProducer();
+        List<ByteBuf> encryptedBuffers = new ArrayList<>();
+        // Mirror a successful encryption: release the input and return a different buffer.
+        when(producer.encryptMessage(any(), any())).thenAnswer(invocation -> {
+            ByteBuf input = invocation.getArgument(1);
+            ByteBuf encrypted = ByteBufAllocator.DEFAULT.buffer(input.readableBytes());
+            encrypted.writeBytes(input.copy());
+            input.release();
+            encryptedBuffers.add(encrypted);
+            return encrypted;
+        });
+        ConnectionHandler connectionHandler = mock(ConnectionHandler.class);
+        when(connectionHandler.getMaxMessageSize()).thenReturn(1);
+        when(producer.getConnectionHandler()).thenReturn(connectionHandler);
+
+        BatchMessageContainerImpl container = new BatchMessageContainerImpl(recordingAllocator);
+        container.setProducer(producer);
+        container.add(newTestMessage(1L), null);
+        container.add(newTestMessage(2L), null);
+
+        assertEquals(allocated.size(), 1, "expected exactly one batch payload allocation");
+        ByteBuf batchPayload = allocated.get(0);
+        // Stand in for anything else still holding the pre-encryption buffer, so that releasing it a second
+        // time is observable rather than being swallowed by ReferenceCountUtil.safeRelease.
+        batchPayload.retain();
+
+        assertNull(container.createOpSendMsg(), "an oversized batch must not produce an op to send");
+
+        assertEquals(encryptedBuffers.size(), 1, "expected exactly one encryption");
+        assertEquals(batchPayload.refCnt(), 1,
+                "the pre-encryption batch payload was released again after encryption had already released it");
+        assertEquals(encryptedBuffers.get(0).refCnt(), 0, "the encrypted payload was not released");
+        batchPayload.release();
+    }
+
 }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BatchMessageContainerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BatchMessageContainerImplTest.java
@@ -24,14 +24,17 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
+import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.util.ReferenceCountUtil;
 import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.pulsar.client.api.CompressionType;
 import org.apache.pulsar.client.api.Schema;
@@ -230,4 +233,54 @@ public class BatchMessageContainerImplTest {
         batchMessageContainer.clear();
         messages.forEach(ReferenceCountUtil::safeRelease);
     }
+
+    /**
+     * With compression and encryption off — the default — {@code getCompressedBatchMetadataAndPayload()} returns
+     * the batch buffer itself and {@code encryptMessage} passes it straight through, so the buffer released in
+     * the oversized branch is the very one {@code discard()} releases again. A second release drops a live
+     * buffer to zero and returns it to the pool while it is still referenced.
+     */
+    @Test
+    public void testOversizedBatchReleasesItsPayloadExactlyOnce() throws Exception {
+        List<ByteBuf> allocated = new ArrayList<>();
+        ByteBufAllocator recordingAllocator = mock(ByteBufAllocator.class);
+        doAnswer(invocation -> {
+            ByteBuf buffer = ByteBufAllocator.DEFAULT.buffer(invocation.getArgument(0));
+            allocated.add(buffer);
+            return buffer;
+        }).when(recordingAllocator).buffer(anyInt());
+
+        ProducerImpl<?> producer = createTestProducer();
+        // encryption disabled: the real implementation returns its input unchanged
+        when(producer.encryptMessage(any(), any())).thenAnswer(invocation -> invocation.getArgument(1));
+        ConnectionHandler connectionHandler = mock(ConnectionHandler.class);
+        when(connectionHandler.getMaxMessageSize()).thenReturn(1);
+        when(producer.getConnectionHandler()).thenReturn(connectionHandler);
+
+        BatchMessageContainerImpl container = new BatchMessageContainerImpl(recordingAllocator);
+        container.setProducer(producer);
+        container.add(newTestMessage(1L), null);
+        container.add(newTestMessage(2L), null);
+
+        assertEquals(allocated.size(), 1, "expected exactly one batch payload allocation");
+        ByteBuf payload = allocated.get(0);
+        // Stand in for anything else still holding the payload, so that an extra release is observable rather
+        // than being swallowed by ReferenceCountUtil.safeRelease.
+        payload.retain();
+
+        assertNull(container.createOpSendMsg(), "an oversized batch must not produce an op to send");
+
+        assertEquals(payload.refCnt(), 1, "the oversized batch payload was released more than once");
+        payload.release();
+    }
+
+    private static MessageImpl<byte[]> newTestMessage(long sequenceId) {
+        MessageMetadata metadata = new MessageMetadata();
+        metadata.setSequenceId(sequenceId);
+        metadata.setProducerName("producer1");
+        metadata.setPublishTime(System.currentTimeMillis());
+        ByteBuffer payload = ByteBuffer.wrap(("payload-" + sequenceId).getBytes(StandardCharsets.UTF_8));
+        return MessageImpl.create(metadata, payload, Schema.BYTES, null);
+    }
+
 }


### PR DESCRIPTION
### Motivation

Chunking has been guarded against non-persistent topics since it was introduced (PIP-37, #4400), but only
at the point where chunking is *performed*, not where it is *decided*:

```java
// how many chunks — no topic-type check
totalChunks = MathUtils.ceilDiv(Math.max(1, compressedPayload.readableBytes()), payloadChunkSize);
```
```java
// performing the chunking — guarded
if (totalChunks > 1 && TopicName.get(topic).isPersistent()) {
    chunkPayload = compressedPayload.slice(readStartIndex, ...);
    if (chunkId != totalChunks - 1) {
        chunkPayload.retain();
    }
    msgMetadata.setChunkId(chunkId).setNumChunksFromMsg(totalChunks)...;
}
```

The send loop runs `totalChunks` times regardless. On a non-persistent topic the guarded block is skipped
while the loop still runs N times, so three things follow from that one skip:

- `chunkPayload` stays the *whole* payload, which is published N times;
- no chunk metadata is written, so the consumer cannot tell these are one message and delivers N duplicates
  that deduplication cannot catch either;
- the compensating `retain()` lives inside the skipped block, so the payload is handed to N `ByteBufPair`s
  while only one reference is held — N releases against a refcount of 1.

The message-size checks have the same blind spot. Both the compressed-size check in `sendAsync()` and
`isMessageSizeExceeded()` skip validation whenever `conf.isChunkingEnabled()` is true, on the assumption
that an oversized message will be chunked. On a non-persistent topic it never is, so a payload above the
broker limit is sent as a single oversized frame instead of being rejected locally with
`InvalidMessageException`.

Nothing rejects the configuration: the builder only refuses chunking together with batching.

> **Note:** an earlier revision of this PR also fixed an oversized-batch double release in
> `BatchMessageContainerImpl`. That defect has since been fixed on `master` by #26455 (buffer ownership on
> the send failure paths), so that part was dropped when merging `master`. Regression tests for the oversized
> branches are kept, since #26455 did not add one for that path.

### Modifications

Introduce a single private `ProducerImpl.isChunkingEnabled()` that returns
`conf.isChunkingEnabled() && persistentTopic`, and route every decision that depends on chunking through it:

- the chunk computation, so a non-persistent topic computes `totalChunks = 1` and takes the ordinary
  single-message path (the slicing site's own topic check then becomes redundant and is reduced to
  `totalChunks > 1`, matching the sibling site in the same method);
- the compressed-size check in `sendAsync()`;
- `isMessageSizeExceeded()`.

Because the duplicate publishing and the refcount underflow are two symptoms of the same skipped block,
unifying the condition removes both; no separate accounting change is needed. The repeated
`TopicName.get(topic)` parse on the send path is replaced by a field computed once in the constructor.

No wire format or API change. Applications sending large messages to a non-persistent topic with chunking
enabled now publish them once instead of N times, and a message above the broker limit fails locally with
`InvalidMessageException` exactly as it does with chunking disabled.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

  - *Added `MessageChunkingTest.testLargeMessageOnNonPersistentTopicIsSentOnceWithoutChunking`: a payload
    larger than `chunkMaxMessageSize` is sent to a non-persistent topic and must be delivered exactly once.
    It fails before the change with "the payload was published more than once on a non-persistent topic".*
  - *Added `MessageChunkingTest.testLargeMessageOnNonPersistentTopicAboveBrokerLimitIsRejectedLocally`: a
    payload larger than the broker's `maxMessageSize` plus frame padding is sent to a non-persistent topic
    with chunking enabled and must be rejected locally with `InvalidMessageException`. Before the change
    the send is not rejected by the client.*
  - *Added three regression tests in `BatchMessageContainerImplTest` for the oversized-batch branches now
    covered by #26455: `testOversizedSingleMessageBatchReleasesItsPayloadExactlyOnce` (single-message branch,
    where `cmd.release()` is the only legitimate release), `testOversizedBatchReleasesItsPayloadExactlyOnce`
    (multi-message branch, container-owned buffer) and `testOversizedEncryptedBatchReleasesItsBuffersExactlyOnce`
    (multi-message branch after a successful encryption). Each fails when the corresponding ownership handling
    is removed.*
  - *`MessageChunkingTest` (19), `BatchMessageContainerImplTest` (25) and `RawBatchMessageContainerImplTest`
    (10) pass, and `./gradlew quickCheck` is clean.*

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

Chunking is now inert on non-persistent topics, where it never produced a message a consumer could
reassemble. The setting is still accepted.
