### PR TITLE
[fix][test] Await schema policy updates in OneWayReplicatorTest

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorTest.java
@@ -522,8 +522,8 @@ public class OneWayReplicatorTest extends OneWayReplicatorTestBase {
         waitReplicatorStarted(topicName);
         admin1.namespaces().setSchemaCompatibilityStrategy(ns, SchemaCompatibilityStrategy.BACKWARD_TRANSITIVE);
         admin2.namespaces().setSchemaCompatibilityStrategy(ns, SchemaCompatibilityStrategy.BACKWARD_TRANSITIVE);
-        admin1.namespaces().setIsAllowAutoUpdateSchemaAsync(ns, true, null);
-        admin2.namespaces().setIsAllowAutoUpdateSchemaAsync(ns, isAllowAutoUpdateSchema, null);
+        admin1.namespaces().setIsAllowAutoUpdateSchema(ns, true, null);
+        admin2.namespaces().setIsAllowAutoUpdateSchema(ns, isAllowAutoUpdateSchema, null);
         RetentionPolicies retentionPolicies = new RetentionPolicies(10, 1);
         admin1.namespaces().setRetention(ns, retentionPolicies);
         admin2.namespaces().setRetention(ns, retentionPolicies);
@@ -598,8 +598,8 @@ public class OneWayReplicatorTest extends OneWayReplicatorTestBase {
         });
 
         // Change policies.
-        admin1.namespaces().setIsAllowAutoUpdateSchemaAsync(ns, true, null);
-        admin2.namespaces().setIsAllowAutoUpdateSchemaAsync(ns, isAllowAutoUpdateSchema,
+        admin1.namespaces().setIsAllowAutoUpdateSchema(ns, true, null);
+        admin2.namespaces().setIsAllowAutoUpdateSchema(ns, isAllowAutoUpdateSchema,
                 allowAutoUpdateSchemaWithReplicator);
         Awaitility.await().untilAsserted(() -> {
             assertTrue(topic1.get().isAllowAutoUpdateSchema);
@@ -624,7 +624,7 @@ public class OneWayReplicatorTest extends OneWayReplicatorTestBase {
             TopicStats topicStats = admin1.topics().getStats(topicName);
             assertEquals(topicStats.getReplication().get(cluster2).getReplicationBacklog(), 1);
             // Change the policy to allow replicator update schemas.
-            admin2.namespaces().setIsAllowAutoUpdateSchemaAsync(ns, isAllowAutoUpdateSchema, true);
+            admin2.namespaces().setIsAllowAutoUpdateSchema(ns, isAllowAutoUpdateSchema, true);
             Awaitility.await().untilAsserted(() -> {
                 assertEquals(topic2.isAllowAutoUpdateSchema, isAllowAutoUpdateSchema);
                 assertTrue(topic2.isAllowAutoUpdateSchemaWithReplicator);


### PR DESCRIPTION
### Motivation

`OneWayReplicatorTest.testMultipleVersionSchemas(false, true)` failed in [Broker Group 5 CI](https://github.com/apache/pulsar/actions/runs/34459586861/job/102816791734?pr=26022), including its retry, while waiting for the destination schema auto-update policy to become `false`.

The test discards the schema-policy update futures and immediately updates retention on the same namespace. The CI log shows the destination schema policy becoming `false`, followed by the retention update restoring `true`. `internalSetRetention` writes a previously read policy snapshot, so these overlapping requests can lose the schema-policy update.

### Modifications

Use the synchronous schema-policy setter for all five updates in this test. This orders the setup requests and surfaces admin failures directly. Keep the Awaitility checks for broker propagation and all assertions covering schema versions, replication blocking, and recovery after unloading the source topic.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is covered by `OneWayReplicatorTest.testMultipleVersionSchemas`. Verified locally with temporary `invocationCount = 10`: all 50 invocations passed (five parameter combinations repeated ten times), with `-PtestRetryCount=0`. Removed the temporary repetition annotation afterward. `./gradlew quickCheck` also passed.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
