### PR TITLE
[improve][test] Reduce overlapping TestNG fixtures

### DIFF
--- a/build-logic/conventions/src/main/kotlin/pulsar.java-conventions.gradle.kts
+++ b/build-logic/conventions/src/main/kotlin/pulsar.java-conventions.gradle.kts
@@ -213,6 +213,9 @@ tasks.withType<Test>().configureEach {
         })
     }
     useTestNG {
+        // Group classes and factory instances so their fixtures are released promptly.
+        isPreserveOrder = true
+        isGroupByInstances = true
         listeners.addAll(listOf(
             "org.apache.pulsar.tests.PulsarTestListener",
             "org.apache.pulsar.tests.AnnotationListener",


### PR DESCRIPTION
### Motivation

TestNG's default API ordering can interleave methods from different classes. Class-scoped broker fixtures then remain live together until their respective last methods finish, adding avoidable memory pressure within a test worker.

### Modifications

Preserve class order and group factory-created instances in the shared TestNG configuration. This lets class and instance fixtures finish before the next group starts. Both options are needed because class ordering alone can interleave different instances of a factory-created test class. Gradle's test-fork parallelism and heap limits are unchanged.

Related fixture-isolation cleanup: #26563.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

- `assemble spotlessCheck checkstyleMain checkstyleTest` passed.
- All seven `LoadBalancerTest` tests and four invocations of the selected `KeySharedSubscriptionTest` methods passed with retries disabled.
- Standalone lifecycle probes using TestNG 7.12.0 passed: the two-class probe reduced peak active fixtures from two to one; the factory probe retained one active fixture with both settings enabled. Each probe covered all of its four or six methods, respectively.
- `help` and the selected tests ran successfully with configuration caching enabled.
- Independent local review found no remaining issues.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [x] The default values of configurations — TestNG class/instance ordering
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
