### PR TITLE
[fix][broker] Fix multi-role authorization regressions and optimize nested checks

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationDataAnonymous.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationDataAnonymous.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.authentication;
+
+/**
+ * Authentication data for an anonymous client.
+ */
+public final class AuthenticationDataAnonymous implements AuthenticationDataSource {
+    public static final AuthenticationDataAnonymous INSTANCE = new AuthenticationDataAnonymous();
+
+    private AuthenticationDataAnonymous() {
+    }
+}

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationDataForwarded.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationDataForwarded.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.authentication;
+
+/**
+ * Authentication data for a forwarded principal without authenticated original credentials.
+ */
+public final class AuthenticationDataForwarded implements AuthenticationDataSource {
+    public static final AuthenticationDataForwarded INSTANCE = new AuthenticationDataForwarded();
+
+    private AuthenticationDataForwarded() {
+    }
+}

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationService.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationService.java
@@ -156,7 +156,7 @@ public class AuthenticationService implements Closeable {
             if (!providers.isEmpty()) {
                 if (StringUtils.isNotBlank(anonymousUserRole)) {
                     request.setAttribute(AuthenticatedRoleAttributeName, anonymousUserRole);
-                    request.setAttribute(AuthenticatedDataAttributeName, new AuthenticationDataHttps(request));
+                    request.setAttribute(AuthenticatedDataAttributeName, AuthenticationDataAnonymous.INSTANCE);
                     return true;
                 }
                 // If at least a provider was configured, then the authentication needs to be provider

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/MultiRolesTokenAuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/MultiRolesTokenAuthorizationProvider.java
@@ -26,15 +26,17 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import lombok.CustomLog;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.authentication.AuthenticationDataAnonymous;
+import org.apache.pulsar.broker.authentication.AuthenticationDataForwarded;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSubscription;
 import org.apache.pulsar.broker.authentication.AuthenticationProvider;
 import org.apache.pulsar.broker.authentication.TokenAuthenticationProvider;
-import org.apache.pulsar.broker.resources.PulsarResources;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.NamespaceOperation;
@@ -69,12 +71,6 @@ public class MultiRolesTokenAuthorizationProvider extends PulsarAuthorizationPro
     private String roleClaim = DEFAULT_ROLE_CLAIM;
     private TokenAuthenticationProvider authenticationProvider;
 
-    @Deprecated
-    @Override
-    public void initialize(ServiceConfiguration conf, PulsarResources pulsarResources) throws IOException {
-        initialize(new InitialContext(conf, pulsarResources, null));
-    }
-
     @Override
     public void initialize(InitialContext context) throws IOException {
         ServiceConfiguration conf = context.config();
@@ -88,14 +84,18 @@ public class MultiRolesTokenAuthorizationProvider extends PulsarAuthorizationPro
             this.roleClaim = (String) tokenAuthClaim;
         }
 
-        if (!conf.isAuthenticationEnabled()) {
-            throw new IOException("MultiRolesTokenAuthorizationProvider requires authenticationEnabled=true");
-        }
         // Token and OpenID share the "token" method; the service returns their AuthenticationProviderList
         // when both are configured.
         AuthenticationProvider sharedProvider = context.authenticationService() == null ? null
                 : context.authenticationService()
                         .getAuthenticationProvider(TokenAuthenticationProvider.AUTH_METHOD_NAME);
+        if (!conf.isAuthorizationEnabled() && !(sharedProvider instanceof TokenAuthenticationProvider)) {
+            super.initialize(context);
+            return;
+        }
+        if (!conf.isAuthenticationEnabled()) {
+            throw new IOException("MultiRolesTokenAuthorizationProvider requires authenticationEnabled=true");
+        }
         if (!(sharedProvider instanceof TokenAuthenticationProvider tokenProvider)) {
             throw new IOException("MultiRolesTokenAuthorizationProvider requires an initialized token authentication "
                     + "provider in AuthorizationProvider.InitialContext");
@@ -170,24 +170,39 @@ public class MultiRolesTokenAuthorizationProvider extends PulsarAuthorizationPro
     }
 
     private CompletableFuture<Set<String>> getRolesAsync(String role, AuthenticationDataSource authData) {
-        if (authData == null || (authData instanceof AuthenticationDataSubscription subscription
-                && subscription.getAuthData() == null)) {
+        AuthenticationDataSource roleData = authData;
+        // Subscription wrappers must preserve principal-only and already-resolved role contexts.
+        while (roleData instanceof AuthenticationDataSubscription subscription
+                && !(roleData instanceof RoleAuthenticationData)) {
+            roleData = subscription.getAuthData();
+        }
+        if (roleData instanceof RoleAuthenticationData resolved) {
+            return CompletableFuture.completedFuture(Collections.singleton(resolved.role));
+        }
+        if (roleData == null || roleData instanceof AuthenticationDataAnonymous
+                || roleData instanceof AuthenticationDataForwarded) {
             return CompletableFuture.completedFuture(
                     role == null ? Collections.emptySet() : Collections.singleton(role));
         }
         try {
             return authenticationProvider.authenticateRolesAsync(authData, roleClaim)
                     .exceptionally(error -> {
-                        log.debug().log("Unable to extract additional roles from JWT token");
+                        log.debug().exception(error).log("Unable to extract additional roles from JWT token");
                         return Collections.emptySet();
                     });
         } catch (RuntimeException e) {
+            log.debug().exception(e).log("Unable to extract additional roles from JWT token");
             return CompletableFuture.completedFuture(Collections.emptySet());
         }
     }
 
     public CompletableFuture<Boolean> authorize(String role, AuthenticationDataSource authenticationData,
                                                 Function<String, CompletableFuture<Boolean>> authorizeFunc) {
+        return authorize(role, authenticationData, (resolvedRole, data) -> authorizeFunc.apply(resolvedRole));
+    }
+
+    private CompletableFuture<Boolean> authorize(String role, AuthenticationDataSource authenticationData,
+            BiFunction<String, AuthenticationDataSource, CompletableFuture<Boolean>> authorizeFunc) {
         if (role != null && conf.getSuperUserRoles().contains(role)) {
             return CompletableFuture.completedFuture(true);
         }
@@ -201,9 +216,12 @@ public class MultiRolesTokenAuthorizationProvider extends PulsarAuthorizationPro
                     }
                     List<CompletableFuture<Boolean>> futures = new ArrayList<>(roles.size());
                     if (roles.size() == 1) {
-                        roles.forEach(r -> futures.add(authorizeFunc.apply(r)));
+                        roles.forEach(r -> futures.add(
+                                authorizeFunc.apply(r, new RoleAuthenticationData(authenticationData, r))));
                     } else {
-                        roles.forEach(r -> futures.add(authorizeFunc.apply(r).exceptionally(ex -> false)));
+                        roles.forEach(r -> futures.add(
+                                authorizeFunc.apply(r, new RoleAuthenticationData(authenticationData, r))
+                                        .exceptionally(ex -> false)));
                     }
                     return FutureUtil.waitForAny(futures, ret -> (boolean) ret).thenApply(v -> v.isPresent());
                 });
@@ -218,7 +236,7 @@ public class MultiRolesTokenAuthorizationProvider extends PulsarAuthorizationPro
     @Override
     public CompletableFuture<Boolean> canProduceAsync(TopicName topicName, String role,
                                                       AuthenticationDataSource authenticationData) {
-        return authorize(role, authenticationData, r -> super.canProduceAsync(topicName, r, authenticationData));
+        return authorize(role, authenticationData, (r, data) -> super.canProduceAsync(topicName, r, data));
     }
 
     /**
@@ -233,7 +251,7 @@ public class MultiRolesTokenAuthorizationProvider extends PulsarAuthorizationPro
     public CompletableFuture<Boolean> canConsumeAsync(TopicName topicName, String role,
                                                       AuthenticationDataSource authenticationData,
                                                       String subscription) {
-        return authorize(role, authenticationData, r -> super.canConsumeAsync(topicName, r, authenticationData,
+        return authorize(role, authenticationData, (r, data) -> super.canConsumeAsync(topicName, r, data,
                 subscription));
     }
 
@@ -250,27 +268,27 @@ public class MultiRolesTokenAuthorizationProvider extends PulsarAuthorizationPro
     @Override
     public CompletableFuture<Boolean> canLookupAsync(TopicName topicName, String role,
                                                      AuthenticationDataSource authenticationData) {
-        return authorize(role, authenticationData, r -> super.canLookupAsync(topicName, r, authenticationData));
+        return authorize(role, authenticationData, (r, data) -> super.canLookupAsync(topicName, r, data));
     }
 
     @Override
     public CompletableFuture<Boolean> allowFunctionOpsAsync(NamespaceName namespaceName, String role,
                                                             AuthenticationDataSource authenticationData) {
         return authorize(role, authenticationData,
-                r -> super.allowFunctionOpsAsync(namespaceName, r, authenticationData));
+                (r, data) -> super.allowFunctionOpsAsync(namespaceName, r, data));
     }
 
     @Override
     public CompletableFuture<Boolean> allowSourceOpsAsync(NamespaceName namespaceName, String role,
                                                           AuthenticationDataSource authenticationData) {
         return authorize(role, authenticationData,
-                r -> super.allowSourceOpsAsync(namespaceName, r, authenticationData));
+                (r, data) -> super.allowSourceOpsAsync(namespaceName, r, data));
     }
 
     @Override
     public CompletableFuture<Boolean> allowSinkOpsAsync(NamespaceName namespaceName, String role,
                                                         AuthenticationDataSource authenticationData) {
-        return authorize(role, authenticationData, r -> super.allowSinkOpsAsync(namespaceName, r, authenticationData));
+        return authorize(role, authenticationData, (r, data) -> super.allowSinkOpsAsync(namespaceName, r, data));
     }
 
     @Override
@@ -278,7 +296,7 @@ public class MultiRolesTokenAuthorizationProvider extends PulsarAuthorizationPro
                                                                 String role,
                                                                 TenantOperation operation,
                                                                 AuthenticationDataSource authData) {
-        return authorize(role, authData, r -> super.allowTenantOperationAsync(tenantName, r, operation, authData));
+        return authorize(role, authData, (r, data) -> super.allowTenantOperationAsync(tenantName, r, operation, data));
     }
 
     @Override
@@ -287,7 +305,7 @@ public class MultiRolesTokenAuthorizationProvider extends PulsarAuthorizationPro
                                                                    NamespaceOperation operation,
                                                                    AuthenticationDataSource authData) {
         return authorize(role, authData,
-                r -> super.allowNamespaceOperationAsync(namespaceName, r, operation, authData));
+                (r, data) -> super.allowNamespaceOperationAsync(namespaceName, r, operation, data));
     }
 
     @Override
@@ -297,7 +315,7 @@ public class MultiRolesTokenAuthorizationProvider extends PulsarAuthorizationPro
                                                                          String role,
                                                                          AuthenticationDataSource authData) {
         return authorize(role, authData,
-                r -> super.allowNamespacePolicyOperationAsync(namespaceName, policy, operation, r, authData));
+                (r, data) -> super.allowNamespacePolicyOperationAsync(namespaceName, policy, operation, r, data));
     }
 
     @Override
@@ -305,7 +323,7 @@ public class MultiRolesTokenAuthorizationProvider extends PulsarAuthorizationPro
                                                                String role,
                                                                TopicOperation operation,
                                                                AuthenticationDataSource authData) {
-        return authorize(role, authData, r -> super.allowTopicOperationAsync(topicName, r, operation, authData));
+        return authorize(role, authData, (r, data) -> super.allowTopicOperationAsync(topicName, r, operation, data));
     }
 
     @Override
@@ -315,6 +333,20 @@ public class MultiRolesTokenAuthorizationProvider extends PulsarAuthorizationPro
                                                                      PolicyOperation policyOperation,
                                                                      AuthenticationDataSource authData) {
         return authorize(role, authData,
-                r -> super.allowTopicPolicyOperationAsync(topicName, r, policyName, policyOperation, authData));
+                (r, data) -> super.allowTopicPolicyOperationAsync(topicName, r, policyName, policyOperation, data));
+    }
+
+    /**
+     * Carries a resolved role only through the nested checks of one authorization call.
+     * The delegate may be null for role-only checks: getRolesAsync then uses only the supplied role,
+     * and nested checks still evaluate that role's permissions.
+     */
+    private static final class RoleAuthenticationData extends AuthenticationDataSubscription {
+        private final String role;
+
+        private RoleAuthenticationData(AuthenticationDataSource data, String role) {
+            super(data, data == null ? null : data.getSubscription());
+            this.role = role;
+        }
     }
 }

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
@@ -76,13 +76,15 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
     @Deprecated
     @Override
     public void initialize(ServiceConfiguration conf, PulsarResources pulsarResources) throws IOException {
-        initialize(InitialContext.builder().config(conf).pulsarResources(pulsarResources).build());
+        this.conf = requireNonNull(conf, "ServiceConfiguration can't be null");
+        this.pulsarResources = requireNonNull(pulsarResources, "PulsarResources can't be null");
     }
 
     @Override
     public void initialize(InitialContext context) throws IOException {
-        this.conf = requireNonNull(context.config(), "ServiceConfiguration can't be null");
-        this.pulsarResources = requireNonNull(context.pulsarResources(), "PulsarResources can't be null");
+        // Preserve initialization in third-party subclasses that override the legacy two-argument method.
+        // Keep field assignment in that method so overrides can call super without recursing here.
+        initialize(context.config(), context.pulsarResources());
     }
 
     /**

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authorization/AuthorizationServiceTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authorization/AuthorizationServiceTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertTrue;
+import java.io.IOException;
 import java.util.HashSet;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.ServiceConfiguration;
@@ -85,6 +86,29 @@ public class AuthorizationServiceTest {
             provider.initialize(legacyConfig, legacyResources);
             assertThat(provider.conf).isSameAs(legacyConfig);
             assertThat(provider.pulsarResources).isSameAs(legacyResources);
+        }
+    }
+
+    public static class LegacyPulsarProvider extends PulsarAuthorizationProvider {
+        private int initializationCount;
+
+        @Override
+        @SuppressWarnings("deprecation")
+        public void initialize(ServiceConfiguration config, PulsarResources resources) throws IOException {
+            super.initialize(config, resources);
+            initializationCount++;
+        }
+    }
+
+    @Test
+    public void testContextInitializesLegacyPulsarSubclass() throws Exception {
+        ServiceConfiguration config = new ServiceConfiguration();
+        PulsarResources resources = mock(PulsarResources.class);
+        try (LegacyPulsarProvider provider = new LegacyPulsarProvider()) {
+            provider.initialize(new AuthorizationProvider.InitialContext(config, resources, null));
+            assertThat(provider.initializationCount).isEqualTo(1);
+            assertThat(provider.conf).isSameAs(config);
+            assertThat(provider.pulsarResources).isSameAs(resources);
         }
     }
 

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authorization/MultiRolesTokenAuthorizationProviderTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authorization/MultiRolesTokenAuthorizationProviderTest.java
@@ -24,6 +24,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
@@ -47,7 +48,9 @@ import lombok.Cleanup;
 import org.apache.logging.log4j.Level;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.authentication.AuthenticationDataAnonymous;
 import org.apache.pulsar.broker.authentication.AuthenticationDataCommand;
+import org.apache.pulsar.broker.authentication.AuthenticationDataForwarded;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSubscription;
 import org.apache.pulsar.broker.authentication.AuthenticationProvider;
@@ -56,8 +59,14 @@ import org.apache.pulsar.broker.authentication.AuthenticationProviderToken;
 import org.apache.pulsar.broker.authentication.AuthenticationService;
 import org.apache.pulsar.broker.authentication.TokenAuthenticationProvider;
 import org.apache.pulsar.broker.authentication.utils.AuthTokenUtils;
+import org.apache.pulsar.broker.resources.NamespaceResources;
 import org.apache.pulsar.broker.resources.PulsarResources;
 import org.apache.pulsar.broker.resources.TenantResources;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.policies.data.AuthAction;
+import org.apache.pulsar.common.policies.data.Policies;
+import org.apache.pulsar.common.policies.data.TenantInfoImpl;
+import org.apache.pulsar.common.policies.data.TopicOperation;
 import org.apache.pulsar.common.util.RestException;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -67,6 +76,7 @@ public class MultiRolesTokenAuthorizationProviderTest {
     private static ServiceConfiguration tokenConfiguration(SecretKey key) {
         ServiceConfiguration conf = new ServiceConfiguration();
         conf.setAuthenticationEnabled(true);
+        conf.setAuthorizationEnabled(true);
         conf.setAuthenticationProviders(Set.of(AuthenticationProviderToken.class.getName()));
         conf.getProperties().setProperty("tokenSecretKey", AuthTokenUtils.encodeKeyBase64(key));
         return conf;
@@ -133,8 +143,6 @@ public class MultiRolesTokenAuthorizationProviderTest {
         assertThatThrownBy(() -> provider.initialize(new AuthorizationProvider.InitialContext(
                 conf, mock(PulsarResources.class), null)))
                 .isInstanceOf(IOException.class).hasMessageContaining("initialized token authentication provider");
-        assertThatThrownBy(() -> provider.initialize(conf, mock(PulsarResources.class)))
-                .isInstanceOf(IOException.class);
     }
 
     @DataProvider
@@ -181,6 +189,118 @@ public class MultiRolesTokenAuthorizationProviderTest {
         assertThatThrownBy(() -> provider.initialize(new AuthorizationProvider.InitialContext(
                 conf, null, authenticationService(mock(TokenAuthenticationProvider.class)))))
                 .isInstanceOf(IOException.class).hasMessageContaining("authenticationEnabled=true");
+    }
+
+    @DataProvider
+    public Object[][] authenticationModes() {
+        return new Object[][]{{false}, {true}};
+    }
+
+    @Test(dataProvider = "authenticationModes")
+    public void testDisabledAuthorizationWithoutTokenProvider(boolean authenticationEnabled) throws Exception {
+        ServiceConfiguration config = new ServiceConfiguration();
+        config.setAuthenticationEnabled(authenticationEnabled);
+        config.setAuthenticationProviders(Set.of(AuthenticationProviderTls.class.getName()));
+        config.setAuthorizationProvider(MultiRolesTokenAuthorizationProvider.class.getName());
+        PulsarResources resources = mock(PulsarResources.class);
+        try (AuthenticationService authenticationService = new AuthenticationService(config)) {
+            AuthorizationService service = new AuthorizationService(config, resources, authenticationService);
+            assertThat(service.canProduceAsync(TopicName.get("persistent://tenant/ns/topic"), "user", null).get())
+                    .isTrue();
+        }
+    }
+
+    @DataProvider
+    public Object[][] topicChecks() {
+        return new Object[][]{
+                {TopicOperation.TERMINATE, "reader", false},
+                {TopicOperation.PRODUCE, "reader", true},
+                {TopicOperation.LOOKUP, "reader", true},
+                {TopicOperation.CONSUME, "reader", true},
+                {TopicOperation.CONSUME, "other", false}
+        };
+    }
+
+    @Test(dataProvider = "topicChecks")
+    public void testNestedTopicChecksValidateRolesOnce(TopicOperation operation, String subscription,
+                                                      boolean allowed) throws Exception {
+        ServiceConfiguration config = tokenConfiguration(Jwts.SIG.HS256.key().build());
+        TokenAuthenticationProvider authenticationProvider = mock(TokenAuthenticationProvider.class);
+        when(authenticationProvider.authenticateRolesAsync(any(), eq("roles")))
+                .thenReturn(CompletableFuture.completedFuture(Set.of("reader", "writer")));
+        TenantResources tenants = mock(TenantResources.class);
+        when(tenants.getTenantAsync("tenant"))
+                .thenReturn(CompletableFuture.completedFuture(Optional.of(new TenantInfoImpl(Set.of(), Set.of()))));
+        PulsarResources resources = mock(PulsarResources.class);
+        when(resources.getTenantResources()).thenReturn(tenants);
+        NamespaceResources namespaces = mock(NamespaceResources.class);
+        when(resources.getNamespaceResources()).thenReturn(namespaces);
+        Policies policies = new Policies();
+        policies.auth_policies.getNamespaceAuthentication().put("reader", Set.of(AuthAction.consume));
+        policies.auth_policies.getNamespaceAuthentication().put("writer", Set.of(AuthAction.produce));
+        policies.auth_policies.getSubscriptionAuthentication().put("reader", Set.of("reader"));
+        policies.auth_policies.getSubscriptionAuthentication().put("other", Set.of("other"));
+        when(namespaces.getPoliciesAsync(any())).thenReturn(CompletableFuture.completedFuture(Optional.of(policies)));
+        try (MultiRolesTokenAuthorizationProvider provider = new MultiRolesTokenAuthorizationProvider()) {
+            provider.initialize(new AuthorizationProvider.InitialContext(config, resources,
+                    authenticationService(authenticationProvider)));
+            AuthenticationDataSource data = new AuthenticationDataSubscription(
+                    new AuthenticationDataCommand("token"), subscription);
+            assertThat(provider.allowTopicOperationAsync(TopicName.get("persistent://tenant/ns/topic"),
+                    "reader", operation, data).get()).isEqualTo(allowed);
+            verify(authenticationProvider).authenticateRolesAsync(data, "roles");
+            when(authenticationProvider.authenticateRolesAsync(data, "roles"))
+                    .thenReturn(CompletableFuture.completedFuture(Set.of()));
+            assertThat(provider.allowTopicOperationAsync(TopicName.get("persistent://tenant/ns/topic"),
+                    "reader", operation, data).get()).isFalse();
+            verify(authenticationProvider, times(2)).authenticateRolesAsync(data, "roles");
+        }
+    }
+
+    @DataProvider
+    public Object[][] roleOnlyAuthenticationData() {
+        return new Object[][]{
+                {null},
+                {new AuthenticationDataSubscription(null, "subscription")},
+                {AuthenticationDataForwarded.INSTANCE},
+                {new AuthenticationDataSubscription(AuthenticationDataForwarded.INSTANCE, "subscription")},
+                {new AuthenticationDataSubscription(
+                        new AuthenticationDataSubscription(AuthenticationDataForwarded.INSTANCE, "inner"), "outer")},
+                {AuthenticationDataAnonymous.INSTANCE},
+                {new AuthenticationDataSubscription(AuthenticationDataAnonymous.INSTANCE, "subscription")},
+                {new AuthenticationDataSubscription(
+                        new AuthenticationDataSubscription(AuthenticationDataAnonymous.INSTANCE, "inner"), "outer")}
+        };
+    }
+
+    @Test(dataProvider = "roleOnlyAuthenticationData")
+    public void testNestedChecksWithRoleOnlyAuthenticationData(AuthenticationDataSource data) throws Exception {
+        ServiceConfiguration config = tokenConfiguration(Jwts.SIG.HS256.key().build());
+        TokenAuthenticationProvider authenticationProvider = mock(TokenAuthenticationProvider.class);
+        TenantResources tenants = mock(TenantResources.class);
+        when(tenants.getTenantAsync("tenant"))
+                .thenReturn(CompletableFuture.completedFuture(Optional.of(new TenantInfoImpl(Set.of(), Set.of()))));
+        NamespaceResources namespaces = mock(NamespaceResources.class);
+        Policies policies = new Policies();
+        policies.auth_policies.getNamespaceAuthentication().put("reader", Set.of(AuthAction.consume));
+        when(namespaces.getPoliciesAsync(any())).thenReturn(CompletableFuture.completedFuture(Optional.of(policies)));
+        PulsarResources resources = mock(PulsarResources.class);
+        when(resources.getTenantResources()).thenReturn(tenants);
+        when(resources.getNamespaceResources()).thenReturn(namespaces);
+        TopicName topic = TopicName.get("persistent://tenant/ns/topic");
+        try (MultiRolesTokenAuthorizationProvider provider = new MultiRolesTokenAuthorizationProvider()) {
+            provider.initialize(new AuthorizationProvider.InitialContext(config, resources,
+                    authenticationService(authenticationProvider)));
+            assertThat(provider.allowTopicOperationAsync(topic, "reader", TopicOperation.LOOKUP, data).get())
+                    .isTrue();
+            assertThat(provider.allowTopicOperationAsync(topic, "reader", TopicOperation.CONSUME, data).get())
+                    .isTrue();
+            assertThat(provider.allowTopicOperationAsync(topic, "other", TopicOperation.CONSUME, data).get())
+                    .isFalse();
+            assertThat(provider.allowTopicOperationAsync(topic, null, TopicOperation.CONSUME, data).get())
+                    .isFalse();
+            verify(authenticationProvider, never()).authenticateRolesAsync(any(), any());
+        }
     }
 
     @DataProvider

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -82,6 +82,8 @@ import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.TransactionMetadataStoreService;
+import org.apache.pulsar.broker.authentication.AuthenticationDataAnonymous;
+import org.apache.pulsar.broker.authentication.AuthenticationDataForwarded;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSubscription;
 import org.apache.pulsar.broker.authentication.AuthenticationProvider;
@@ -1827,26 +1829,27 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                  * if the client does not configure an authentication method
                  * the proxy side will set the value of anonymousUserRole to clientAuthRole when it creates a connection
                  * and the value of clientAuthMethod will be none.
-                 * Similarly, should also set the value of authRole to anonymousUserRole on the broker side.
+                 * The broker uses that role for the original principal while authenticating the proxy separately.
                  */
                 if (originalAuthenticationProvider == null) {
-                    authRole = getBrokerService().getAuthenticationService().getAnonymousUserRole()
+                    originalPrincipal = getBrokerService().getAuthenticationService().getAnonymousUserRole()
                             .orElseThrow(() ->
                                     new AuthenticationException("No anonymous role, and can't find "
                                             + "AuthenticationProvider for original role using auth method "
                                             + "[" + originalAuthMethod + "] is not available"));
-                    originalPrincipal = authRole;
-                    completeConnect(clientProtocolVersion, clientVersion);
-                    return;
+                    originalAuthData = AuthenticationDataAnonymous.INSTANCE;
+                } else {
+                    originalAuthDataCopy = AuthData.of(connect.getOriginalAuthData().getBytes());
+                    originalAuthState = originalAuthenticationProvider.newAuthState(
+                            originalAuthDataCopy,
+                            remoteAddress,
+                            sslSession);
                 }
-
-                originalAuthDataCopy = AuthData.of(connect.getOriginalAuthData().getBytes());
-                originalAuthState = originalAuthenticationProvider.newAuthState(
-                        originalAuthDataCopy,
-                        remoteAddress,
-                        sslSession);
             } else if (connect.hasOriginalPrincipal()) {
                 originalPrincipal = connect.getOriginalPrincipal();
+                if (!WEBSOCKET_DUMMY_ORIGINAL_PRINCIPLE.equals(originalPrincipal)) {
+                    originalAuthData = AuthenticationDataForwarded.INSTANCE;
+                }
 
                 log.debug()
                         .attr("originalPrincipal", originalPrincipal)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/AuthenticationServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/AuthenticationServiceTest.java
@@ -36,18 +36,28 @@ import java.io.IOException;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
 import javax.naming.AuthenticationException;
 import lombok.Cleanup;
 import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.authentication.AuthenticationDataAnonymous;
 import org.apache.pulsar.broker.authentication.AuthenticationDataCommand;
 import org.apache.pulsar.broker.authentication.AuthenticationDataHttps;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
 import org.apache.pulsar.broker.authentication.AuthenticationProvider;
+import org.apache.pulsar.broker.authentication.AuthenticationProviderToken;
 import org.apache.pulsar.broker.authentication.AuthenticationService;
 import org.apache.pulsar.broker.authentication.AuthenticationState;
+import org.apache.pulsar.broker.authentication.utils.AuthTokenUtils;
+import org.apache.pulsar.broker.authorization.AuthorizationProvider;
+import org.apache.pulsar.broker.authorization.MultiRolesTokenAuthorizationProvider;
+import org.apache.pulsar.broker.resources.PulsarResources;
 import org.apache.pulsar.broker.web.AuthenticationFilter;
 import org.apache.pulsar.common.api.AuthData;
+import org.mockito.ArgumentCaptor;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 public class AuthenticationServiceTest {
@@ -176,8 +186,42 @@ public class AuthenticationServiceTest {
         doFilter = service.authenticateHttpRequest(requestCustomAuthProvider, (HttpServletResponse) null);
         assertTrue(doFilter, "Authentication should have succeeded");
         verify(requestCustomAuthProvider).setAttribute(AuthenticatedRoleAttributeName, anonRole);
+        verify(requestCustomAuthProvider).setAttribute(AuthenticatedDataAttributeName,
+                AuthenticationDataAnonymous.INSTANCE);
 
         service.close();
+    }
+
+    @DataProvider
+    public Object[][] anonymousHttpHeaders() {
+        return new Object[][]{{null}, {"Bearer not-a-token"}};
+    }
+
+    @Test(dataProvider = "anonymousHttpHeaders")
+    public void testAnonymousHttpRoleAuthorization(String authorizationHeader) throws Exception {
+        SecretKey key = KeyGenerator.getInstance("HmacSHA256").generateKey();
+        ServiceConfiguration config = new ServiceConfiguration();
+        config.setAuthenticationEnabled(true);
+        config.setAuthorizationEnabled(true);
+        config.setAnonymousUserRole("anon");
+        config.setAuthenticationProviders(Set.of(AuthenticationProviderToken.class.getName()));
+        config.getProperties().setProperty("tokenSecretKey", AuthTokenUtils.encodeKeyBase64(key));
+        try (AuthenticationService service = new AuthenticationService(config);
+                MultiRolesTokenAuthorizationProvider authorization = new MultiRolesTokenAuthorizationProvider()) {
+            authorization.initialize(new AuthorizationProvider.InitialContext(config, mock(PulsarResources.class),
+                    service));
+            HttpServletRequest request = mock(HttpServletRequest.class);
+            when(request.getHeader("Authorization")).thenReturn(authorizationHeader);
+            when(request.getRemoteAddr()).thenReturn("127.0.0.1");
+            assertThat(service.authenticateHttpRequest(request, (HttpServletResponse) null)).isTrue();
+            verify(request).setAttribute(AuthenticatedRoleAttributeName, "anon");
+            ArgumentCaptor<AuthenticationDataSource> data = ArgumentCaptor.forClass(AuthenticationDataSource.class);
+            verify(request).setAttribute(eq(AuthenticatedDataAttributeName), data.capture());
+            assertThat(authorization.authorize("anon", data.getValue(),
+                    role -> CompletableFuture.completedFuture("anon".equals(role))).get()).isTrue();
+            assertThat(authorization.authorize("anon", data.getValue(),
+                    role -> CompletableFuture.completedFuture("other".equals(role))).get()).isFalse();
+        }
     }
 
     @SuppressWarnings("deprecation")

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -102,6 +102,8 @@ import org.apache.pulsar.broker.auth.MockAuthenticationProvider;
 import org.apache.pulsar.broker.auth.MockAuthorizationProvider;
 import org.apache.pulsar.broker.auth.MockMultiStageAuthenticationProvider;
 import org.apache.pulsar.broker.auth.MockMutableAuthenticationProvider;
+import org.apache.pulsar.broker.authentication.AuthenticationDataAnonymous;
+import org.apache.pulsar.broker.authentication.AuthenticationDataForwarded;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSubscription;
 import org.apache.pulsar.broker.authentication.AuthenticationProvider;
@@ -563,10 +565,33 @@ public class ServerCnxTest {
         Object response1 = getResponse();
         assertTrue(response1 instanceof CommandConnected);
         assertEquals(serverCnx.getState(), State.Connected);
-        assertEquals(serverCnx.getAuthRole(), anonymousUserRole);
+        assertEquals(serverCnx.getAuthRole(), "pass.proxy");
         assertEquals(serverCnx.getPrincipal(), anonymousUserRole);
         assertEquals(serverCnx.getOriginalPrincipal(), anonymousUserRole);
+        assertThat(serverCnx.getOriginalAuthData()).isSameAs(AuthenticationDataAnonymous.INSTANCE);
+        assertThat(serverCnx.getAuthenticationData()).isSameAs(AuthenticationDataAnonymous.INSTANCE);
+        assertThat(serverCnx.getAuthData()).isNotSameAs(serverCnx.getOriginalAuthData());
         assertTrue(serverCnx.isActive());
+        channel.finish();
+    }
+
+    @Test(timeOut = 30000)
+    public void testAnonymousOriginalPrincipalWithFailingProxyAuthentication() throws Exception {
+        AuthenticationService authenticationService = mock(AuthenticationService.class);
+        AuthenticationProvider authenticationProvider = new MockAuthenticationProvider();
+        String authMethodName = authenticationProvider.getAuthMethodName();
+        when(brokerService.getAuthenticationService()).thenReturn(authenticationService);
+        when(authenticationService.getAuthenticationProvider(authMethodName)).thenReturn(authenticationProvider);
+        when(authenticationService.getAnonymousUserRole()).thenReturn(Optional.of("anonymous"));
+        svcConfig.setAuthenticationEnabled(true);
+        svcConfig.setAuthenticateOriginalAuthData(true);
+        svcConfig.setProxyRoles(Collections.singleton("pass.proxy"));
+        resetChannel();
+
+        channel.writeInbound(Commands.newConnect(authMethodName, "fail.proxy", 1, null,
+                null, "anonymous", null, null));
+        assertTrue(getResponse() instanceof CommandError);
+        assertFalse(serverCnx.isActive());
         channel.finish();
     }
 
@@ -1346,7 +1371,8 @@ public class ServerCnxTest {
         channel.writeInbound(connect);
         Object connectResponse = getResponse();
         assertTrue(connectResponse instanceof CommandConnected);
-        assertNull(serverCnx.getOriginalAuthData());
+        assertThat(serverCnx.getOriginalAuthData()).isSameAs(AuthenticationDataForwarded.INSTANCE);
+        assertThat(serverCnx.getAuthenticationData()).isSameAs(AuthenticationDataForwarded.INSTANCE);
         assertNull(serverCnx.getOriginalAuthState());
         assertEquals(serverCnx.getOriginalPrincipal(), clientRole);
         assertEquals(serverCnx.getAuthData().getCommandData(), proxyRole);
@@ -1363,12 +1389,7 @@ public class ServerCnxTest {
         assertEquals(((CommandLookupTopicResponse) lookupResponse).getRequestId(), 1);
         verify(authorizationService, times(1))
                 .allowTopicOperationAsync(topicName, TopicOperation.LOOKUP, clientRole, proxyRole,
-                        serverCnx.getAuthData(), serverCnx.getAuthData());
-        // This test is an example of https://github.com/apache/pulsar/issues/19332. Essentially, we're passing
-        // the proxy's auth data because it is all we have. This test should be updated when we resolve that issue.
-        verify(authorizationService, times(1))
-                .allowTopicOperationAsync(topicName, TopicOperation.LOOKUP, clientRole, proxyRole,
-                        serverCnx.getAuthData(), serverCnx.getAuthData());
+                        serverCnx.getOriginalAuthData(), serverCnx.getAuthData());
 
         // producer
         ByteBuf producer = Commands.newProducer(topicName.toString(), 1, 2, "test-producer", new HashMap<>(), false);
@@ -1377,13 +1398,12 @@ public class ServerCnxTest {
         assertTrue(producerResponse instanceof CommandError);
         assertEquals(((CommandError) producerResponse).getError(), ServerError.AuthorizationError);
         assertEquals(((CommandError) producerResponse).getRequestId(), 2);
-        // See https://github.com/apache/pulsar/issues/19332 for justification of this assertion.
         verify(authorizationService, times(1))
                 .allowTopicOperationAsync(topicName, TopicOperation.PRODUCE, clientRole, proxyRole,
-                        serverCnx.getAuthData(), serverCnx.getAuthData());
+                        serverCnx.getOriginalAuthData(), serverCnx.getAuthData());
         verify(authorizationService, times(1))
                 .allowTopicOperationAsync(topicName, TopicOperation.LOOKUP, clientRole, proxyRole,
-                        serverCnx.getAuthData(), serverCnx.getAuthData());
+                        serverCnx.getOriginalAuthData(), serverCnx.getAuthData());
 
         // consumer
         String subscriptionName = "test-subscribe";
@@ -1398,25 +1418,9 @@ public class ServerCnxTest {
                 eq(topicName), eq(TopicOperation.CONSUME),
                 eq(clientRole), eq(proxyRole), argThat(arg -> {
                     assertTrue(arg instanceof AuthenticationDataSubscription);
-                    // We assert that the role is clientRole and commandData is proxyRole due to
-                    // https://github.com/apache/pulsar/issues/19332.
                     AuthenticationDataSubscription authData = (AuthenticationDataSubscription) arg;
-                    assertEquals(authData.getCommandData(), proxyRole);
-                    assertEquals(authData.getSubscription(), subscriptionName);
-                    return true;
-                }), argThat(arg -> {
-                    assertTrue(arg instanceof AuthenticationDataSubscription);
-                    AuthenticationDataSubscription authData = (AuthenticationDataSubscription) arg;
-                    assertEquals(authData.getCommandData(), proxyRole);
-                    assertEquals(authData.getSubscription(), subscriptionName);
-                    return true;
-                }));
-        verify(authorizationService, times(1)).allowTopicOperationAsync(
-                eq(topicName), eq(TopicOperation.CONSUME),
-                eq(clientRole), eq(proxyRole), argThat(arg -> {
-                    assertTrue(arg instanceof AuthenticationDataSubscription);
-                    AuthenticationDataSubscription authData = (AuthenticationDataSubscription) arg;
-                    assertEquals(authData.getCommandData(), proxyRole);
+                    assertThat(authData.getAuthData()).isSameAs(AuthenticationDataForwarded.INSTANCE);
+                    assertNull(authData.getCommandData());
                     assertEquals(authData.getSubscription(), subscriptionName);
                     return true;
                 }), argThat(arg -> {

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/Worker.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/Worker.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.functions.worker;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.util.Optional;
 import lombok.CustomLog;
@@ -38,6 +39,7 @@ public class Worker {
     private final WorkerConfig workerConfig;
     private final WorkerService workerService;
     private WorkerServer server;
+    private AuthenticationService authenticationService;
 
     private final OrderedExecutor orderedExecutor =
             OrderedExecutor.newBuilder().numThreads(8).name("zk-cache-ordered").build();
@@ -53,8 +55,9 @@ public class Worker {
 
     protected void start() throws Exception {
         workerService.initAsStandalone(workerConfig);
-        workerService.start(getAuthenticationService(), getAuthorizationService(), errorNotifier);
-        server = new WorkerServer(workerService, getAuthenticationService());
+        AuthorizationService authorizationService = initializeAuthorizationService();
+        workerService.start(authenticationService, authorizationService, errorNotifier);
+        server = new WorkerServer(workerService, authenticationService);
         server.start();
         log.info("/** Started worker server **/");
 
@@ -68,6 +71,12 @@ public class Worker {
     }
 
 
+
+    @VisibleForTesting
+    AuthorizationService initializeAuthorizationService() throws PulsarServerException {
+        authenticationService = getAuthenticationService();
+        return getAuthorizationService();
+    }
 
     private AuthorizationService getAuthorizationService() throws PulsarServerException {
 
@@ -83,7 +92,7 @@ public class Worker {
                 throw new PulsarServerException(e);
             }
             pulsarResources = new PulsarResources(null, configMetadataStore);
-            return new AuthorizationService(getServiceConfiguration(), this.pulsarResources);
+            return new AuthorizationService(getServiceConfiguration(), this.pulsarResources, authenticationService);
             }
         return null;
     }
@@ -100,6 +109,14 @@ public class Worker {
             workerService.stop();
         } catch (Exception e) {
             log.warn().exception(e).log("Failed to gracefully stop worker service ");
+        }
+
+        if (authenticationService != null) {
+            try {
+                authenticationService.close();
+            } catch (IOException e) {
+                log.warn().exception(e).log("Failed to close authentication service");
+            }
         }
 
         if (this.configMetadataStore != null) {

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/WorkerTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/WorkerTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.functions.worker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import java.util.Optional;
+import java.util.Set;
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import org.apache.pulsar.broker.authentication.AuthenticationDataCommand;
+import org.apache.pulsar.broker.authentication.AuthenticationProviderToken;
+import org.apache.pulsar.broker.authentication.utils.AuthTokenUtils;
+import org.apache.pulsar.broker.authorization.AuthorizationService;
+import org.apache.pulsar.broker.authorization.MultiRolesTokenAuthorizationProvider;
+import org.testng.annotations.Test;
+
+public class WorkerTest {
+    @Test
+    public void testStandaloneMultiRoleAuthorization() throws Exception {
+        SecretKey key = KeyGenerator.getInstance("HmacSHA256").generateKey();
+        WorkerConfig config = new WorkerConfig();
+        config.setAuthenticationEnabled(true);
+        config.setAuthorizationEnabled(true);
+        config.setAuthenticationProviders(Set.of(AuthenticationProviderToken.class.getName()));
+        config.setAuthorizationProvider(MultiRolesTokenAuthorizationProvider.class.getName());
+        config.setSuperUserRoles(Set.of("admin"));
+        config.setConfigurationMetadataStoreUrl("memory:worker-multi-role");
+        config.getProperties().setProperty("tokenSecretKey", AuthTokenUtils.encodeKeyBase64(key));
+        config.getProperties().setProperty("tokenAuthClaim", "sub");
+        Worker worker = new Worker(config);
+        try {
+            AuthorizationService authorization = worker.initializeAuthorizationService();
+            String token = AuthTokenUtils.createToken(key, "admin", Optional.empty());
+            assertThat(authorization.isSuperUser("user", new AuthenticationDataCommand(token)).get()).isTrue();
+            String otherToken = AuthTokenUtils.createToken(key, "user", Optional.empty());
+            assertThat(authorization.isSuperUser("user", new AuthenticationDataCommand(otherToken)).get()).isFalse();
+        } finally {
+            worker.stop();
+        }
+    }
+}

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithJwtAuthorizationTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithJwtAuthorizationTest.java
@@ -26,9 +26,11 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.core.Response;
+import java.lang.reflect.Method;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -41,6 +43,8 @@ import org.apache.pulsar.broker.authentication.utils.AuthTokenUtils;
 import org.apache.pulsar.broker.authorization.MultiRolesTokenAuthorizationProvider;
 import org.apache.pulsar.broker.resources.PulsarResources;
 import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminBuilder;
+import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.AuthenticationFactory;
 import org.apache.pulsar.client.api.ClientBuilder;
@@ -76,6 +80,7 @@ public class ProxyWithJwtAuthorizationTest extends ProducerConsumerBase {
     private static final String PROXY_ROLE = "proxy";
     private static final String BROKER_ROLE = "broker";
     private static final String CLIENT_ROLE = "client";
+    private static final String ANONYMOUS_ROLE = "anonymous";
     @SuppressWarnings("deprecation")
     private static final SecretKey SECRET_KEY = AuthTokenUtils.createSecretKey(SignatureAlgorithm.HS256);
 
@@ -107,6 +112,17 @@ public class ProxyWithJwtAuthorizationTest extends ProducerConsumerBase {
     private Authentication proxyClientAuthentication;
 
     @BeforeMethod
+    public void setupForTest(Method method) throws Exception {
+        String anonymousRole = method.getName().equals("testAnonymousClientPermissionsWithSuperUserProxy")
+                ? ANONYMOUS_ROLE : null;
+        conf.setAuthenticateOriginalAuthData(
+                !method.getName().equals("testForwardedPrincipalPermissions"));
+        proxyConfig.setForwardAuthorizationCredentials(true);
+        conf.setAnonymousUserRole(anonymousRole);
+        proxyConfig.setAnonymousUserRole(anonymousRole);
+        setup();
+    }
+
     @Override
     protected void setup() throws Exception {
         // enable auth&auth and use JWT at broker
@@ -170,6 +186,12 @@ public class ProxyWithJwtAuthorizationTest extends ProducerConsumerBase {
         webServer = new WebServer(proxyConfig, authService);
     }
 
+    @Override
+    protected void customizeNewPulsarAdminBuilder(PulsarAdminBuilder builder) {
+        super.customizeNewPulsarAdminBuilder(builder);
+        builder.authentication(AuthenticationFactory.token(adminToken));
+    }
+
     @AfterMethod(alwaysRun = true)
     @Override
     protected void cleanup() throws Exception {
@@ -185,6 +207,127 @@ public class ProxyWithJwtAuthorizationTest extends ProducerConsumerBase {
         proxyService.start();
         ProxyServiceStarter.addWebServerHandlers(webServer, proxyConfig, proxyService, null, proxyClientAuthentication);
         webServer.start();
+    }
+
+    @Test
+    public void testAnonymousClientPermissionsWithSuperUserProxy() throws Exception {
+        startProxy();
+        admin.clusters().createCluster(CLUSTER_NAME,
+                ClusterData.builder().serviceUrl(brokerUrl.toString()).build());
+        admin.tenants().createTenant("anonymous-client",
+                new TenantInfoImpl(Set.of(ADMIN_ROLE), Set.of(CLUSTER_NAME)));
+        admin.namespaces().createNamespace("anonymous-client/ns");
+        String allowedTopic = "persistent://anonymous-client/ns/allowed";
+        String consumeOnlyTopic = "persistent://anonymous-client/ns/consume-only";
+        String produceOnlyTopic = "persistent://anonymous-client/ns/produce-only";
+        String deniedTopic = "persistent://anonymous-client/ns/denied";
+        for (String topic : List.of(allowedTopic, consumeOnlyTopic, produceOnlyTopic, deniedTopic)) {
+            admin.topics().createNonPartitionedTopic(topic);
+        }
+        admin.topics().grantPermission(allowedTopic, ANONYMOUS_ROLE, Set.of(AuthAction.produce, AuthAction.consume));
+        admin.topics().grantPermission(consumeOnlyTopic, ANONYMOUS_ROLE, Set.of(AuthAction.consume));
+        admin.topics().grantPermission(produceOnlyTopic, ANONYMOUS_ROLE, Set.of(AuthAction.produce));
+
+        @Cleanup
+        PulsarClient client = PulsarClient.builder().serviceUrl(proxyService.getServiceUrl())
+                .operationTimeout(5, TimeUnit.SECONDS).build();
+        @Cleanup
+        Consumer<byte[]> consumer = client.newConsumer().topic(allowedTopic).subscriptionName("sub").subscribe();
+        @Cleanup
+        Producer<byte[]> producer = client.newProducer().topic(allowedTopic).create();
+        producer.send(new byte[]{1});
+        Message<byte[]> message = consumer.receive(5, TimeUnit.SECONDS);
+        assertThat(message).isNotNull();
+        assertThat(message.getData()).containsExactly((byte) 1);
+
+        // Each topic permits lookup through the other action, so these exercise produce/consume authorization.
+        assertThatThrownBy(() -> {
+            try (Producer<byte[]> ignored = client.newProducer().topic(consumeOnlyTopic).create()) {
+                // Creation should be rejected.
+            }
+        }).isInstanceOf(PulsarClientException.AuthorizationException.class);
+        assertThatThrownBy(() -> {
+            try (Consumer<byte[]> ignored = client.newConsumer().topic(produceOnlyTopic)
+                    .subscriptionName("sub").subscribe()) {
+                // Subscription should be rejected.
+            }
+        }).isInstanceOf(PulsarClientException.AuthorizationException.class);
+
+        @Cleanup
+        PulsarAdmin anonymousAdmin = PulsarAdmin.builder().serviceHttpUrl(webServer.getServiceUri().toString()).build();
+        assertThat(anonymousAdmin.topics().getStats(allowedTopic)).isNotNull();
+        assertThatThrownBy(() -> anonymousAdmin.topics().getStats(deniedTopic))
+                .isInstanceOf(PulsarAdminException.NotAuthorizedException.class);
+    }
+
+    @DataProvider
+    public Object[][] forwardedCredentialSettings() {
+        return new Object[][]{{false}, {true}};
+    }
+
+    @Test(dataProvider = "forwardedCredentialSettings")
+    public void testForwardedPrincipalPermissions(boolean forwardCredentials) throws Exception {
+        proxyConfig.setForwardAuthorizationCredentials(forwardCredentials);
+        startProxy();
+        admin.clusters().createCluster(CLUSTER_NAME,
+                ClusterData.builder().serviceUrl(brokerUrl.toString()).build());
+        admin.tenants().createTenant("forwarded-client",
+                new TenantInfoImpl(Set.of(ADMIN_ROLE), Set.of(CLUSTER_NAME)));
+        String namespace = "forwarded-client/ns";
+        admin.namespaces().createNamespace(namespace);
+        admin.namespaces().setSubscriptionAuthMode(namespace, SubscriptionAuthMode.Prefix);
+        String allowedTopic = "persistent://" + namespace + "/allowed";
+        String consumeOnlyTopic = "persistent://" + namespace + "/consume-only";
+        String produceOnlyTopic = "persistent://" + namespace + "/produce-only";
+        String additionalRoleTopic = "persistent://" + namespace + "/additional-role";
+        for (String topic : List.of(allowedTopic, consumeOnlyTopic, produceOnlyTopic, additionalRoleTopic)) {
+            admin.topics().createNonPartitionedTopic(topic);
+        }
+        admin.topics().grantPermission(allowedTopic, CLIENT_ROLE, Set.of(AuthAction.produce, AuthAction.consume));
+        admin.topics().grantPermission(consumeOnlyTopic, CLIENT_ROLE, Set.of(AuthAction.consume));
+        admin.topics().grantPermission(produceOnlyTopic, CLIENT_ROLE, Set.of(AuthAction.produce));
+        admin.topics().grantPermission(additionalRoleTopic, "additional-role",
+                Set.of(AuthAction.produce, AuthAction.consume));
+
+        String token = Jwts.builder()
+                .claim(roleClaim, multiRoles ? new String[]{CLIENT_ROLE, "additional-role"} : CLIENT_ROLE)
+                .signWith(SECRET_KEY).compact();
+        @Cleanup
+        PulsarClient client = PulsarClient.builder().serviceUrl(proxyService.getServiceUrl())
+                .authentication(AuthenticationFactory.token(token)).operationTimeout(5, TimeUnit.SECONDS).build();
+        @Cleanup
+        Consumer<byte[]> consumer = client.newConsumer().topic(allowedTopic)
+                .subscriptionName(CLIENT_ROLE + "-sub").subscribe();
+        @Cleanup
+        Producer<byte[]> producer = client.newProducer().topic(allowedTopic).create();
+        producer.send(new byte[]{1});
+        Message<byte[]> message = consumer.receive(5, TimeUnit.SECONDS);
+        assertThat(message).isNotNull();
+        assertThat(message.getData()).containsExactly((byte) 1);
+
+        // Lookup is allowed on these topics; the requested action must still be checked.
+        assertThatThrownBy(() -> {
+            try (Producer<byte[]> ignored = client.newProducer().topic(consumeOnlyTopic).create()) {
+                // Creation should be rejected.
+            }
+        }).isInstanceOf(PulsarClientException.AuthorizationException.class);
+        assertThatThrownBy(() -> {
+            try (Consumer<byte[]> ignored = client.newConsumer().topic(produceOnlyTopic)
+                    .subscriptionName(CLIENT_ROLE + "-sub").subscribe()) {
+                // Subscription should be rejected.
+            }
+        }).isInstanceOf(PulsarClientException.AuthorizationException.class);
+        assertThatThrownBy(() -> {
+            try (Consumer<byte[]> ignored = client.newConsumer().topic(allowedTopic)
+                    .subscriptionName("other-sub").subscribe()) {
+                // Subscription prefix must match the forwarded principal.
+            }
+        }).isInstanceOf(PulsarClientException.AuthorizationException.class);
+        assertThatThrownBy(() -> {
+            try (Producer<byte[]> ignored = client.newProducer().topic(additionalRoleTopic).create()) {
+                // Additional roles require original-client authentication.
+            }
+        }).isInstanceOf(PulsarClientException.AuthorizationException.class);
     }
 
     @Test


### PR DESCRIPTION
### Motivation

Follow up to #26549 to fix authorization-provider initialization and proxy authorization regressions, and avoid repeating token validation in nested checks.

Legacy subclasses need their initializer invoked, and standalone function workers need authorization to use the initialized authentication service. Anonymous and forwarded clients also need a consistent authorization context across lookup, produce, consume, and subscription checks.

### Modifications

- Preserve legacy initialization in subclasses of `PulsarAuthorizationProvider`.
- Share one authentication service across standalone worker authorization and HTTP handling, and close it on shutdown.
- Allow the multi-role provider to initialize without a token provider when authorization is disabled.
- Resolve token roles once per authorization operation and carry each resolved role through nested checks.
- Use an explicit anonymous authentication context for binary connections and HTTP requests.
- Authorize by the forwarded principal when original-client authentication is disabled.
- Include the cause in role-extraction diagnostics.

### Verifying this change

Regression coverage includes legacy and worker initialization, nested role resolution, anonymous-client binary and HTTP operations, and forwarded-principal permissions with credential forwarding enabled and disabled.

Local validation passed:

- 177 tests across the full `MultiRolesTokenAuthorizationProviderTest`, `ServerCnxTest`, and `ProxyWithJwtAuthorizationTest` classes.
- Authorization-service, authentication-service, authentication-filter, and standalone-worker tests during development.
- `./gradlew quickCheck`; `./gradlew checkBinaryLicense` also passed during development.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [x] The public API — restores legacy authorization-provider initialization.
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [x] The binary protocol — updates anonymous and forwarded-principal connection context handling.
- [x] The REST endpoints — updates anonymous HTTP authentication context handling.
- [ ] The admin CLI options
- [ ] The metrics
- [x] Anything that affects deployment — fixes standalone function-worker initialization.
