### PR TITLE
[fix][test] Allow for CLI startup in function integration tests

### DIFF
--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTest.java
@@ -1381,9 +1381,10 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
 
     private void getFunctionStatus(String functionName, int numMessages, boolean checkRestarts, int parallelism)
             throws Exception {
+        // Each status check starts the admin CLI; allow for startup and command completion on busy CI runners.
         Awaitility.await()
                 .pollInterval(Duration.ofSeconds(1))
-                .atMost(Duration.ofSeconds(15))
+                .atMost(Duration.ofSeconds(30))
                 .ignoreExceptions()
                 .untilAsserted(() ->
                         doGetFunctionStatus(functionName, numMessages, checkRestarts, parallelism));

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarStateTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarStateTest.java
@@ -149,7 +149,8 @@ public abstract class PulsarStateTest extends PulsarStandaloneTestSuite {
         getFunctionInfoNotFound(functionName);
     }
 
-    @Test(groups = {"python_state", "state", "function", "python_function"})
+    // Both passes launch many admin CLI JVMs to verify state operations and cleanup after deletion.
+    @Test(groups = {"python_state", "state", "function", "python_function"}, timeOut = 600_000)
     public void testPythonWordCountFunction() throws Exception {
         if (PulsarMetadataStateStoreProviderImpl.class.getName().equals(stateStoreProvider)) {
             // python function doesn't support metadata state store yet
@@ -163,7 +164,8 @@ public abstract class PulsarStateTest extends PulsarStandaloneTestSuite {
         doTestPythonWordCountFunction(functionName);
     }
 
-    @Test(groups = {"java_state", "state", "function", "java_function"})
+    // Both passes launch many admin CLI JVMs to verify state operations and cleanup after deletion.
+    @Test(groups = {"java_state", "state", "function", "java_function"}, timeOut = 600_000)
     public void testJavaWordCountFunction() throws Exception {
         String functionName = "test-wordcount-java-fn-" + randomName(8);
         doTestJavaWordCountFunction(functionName);


### PR DESCRIPTION
### Motivation

Function integration tests invoke `pulsar-admin` in a fresh JVM for each status or state operation. On busy CI runners, startup and command completion consume a significant part of the existing deadlines. A status probe can time out even when the function has reached the expected state. The word-count tests each execute two complete create/check/delete cycles to verify state cleanup after deletion, but currently share the default five-minute timeout with shorter tests.

### Modifications

- Allow 30 seconds for function status polling, including CLI startup and command completion, instead of 15 seconds.
- Give the Java and Python word-count lifecycle tests an explicit ten-minute timeout for their two passes.
- Keep polling intervals, state assertions, message counts, and cleanup checks unchanged.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is covered by existing integration tests:

- `PulsarFunctionsJavaProcessTest.testJavaExclamationCustomBatchingFunction`: 10/10 invocations passed with retries disabled, using a temporary `invocationCount = 10` that was removed afterward.
- Java word-count lifecycle tests passed with both BookKeeper and metadata state stores; the Python lifecycle test passed with BookKeeper. Each test retains its two create/check/delete passes. The unsupported metadata/Python combination returns early and is not counted as Python coverage.
- `./gradlew spotlessCheck checkstyleMain checkstyleTest` passed locally.

The integration runs used the current test sources with a cached test image built on September 1, 2026, rather than a newly built runtime image. They verify the exercised test paths but do not reproduce every constrained-runner timing condition.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
