### PR TITLE
[fix][managed-ledger] Honor batch-index cap in isCursorDataFullyPersistable

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -411,7 +411,11 @@ public class ManagedCursorImpl implements ManagedCursor {
     public boolean isCursorDataFullyPersistable() {
         lock.readLock().lock();
         try {
-            return individualDeletedMessages.size() <= getConfig().getMaxUnackedRangesToPersist();
+            if (individualDeletedMessages.size() > getConfig().getMaxUnackedRangesToPersist()) {
+                return false;
+            }
+            return batchDeletedIndexes == null
+                    || batchDeletedIndexes.size() <= getConfig().getMaxBatchDeletedIndexToPersist();
         } finally {
             lock.readLock().unlock();
         }

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorBatchAckRecoveryTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorBatchAckRecoveryTest.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import lombok.Cleanup;
+import org.awaitility.Awaitility;
 import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
 import org.apache.bookkeeper.mledger.ManagedLedgerException.MetaStoreException;
 import org.apache.bookkeeper.mledger.Position;
@@ -48,6 +49,33 @@ public class ManagedCursorBatchAckRecoveryTest extends MockedBookKeeperTestCase 
     @DataProvider(name = "booleans")
     public Object[][] booleans() {
         return new Object[][] {{false}, {true}};
+    }
+
+    @Test
+    public void testIsCursorDataFullyPersistableReflectsBatchDeletedIndexLimit() throws Exception {
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        config.setDeletionAtBatchIndexLevelEnabled(true);
+        config.setMaxBatchDeletedIndexToPersist(2);
+        config.setThrottleMarkDelete(0);
+        String name = "tenant/ns/persistent/cursor-data-fully-persistable-batch-index";
+        @Cleanup
+        ManagedLedgerImpl ledger = (ManagedLedgerImpl) factory.open(name, config);
+        ManagedCursorImpl cursor = (ManagedCursorImpl) ledger.openCursor("sub");
+        List<Position> positions = new ArrayList<>();
+        for (int i = 0; i <= 3; i++) {
+            positions.add(ledger.addEntry(new byte[] {(byte) i}));
+        }
+        cursor.delete(positions.get(0));
+        Awaitility.await().until(() -> cursor.getStats().getPersistLedgerSucceed() > 0);
+
+        long[][] ackSets = {{2L}, {Long.MIN_VALUE, 1L}, {5L, 0L, 3L}};
+        for (int i = 1; i < positions.size(); i++) {
+            Position position = positions.get(i);
+            cursor.delete(AckSetStateUtil.createPositionWithAckSet(
+                    position.getLedgerId(), position.getEntryId(), ackSets[i - 1]));
+        }
+
+        assertThat(cursor.isCursorDataFullyPersistable()).isFalse();
     }
 
     @Test(dataProvider = "batchRecovery")


### PR DESCRIPTION
Fixes #26499

### Motivation

`ManagedCursorImpl.isCursorDataFullyPersistable()` only compared the whole-entry
deletion range count to `maxUnackedRangesToPersist`. When partial batch ACK state
exceeded `maxBatchDeletedIndexToPersist`, the method still returned `true` even
though `buildBatchEntryDeletionIndexInfoList()` truncates on persist. That
mismatch can leave dispatchers running while some batch ACK records would not
survive a cursor-state write.

### Modifications

- Extend `isCursorDataFullyPersistable()` to return `false` when
  `batchDeletedIndexes` exceeds `maxBatchDeletedIndexToPersist`.
- Add a managed-ledger test reproducing the issue scenario (three partial batch
  ACK records with limit 2), including boundary checks at the cap.
- Document and test PIP-299 interaction: when
  `dispatcherPauseOnAckStatePersistentEnabled` is on, multi-consumer dispatchers
  also treat `managedLedgerMaxBatchDeletedIndexToPersist` as a pause threshold
  via `isCursorDataFullyPersistable()` (in addition to
  `managedLedgerMaxUnackedRangesToPersist`).

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- `./gradlew :managed-ledger:checkstyleTest :managed-ledger:test --tests org.apache.bookkeeper.mledger.impl.ManagedCursorBatchAckRecoveryTest.testIsCursorDataFullyPersistableReflectsBatchDeletedIndexLimit`
- `./gradlew :pulsar-broker:test --tests org.apache.pulsar.client.api.SubscriptionPauseOnAckStatPersistTest.testPauseOnBatchDeletedIndexLimitExceeded`

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment