### PR TITLE
[fix][ci] Ensure disk headroom for replication tests

### DIFF
--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -276,8 +276,8 @@ jobs:
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm
 
-      - name: Clean Disk when tracing test resource cleanup
-        if: ${{ env.TRACE_TEST_RESOURCE_CLEANUP != 'off' }}
+      - name: Clean Disk for replication tests or resource tracing
+        if: ${{ matrix.group == 'BROKER_GROUP_5' || env.TRACE_TEST_RESOURCE_CLEANUP != 'off' }}
         uses: ./.github/actions/clean-disk
 
       - name: Setup ssh access to build runner VM


### PR DESCRIPTION
### Motivation

Replication tests start multiple local BookKeeper ensembles. With limited free disk space, ledger directories can cross BookKeeper's disk-usage threshold and become unwritable, causing failures unrelated to the replication behavior under test.

### Modifications

Run the existing disk-cleanup action for Broker Group 5 as well as resource-tracing runs. The action stops once its existing 20 GiB free-space threshold is met. Test selection, BookKeeper thresholds, Gradle caches and build artifacts are unchanged.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

`spotlessCheck checkstyleMain checkstyleTest` passed. Nine workflow-expression cases verified replication and non-replication groups with resource tracing off/on/full. Actionlint reports no new diagnostics relative to master. Local review found no remaining issues.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
