### PR TITLE
[fix][test] Isolate mutable broker fixtures between test methods

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerDispatchRateLimiterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerDispatchRateLimiterTest.java
@@ -40,19 +40,19 @@ import org.apache.pulsar.client.api.SubscriptionType;
 import org.awaitility.Awaitility;
 import org.mockito.exceptions.misusing.DisabledMockException;
 import org.testng.Assert;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 @Test(groups = "broker")
 public class BrokerDispatchRateLimiterTest extends BrokerTestBase {
-    @BeforeClass
+    @BeforeMethod
     @Override
     protected void setup() throws Exception {
         super.baseSetup();
     }
 
-    @AfterClass(alwaysRun = true)
+    @AfterMethod(alwaysRun = true)
     @Override
     protected void cleanup() throws Exception {
         super.internalCleanup();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceAutoTopicCreationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceAutoTopicCreationTest.java
@@ -52,29 +52,23 @@ import org.apache.pulsar.common.policies.data.TopicType;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.awaitility.Awaitility;
 import org.testng.Assert;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 @Test(groups = "broker")
 public class BrokerServiceAutoTopicCreationTest extends BrokerTestBase{
 
-    @BeforeClass
+    @BeforeMethod
     @Override
     protected void setup() throws Exception {
         super.baseSetup();
     }
 
-    @AfterClass(alwaysRun = true)
+    @AfterMethod(alwaysRun = true)
     @Override
     protected void cleanup() throws Exception {
         super.internalCleanup();
-    }
-
-    @AfterMethod(alwaysRun = true)
-    protected void cleanupTest() throws Exception {
-        pulsar.getAdminClient().namespaces().removeAutoTopicCreation("prop/ns-abc");
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
@@ -2257,37 +2257,36 @@ public class BrokerServiceTest extends BrokerTestBase {
         Set<String> providers = new HashSet<>();
         providers.add("org.apache.pulsar.broker.authentication.AuthenticationProviderTls");
 
-        conf.setAuthenticationEnabled(true);
-        conf.setAuthenticationProviders(providers);
-        conf.setBrokerServicePortTls(Optional.of(0));
-        conf.setWebServicePortTls(Optional.of(0));
-        conf.setTlsCertificateFilePath(BROKER_CERT_FILE_PATH);
-        conf.setTlsKeyFilePath(BROKER_KEY_FILE_PATH);
-        conf.setTlsAllowInsecureConnection(false);
-        conf.setTlsTrustCertsFilePath(CA_CERT_FILE_PATH);
-        conf.setNumExecutorThreadPoolSize(5);
-        restartBroker();
-
-        String authParam = String.format("tlsCertFile:%s,tlsKeyFile:%s", getTlsFileForClient("admin.cert"),
-                getTlsFileForClient("admin.key-pk8"));
-        String authClassName = "org.apache.pulsar.client.impl.auth.AuthenticationTls";
-        ClientConfigurationData conf = new ClientConfigurationData();
-        conf.setServiceUrl(brokerUrlTls.toString());
-        conf.setAuthParams(authParam);
-        conf.setAuthPluginClassName(authClassName);
-        conf.setTlsAllowInsecureConnection(true);
-
-        PulsarClient pulsarClient = null;
         try {
-            pulsarClient = (new ClientBuilderImpl(conf)).build();
+            conf.setAuthenticationEnabled(true);
+            conf.setAuthenticationProviders(providers);
+            conf.setBrokerServicePortTls(Optional.of(0));
+            conf.setWebServicePortTls(Optional.of(0));
+            conf.setTlsCertificateFilePath(BROKER_CERT_FILE_PATH);
+            conf.setTlsKeyFilePath(BROKER_KEY_FILE_PATH);
+            conf.setTlsAllowInsecureConnection(false);
+            conf.setTlsTrustCertsFilePath(CA_CERT_FILE_PATH);
+            conf.setNumExecutorThreadPoolSize(5);
+            restartBroker();
 
-            @Cleanup
-            Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName)
-                    .subscribe();
-        } catch (Exception e) {
-            fail("should not fail");
+            String authParam = String.format("tlsCertFile:%s,tlsKeyFile:%s", getTlsFileForClient("admin.cert"),
+                    getTlsFileForClient("admin.key-pk8"));
+            String authClassName = "org.apache.pulsar.client.impl.auth.AuthenticationTls";
+            ClientConfigurationData conf = new ClientConfigurationData();
+            conf.setServiceUrl(brokerUrlTls.toString());
+            conf.setAuthParams(authParam);
+            conf.setAuthPluginClassName(authClassName);
+            conf.setTlsAllowInsecureConnection(true);
+
+            try (PulsarClient pulsarClient = new ClientBuilderImpl(conf).build()) {
+                @Cleanup
+                Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName)
+                        .subscribe();
+            } catch (Exception e) {
+                fail("should not fail", e);
+            }
         } finally {
-            pulsarClient.close();
+            resetState();
         }
     }
 


### PR DESCRIPTION
### Motivation

Several broker tests share mutable configuration and topic metadata across methods. A dispatch-metrics test leaves rate limits enabled before another method expects unlimited permits. Auto-topic-creation tests retain topics, partitioned-topic metadata, and configuration even though later methods assert exact namespace counts and default behavior. The TLS client-configuration test also leaves the shared broker configured differently for the next method. These leaks cause order-dependent failures when the methods run together.

### Modifications

- Give `BrokerDispatchRateLimiterTest` and `BrokerServiceAutoTopicCreationTest` a fresh broker fixture for each method.
- Remove the redundant namespace-policy cleanup callback, since full fixture cleanup also resets configuration and metadata.
- Restore `BrokerServiceTest`'s fixture in a `finally` block after the TLS client-configuration test, and close its local client with try-with-resources.

Existing assertions, asynchronous waits, and timeouts are preserved.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is covered by both complete `BrokerDispatchRateLimiterTest` and `BrokerServiceAutoTopicCreationTest` classes, plus `BrokerServiceTest.testTlsWithAuthParams` and `testTopicFailureShouldNotHaveDeadLock`.

- Temporarily repeated six affected methods with `invocationCount=10`: 84 test invocations passed, with retries disabled and no skipped tests.
- Removed the temporary repetitions and reran the same selection: 30 tests passed, with retries disabled and no skipped tests.
- `./gradlew spotlessCheck checkstyleMain checkstyleTest` passed across all modules.

Both test runs used one test fork and TestNG `preserveOrder=true` / `groupByInstances=true`. Local review confirmed that assertions and existing waits remain intact.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
