### PR TITLE
[fix][test] Avoid blocking common-pool workers in ledger shutdown test

### DIFF
--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryShutdownTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryShutdownTest.java
@@ -58,7 +58,7 @@ import org.testng.annotations.Test;
 public class ManagedLedgerFactoryShutdownTest {
 
     private final String ledgerName = UUID.randomUUID().toString();
-    private final CountDownLatch slowZk = new CountDownLatch(1);
+    private CompletableFuture<Void> metadataReadGate;
 
     private MetadataStoreExtended metadataStore;
     private BookKeeper bookKeeper;
@@ -69,6 +69,7 @@ public class ManagedLedgerFactoryShutdownTest {
         final long version = 0;
         final long createTimeMillis = System.currentTimeMillis();
 
+        metadataReadGate = new CompletableFuture<>();
         metadataStore = mock(MetadataStoreExtended.class);
         bookKeeper = mock(BookKeeper.class);
 
@@ -85,12 +86,7 @@ public class ManagedLedgerFactoryShutdownTest {
                         .setEntries(0)
                         .setTimestamp(System.currentTimeMillis());
                 Stat stat = new Stat(path, version, createTimeMillis, createTimeMillis, false, false);
-                return CompletableFuture.supplyAsync(() -> {
-                    try {
-                        slowZk.await();
-                    } catch (InterruptedException e) {
-                        e.printStackTrace();
-                    }
+                return metadataReadGate.thenApplyAsync(__ -> {
                     log.info().attr("path", path).attr("managedLedgerInfo", mli)
                             .attr("stat", stat).log("metadataStore.get returned");
                     return Optional.of(new GetResult(mli.toByteArray(), stat));
@@ -102,12 +98,7 @@ public class ManagedLedgerFactoryShutdownTest {
                         .setMarkDeleteLedgerId(0)
                         .setMarkDeleteLedgerId(-1);
                 Stat stat = new Stat(path, version, createTimeMillis, createTimeMillis, false, false);
-                return CompletableFuture.supplyAsync(() -> {
-                    try {
-                        slowZk.await();
-                    } catch (InterruptedException e) {
-                        e.printStackTrace();
-                    }
+                return metadataReadGate.thenApplyAsync(__ -> {
                     log.info().attr("path", path).attr("managedCursorInfo", mci)
                             .attr("stat", stat).log("metadataStore.get returned");
                     return Optional.of(new GetResult(mci.toByteArray(), stat));
@@ -186,8 +177,8 @@ public class ManagedLedgerFactoryShutdownTest {
 
 
         factory.shutdownAsync().get();
-        //make zk returned after factory shutdown
-        slowZk.countDown();
+        // Complete delayed metadata reads only after shutdown, without blocking common-pool workers.
+        metadataReadGate.complete(null);
 
         //
         Assert.assertTrue(callbackInvoked.await(5, TimeUnit.SECONDS));


### PR DESCRIPTION
### Motivation

`ManagedLedgerFactoryShutdownTest.openEncounteredShutdown` delays metadata reads by blocking common-pool workers on a latch. Shutdown also schedules completion on that pool, so a small common pool can stall before the test releases the latch.

### Modifications

Gate the mocked metadata reads with a `CompletableFuture` created for each test invocation. Complete the gate after shutdown, preserving the late-read scenario and callback assertions without occupying workers while waiting.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

Verified `ManagedLedgerFactoryShutdownTest.openEncounteredShutdown` locally with temporary `invocationCount = 10`: 10/10 passed with retries disabled. With common-pool parallelism set to 2, the original test times out after 5 seconds and the fixed test passes 10/10 invocations. The temporary invocation count was removed.

`./gradlew spotlessCheck checkstyleMain checkstyleTest` passed.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
