### PR TITLE
[fix][test] Preserve class loading in broker interceptor fixtures

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/BrokerInterceptorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/BrokerInterceptorTest.java
@@ -18,12 +18,15 @@
  */
 package org.apache.pulsar.broker.intercept;
 
+import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertEquals;
 import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -93,7 +96,9 @@ public class BrokerInterceptorTest extends ProducerConsumerBase {
     @Override
     protected void customizeMainPulsarTestContextBuilder(PulsarTestContext.Builder pulsarTestContextBuilder) {
         HashMap<String, BrokerInterceptorWithClassLoader> brokerInterceptorWithClassLoaderHashMap = new HashMap<>();
-        NarClassLoader narClassLoader = mock(NarClassLoader.class);
+        // The filter chain uses this context class loader for resource and service-provider lookup.
+        NarClassLoader narClassLoader = mock(NarClassLoader.class,
+                delegatesTo(new URLClassLoader(new URL[0], getClass().getClassLoader())));
         BrokerInterceptorWithClassLoader counterBrokerInterceptor =
                 new BrokerInterceptorWithClassLoader(new CounterBrokerInterceptor(), narClassLoader);
         brokerInterceptorWithClassLoaderHashMap.put(CounterBrokerInterceptor.NAME, counterBrokerInterceptor);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/ExceptionsBrokerInterceptorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/ExceptionsBrokerInterceptorTest.java
@@ -18,10 +18,13 @@
  */
 package org.apache.pulsar.broker.intercept;
 
+import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
@@ -63,7 +66,9 @@ public class ExceptionsBrokerInterceptorTest extends ProducerConsumerBase {
     protected void customizeMainPulsarTestContextBuilder(PulsarTestContext.Builder pulsarTestContextBuilder) {
         Map<String, BrokerInterceptorWithClassLoader> listenerMap = new HashMap<>();
         BrokerInterceptor interceptor = new ExceptionsBrokerInterceptor();
-        NarClassLoader narClassLoader = mock(NarClassLoader.class);
+        // The filter chain uses this context class loader for resource and service-provider lookup.
+        NarClassLoader narClassLoader = mock(NarClassLoader.class,
+                delegatesTo(new URLClassLoader(new URL[0], getClass().getClassLoader())));
         listenerMap.put(interceptorName, new BrokerInterceptorWithClassLoader(interceptor, narClassLoader));
         pulsarTestContextBuilder.brokerInterceptor(new BrokerInterceptors(listenerMap));
     }


### PR DESCRIPTION
### Motivation

Broker interceptor tests install a mocked `NarClassLoader` as the thread context class loader while running the HTTP filter chain. A bare mock returns `null` from `getResources`, violating the class-loader contract. If logging service-provider discovery first runs in that context, `ServiceLoader` throws a `NullPointerException` and the setup request fails with HTTP 500. This makes the result depend on class initialization order.

### Modifications

Delegate the context class-loader mocks in the ordinary and exception interceptor fixtures to an empty `URLClassLoader` with the test class loader as its parent. This preserves class and resource lookup while retaining the existing interceptor behavior and cleanup ownership. Listener-only mocks and test assertions remain unchanged.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

- Reproduced the setup failure by running `BrokerInterceptorTest.asyncResponseFilterTest` in isolation before the change; the server stack trace reports the null resource enumeration in `ServiceLoader`. The same isolated test passes with the change.
- Both affected test classes passed locally: 33 invocations, zero failures or skips. `asyncResponseFilterTest` and `testMessageAckedExceptions` each ran 10 times with retries disabled, using temporary invocation counts removed afterward.
- `./gradlew spotlessCheck checkstyleMain checkstyleTest` passed.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
