### PR TITLE
[fix][txn] Prevent queued snapshot writes from stalling

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotSegmentAbortedTxnProcessorImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotSegmentAbortedTxnProcessorImpl.java
@@ -614,6 +614,11 @@ public class SnapshotSegmentAbortedTxnProcessorImpl extends AbstractSnapshotAbor
             if (STATE_UPDATER.compareAndSet(this, OperationState.None, OperationState.Operating)) {
                 //Double-check. Avoid NoSuchElementException due to the first task is completed by other thread.
                 if (taskQueue.isEmpty()) {
+                    STATE_UPDATER.compareAndSet(this, OperationState.Operating, OperationState.None);
+                    // An append may have observed Operating between the empty check and releasing ownership.
+                    if (!taskQueue.isEmpty()) {
+                        executeTask();
+                    }
                     return;
                 }
                 Pair<OperationType, Pair<CompletableFuture<Void>, Supplier<CompletableFuture<Void>>>> firstTask =
@@ -630,12 +635,14 @@ public class SnapshotSegmentAbortedTxnProcessorImpl extends AbstractSnapshotAbor
                     } else {
                         firstTask.getRight().getKey().complete(null);
                         taskQueue.removeFirst();
-                        //Execute the next task in the other thread.
-                        topic.getBrokerService().getPulsar().getTransactionExecutorProvider()
-                                .getExecutor(this).submit(this::executeTask);
                     }
                     STATE_UPDATER.compareAndSet(this, OperationState.Operating,
                             OperationState.None);
+                    if (throwable == null) {
+                        // Release the operation before scheduling: the executor may run the next task immediately.
+                        topic.getBrokerService().getPulsar().getTransactionExecutorProvider()
+                                .getExecutor(this).submit(this::executeTask);
+                    }
                 });
             }
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/BrokerInterceptorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/BrokerInterceptorTest.java
@@ -18,12 +18,15 @@
  */
 package org.apache.pulsar.broker.intercept;
 
+import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertEquals;
 import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -93,7 +96,9 @@ public class BrokerInterceptorTest extends ProducerConsumerBase {
     @Override
     protected void customizeMainPulsarTestContextBuilder(PulsarTestContext.Builder pulsarTestContextBuilder) {
         HashMap<String, BrokerInterceptorWithClassLoader> brokerInterceptorWithClassLoaderHashMap = new HashMap<>();
-        NarClassLoader narClassLoader = mock(NarClassLoader.class);
+        // The filter chain uses this context class loader for resource and service-provider lookup.
+        NarClassLoader narClassLoader = mock(NarClassLoader.class,
+                delegatesTo(new URLClassLoader(new URL[0], getClass().getClassLoader())));
         BrokerInterceptorWithClassLoader counterBrokerInterceptor =
                 new BrokerInterceptorWithClassLoader(new CounterBrokerInterceptor(), narClassLoader);
         brokerInterceptorWithClassLoaderHashMap.put(CounterBrokerInterceptor.NAME, counterBrokerInterceptor);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/ExceptionsBrokerInterceptorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/ExceptionsBrokerInterceptorTest.java
@@ -18,10 +18,13 @@
  */
 package org.apache.pulsar.broker.intercept;
 
+import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
@@ -63,7 +66,9 @@ public class ExceptionsBrokerInterceptorTest extends ProducerConsumerBase {
     protected void customizeMainPulsarTestContextBuilder(PulsarTestContext.Builder pulsarTestContextBuilder) {
         Map<String, BrokerInterceptorWithClassLoader> listenerMap = new HashMap<>();
         BrokerInterceptor interceptor = new ExceptionsBrokerInterceptor();
-        NarClassLoader narClassLoader = mock(NarClassLoader.class);
+        // The filter chain uses this context class loader for resource and service-provider lookup.
+        NarClassLoader narClassLoader = mock(NarClassLoader.class,
+                delegatesTo(new URLClassLoader(new URL[0], getClass().getClassLoader())));
         listenerMap.put(interceptorName, new BrokerInterceptorWithClassLoader(interceptor, narClassLoader));
         pulsarTestContextBuilder.brokerInterceptor(new BrokerInterceptors(listenerMap));
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotSegmentAbortedTxnProcessorWorkerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotSegmentAbortedTxnProcessorWorkerTest.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.transaction.buffer.impl;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import com.google.common.util.concurrent.MoreExecutors;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.broker.transaction.buffer.impl.SnapshotSegmentAbortedTxnProcessorImpl.PersistentWorker;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+@Test(groups = "broker")
+public class SnapshotSegmentAbortedTxnProcessorWorkerTest {
+
+    private ExecutorService executor;
+    private SnapshotSegmentAbortedTxnProcessorImpl processor;
+    private PersistentWorker worker;
+
+    @BeforeMethod
+    public void setup() {
+        PersistentTopic topic = mock(PersistentTopic.class, RETURNS_DEEP_STUBS);
+        when(topic.getName()).thenReturn("persistent://public/default/snapshot-worker");
+        executor = MoreExecutors.newDirectExecutorService();
+        when(topic.getBrokerService().getPulsar().getTransactionExecutorProvider().getExecutor(any(Object.class)))
+                .thenReturn(executor);
+        processor = new SnapshotSegmentAbortedTxnProcessorImpl(topic);
+        worker = processor.new PersistentWorker(topic);
+    }
+
+    @Test(timeOut = 10_000)
+    public void testQueuedTasksContinueWhenExecutorRunsImmediately() throws Exception {
+        CompletableFuture<Void> firstWrite = new CompletableFuture<>();
+        CompletableFuture<Void> secondWrite = new CompletableFuture<>();
+        AtomicBoolean secondStarted = new AtomicBoolean();
+        AtomicBoolean thirdStarted = new AtomicBoolean();
+        CompletableFuture<Void> firstResult = worker.appendTask(PersistentWorker.OperationType.WriteSegment,
+                () -> firstWrite);
+        CompletableFuture<Void> secondResult = worker.appendTask(PersistentWorker.OperationType.WriteSegment, () -> {
+            secondStarted.set(true);
+            return secondWrite;
+        });
+        assertFalse(secondStarted.get());
+
+        firstWrite.complete(null);
+        firstResult.get(5, TimeUnit.SECONDS);
+        assertTrue(secondStarted.get(), "The queued write must start when the previous write completes");
+
+        CompletableFuture<Void> thirdResult = worker.appendTask(PersistentWorker.OperationType.WriteSegment, () -> {
+            thirdStarted.set(true);
+            return CompletableFuture.completedFuture(null);
+        });
+        assertFalse(thirdStarted.get(), "The next write must wait for the in-flight write");
+        secondWrite.complete(null);
+        secondResult.get(5, TimeUnit.SECONDS);
+        thirdResult.get(5, TimeUnit.SECONDS);
+        assertTrue(thirdStarted.get());
+    }
+
+    @Test(timeOut = 10_000)
+    public void testQueueDrainedBeforeAcquiringOperation() throws Exception {
+        AtomicInteger stage = new AtomicInteger();
+        AtomicReference<CompletableFuture<Void>> appendedWhileOperating = new AtomicReference<>();
+        worker.taskQueue = new ConcurrentLinkedDeque<>() {
+            @Override
+            public boolean isEmpty() {
+                boolean empty = super.isEmpty();
+                if (!empty && stage.compareAndSet(0, 1)) {
+                    // Another caller drains the queue after the initial snapshot, before ownership is acquired.
+                    worker.appendTask(PersistentWorker.OperationType.WriteSegment,
+                            () -> CompletableFuture.completedFuture(null));
+                    stage.set(2);
+                } else if (empty && stage.compareAndSet(2, 3)) {
+                    // An append observes Operating after the second empty snapshot, before ownership is released.
+                    appendedWhileOperating.set(worker.appendTask(PersistentWorker.OperationType.WriteSegment,
+                            () -> CompletableFuture.completedFuture(null)));
+                }
+                return empty;
+            }
+        };
+        worker.appendTask(PersistentWorker.OperationType.WriteSegment,
+                () -> CompletableFuture.completedFuture(null)).get(5, TimeUnit.SECONDS);
+        assertEquals(stage.get(), 3, "Both queue observations must be exercised");
+        appendedWhileOperating.get().get(5, TimeUnit.SECONDS);
+        worker.appendTask(PersistentWorker.OperationType.WriteSegment,
+                () -> CompletableFuture.completedFuture(null)).get(5, TimeUnit.SECONDS);
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void cleanup() throws Exception {
+        worker.closeAsync().get(5, TimeUnit.SECONDS);
+        processor.closeAsync().get(5, TimeUnit.SECONDS);
+        executor.shutdownNow();
+    }
+}


### PR DESCRIPTION
Depends on #26567. Its interceptor fixture class-loading fix is included so the broker test suite can run successfully.

Fixes #19650

### Motivation

`SegmentAbortedTxnProcessorTest.testClearSnapshotSegments` can observe only one of the two expected snapshot segments because the persistent worker schedules its next task before releasing its operating state. If that task runs immediately, it cannot acquire the state and returns, leaving the next write queued until another operation triggers processing.

A related race occurs when another caller drains the queue between the initial empty check and acquiring the operating state: the second empty check returns without releasing that state.

### Modifications

Release the operating state before scheduling the next successful task. When the second queue check finds no work, release the state and recheck the queue to cover an append that observed the worker as busy.

Add deterministic tests for immediate executor handoff and for queue drain/append interleavings, retaining assertions that queued writes run serially and eventually complete.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

- The immediate-executor test fails on the original implementation because the second write never starts.
- The queue-interleaving test fails without the empty-queue fix because an appended write never completes.
- Both regression tests passed 10 invocations each with retries disabled; temporary invocation counts were removed.
- All 6 tests in `SegmentAbortedTxnProcessorTest` passed, including `testClearSnapshotSegments`.
- `./gradlew spotlessCheck checkstyleMain checkstyleTest` passed.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [x] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

