### PR TITLE
[fix][test] Await both DLQ producers in multi-consumer test

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DeadLetterTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DeadLetterTopicTest.java
@@ -1336,10 +1336,9 @@ public class DeadLetterTopicTest extends SharedPulsarBaseTest {
                 .pollInterval(Duration.ofSeconds(1)).untilAsserted(() -> {
             assertTrue(admin.namespaces().getTopics(getNamespace()).contains(deadLetterTopic));
             assertTrue(admin.topics().getSubscriptions(deadLetterTopic).contains(dlqInitialSub));
+            // Each consumer creates its DLQ producer asynchronously after its final redelivery.
+            assertEquals(admin.topics().getStats(deadLetterTopic).getPublishers().size(), 2);
         });
-
-        // We should assert that all consumers are able to produce messages to DLQ
-        assertEquals(admin.topics().getStats(deadLetterTopic).getPublishers().size(), 2);
 
         Consumer<byte[]> deadLetterConsumer = newPulsarClient.newConsumer(Schema.BYTES)
                 .topic(deadLetterTopic)


### PR DESCRIPTION
### Motivation

`testDeadLetterTopicWithInitialSubscriptionAndMultiConsumers` waits for the dead-letter topic and initial subscription to exist, then immediately asserts that both consumers have a DLQ producer. Each consumer creates its producer asynchronously, so the second producer can still be pending when the topic and subscription are visible.

### Modifications

Include the exact two-producer assertion in the existing bounded Awaitility check. The test still verifies that both consumers can create DLQ producers and that all messages reach the dead-letter topic.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

Verified `DeadLetterTopicTest.testDeadLetterTopicWithInitialSubscriptionAndMultiConsumers` locally with temporary `invocationCount = 10`: 10/10 passed with retries disabled. The temporary invocation count was removed.

`./gradlew spotlessCheck checkstyleMain checkstyleTest` passed.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
