### PR TITLE
[fix][test] Cover scheduler shutdown membership-lock deadlock

### DIFF
--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/SchedulerManager.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/SchedulerManager.java
@@ -768,26 +768,29 @@ public class SchedulerManager implements AutoCloseable {
     }
 
     @Override
-    public synchronized void close() {
+    public void close() {
         log.info("Closing scheduler manager");
-        // make sure we are not closing while a scheduling is being calculated
+        // Acquire schedulerLock before the manager monitor, as scheduling does when reading membership.
+        // This also prevents closing the producer while a scheduling is being calculated.
         schedulerLock.lock();
         try {
-            isRunning = false;
+            synchronized (this) {
+                isRunning = false;
 
-            if (scheduledExecutorService != null) {
-                scheduledExecutorService.shutdown();
-            }
+                if (scheduledExecutorService != null) {
+                    scheduledExecutorService.shutdown();
+                }
 
-            if (executorService != null) {
-                executorService.shutdown();
-            }
+                if (executorService != null) {
+                    executorService.shutdown();
+                }
 
-            if (exclusiveProducer != null) {
-                try {
-                    exclusiveProducer.close();
-                } catch (PulsarClientException e) {
-                    log.warn().exception(e).log("Failed to shutdown scheduler manager assignment producer");
+                if (exclusiveProducer != null) {
+                    try {
+                        exclusiveProducer.close();
+                    } catch (PulsarClientException e) {
+                        log.warn().exception(e).log("Failed to shutdown scheduler manager assignment producer");
+                    }
                 }
             }
         } finally {

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/SchedulerManagerTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/SchedulerManagerTest.java
@@ -26,11 +26,13 @@ import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import java.lang.reflect.Method;
@@ -42,11 +44,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
 import lombok.CustomLog;
 import lombok.val;
 import org.apache.pulsar.client.admin.LongRunningProcessStatus;
@@ -64,6 +69,7 @@ import org.apache.pulsar.functions.runtime.thread.ThreadRuntimeFactory;
 import org.apache.pulsar.functions.runtime.thread.ThreadRuntimeFactoryConfig;
 import org.apache.pulsar.functions.utils.FunctionCommon;
 import org.apache.pulsar.functions.worker.scheduler.RoundRobinScheduler;
+import org.awaitility.Awaitility;
 import org.mockito.Mockito;
 import org.mockito.invocation.Invocation;
 import org.testng.Assert;
@@ -174,6 +180,43 @@ public class SchedulerManagerTest {
     public void stop() {
         schedulerManager.close();
         this.executor.shutdownNow();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testCloseDoesNotBlockMembershipChecksWhileWaitingForScheduler() throws Exception {
+        doReturn(List.of(WorkerInfo.of("worker-1", "localhost", 5000)))
+                .when(membershipManager).getCurrentMembership();
+        schedulerManager.initialize(producer);
+        ReentrantLock schedulerLock = (ReentrantLock) schedulerManager.getSchedulerLock();
+        AtomicReference<Thread> closingThread = new AtomicReference<>();
+        ExecutorService closeExecutor = Executors.newSingleThreadExecutor(new DefaultThreadFactory("scheduler-close"));
+        Future<?> closeFuture = null;
+        schedulerLock.lock();
+        try {
+            closeFuture = closeExecutor.submit(() -> {
+                closingThread.set(Thread.currentThread());
+                schedulerManager.close();
+            });
+            Awaitility.await().until(() -> closingThread.get() != null
+                    && schedulerLock.hasQueuedThread(closingThread.get()));
+
+            // A scheduler holding schedulerLock must still be able to read membership while close waits.
+            // Use a separate task with a bounded wait so a regression can release the lock during cleanup.
+            executor.submit(() -> assertThrows(SchedulerManager.TooFewWorkersException.class,
+                    () -> schedulerManager.rebalanceIfNotInprogress())).get(5, TimeUnit.SECONDS);
+            verify(producer, never()).close();
+        } finally {
+            schedulerLock.unlock();
+            try {
+                if (closeFuture != null) {
+                    closeFuture.get(5, TimeUnit.SECONDS);
+                }
+            } finally {
+                closeExecutor.shutdownNow();
+            }
+        }
+        verify(producer).close();
     }
 
     @Test


### PR DESCRIPTION
### Motivation

PR #26556 fixed the lock-order deadlock in `SchedulerManager.close()` and added bounded shutdown for stuck scheduling rounds. Add regression coverage to ensure membership queries can still complete while shutdown waits for the scheduler lock.

The deadlock was observed during `PulsarFunctionTlsTest.tearDown` in [Broker Group 2 in PR #26547](https://github.com/apache/pulsar/actions/runs/34691724745/job/103603479879): the test worker held the manager monitor while waiting for `schedulerLock`, while the scheduler held `schedulerLock` and waited for the monitor to read membership.

### Modifications

Add a bounded regression test that holds the exposed scheduler lock, waits until shutdown queues for it, and checks that a membership query can still finish. Verify that the producer remains open until the lock is released and then closes successfully. Cleanup releases the lock even on failure so the test detects the inversion without hanging the test JVM.

This PR retains the shutdown implementation from #26556 and adds only test coverage; it makes no production-code changes.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

- After merging upstream master, all 15 tests in `SchedulerManagerTest` pass with retries disabled, including the membership-lock regression test and the upstream stuck-scheduling-round test.
- `./gradlew quickCheck` passes.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
